### PR TITLE
Patch trim with feathering

### DIFF
--- a/src/Intervention/Image/Image.php
+++ b/src/Intervention/Image/Image.php
@@ -821,7 +821,7 @@ class Image
                 for ($x=0; $x < $this->width; $x++) {
                     $checkColor = imagecolorsforindex($this->resource, imagecolorat($this->resource, $x, $y));
                     if ($colorDiffers($color, $checkColor)) {
-                        $top_y = $y;
+                        $top_y = max(0, $y - $feather);
                         break 2;
                     }
                 }
@@ -834,7 +834,7 @@ class Image
                 for ($y=$top_y; $y < $this->height; $y++) {
                     $checkColor = imagecolorsforindex($this->resource, imagecolorat($this->resource, $x, $y));
                     if ($colorDiffers($color, $checkColor)) {
-                        $top_x = $x;
+                        $top_x = max(0, $x - $feather);
                         break 2;
                     }
                 }
@@ -847,7 +847,7 @@ class Image
                 for ($x=$top_x; $x < $this->width; $x++) {
                     $checkColor = imagecolorsforindex($this->resource, imagecolorat($this->resource, $x, $y));
                     if ($colorDiffers($color, $checkColor)) {
-                        $bottom_y = $y+1;
+                        $bottom_y = min($this->height, $y+1 + $feather);
                         break 2;
                     }
                 }
@@ -860,15 +860,15 @@ class Image
                 for ($y=$top_y; $y < $bottom_y; $y++) {
                     $checkColor = imagecolorsforindex($this->resource, imagecolorat($this->resource, $x, $y));
                     if ($colorDiffers($color, $checkColor)) {
-                        $bottom_x = $x+1;
+                        $bottom_x = min($this->width, $x+1 + $feather);
                         break 2;
                     }
                 }
             }
         }
 
-        // trim parts of image, taking a possible feathering range into account
-        $this->modify(0, 0, max(0, $top_x - $feather), max(0, $top_y - $feather), ($bottom_x-$top_x) + (2 * $feather), ($bottom_y-$top_y) + (2 * $feather), ($bottom_x-$top_x) + (2 * $feather), ($bottom_y-$top_y) + (2 * $feather));
+        // trim parts of image
+        $this->modify(0, 0, $top_x, $top_y, ($bottom_x-$top_x), ($bottom_y-$top_y), ($bottom_x-$top_x), ($bottom_y-$top_y));
 
         return $this;
     }


### PR DESCRIPTION
Sometimes it is useful to leave a little 'border' around an object untouched when trimming, for example to improve/not mess up a composition too much. The tolerance parameter is not always appropriate. A simple solution is to use resizeCancas() with (for example) a white background after trimming. However this solution is too simple since not all backgrounds are solid.

A  more elegant solution might be to use the concept of 'feathering', also used with the 'magic wand' tool in Photoshop / GIMP, etc. 

Also see item #10: http://www.ehow.com/how_5130229_use-magic-wand-tool.html

This PR adds a (perhaps naive) approach to feathering, some initial tests work nice for me ;). 

TODO: 
- add unit test
- instead of a fixed amount of pixels, using a percentage might be useful, either:
  - of the original 
  - of the trimmed image
