### PR TITLE
Update PNG encoding quality

### DIFF
--- a/src/Intervention/Image/Image.php
+++ b/src/Intervention/Image/Image.php
@@ -1509,6 +1509,7 @@ class Image
             case 'png':
             case 'image/png':
             case IMAGETYPE_PNG:
+                $quality = 100 - $quality;
                 $quality = round($quality / 11.11111111111); // transform quality to png setting
                 imagealphablending($this->resource, false);
                 imagesavealpha($this->resource, true);


### PR DESCRIPTION
PNG quality for encoding should be similar to JPG (0 being worst to 100 being the best). It is currently the opposite. This is because imagepng's quality scale is 0 (no compression) to 9 (full compression). The current best and largest images are at 0 quality instead of 100. This commit fixes this issue.
