### PR TITLE
Fixed issue with exif throwing a warning if no exif data is returned

### DIFF
--- a/src/Intervention/Image/Image.php
+++ b/src/Intervention/Image/Image.php
@@ -1439,7 +1439,7 @@ class Image
 
         $data = exif_read_data($this->dirname .'/'. $this->basename, 'EXIF', false);
 
-        if (! is_null($key)) {
+        if (! is_null($key) && is_array($data)) {
             return array_key_exists($key, $data) ? $data[$key] : null;
         }
 


### PR DESCRIPTION
in Image::exif() 'array_key_exists' throws a warning if 'exif_read_data' returns false, this resolves by confirming data is an array before it returns $data[$key]
