### PR TITLE
Fixed wrong documentation

### DIFF
--- a/src/Intervention/Image/Image.php
+++ b/src/Intervention/Image/Image.php
@@ -42,7 +42,7 @@ class Image
     public $dirname;
 
     /**
-     * Trailing name component of current image filename
+     * The current basename of the image file, if instance was created from file.
      *
      * @var string
      */
@@ -56,7 +56,7 @@ class Image
     public $extension;
 
     /**
-     * Combined filename (basename and extension)
+     * The current image basename without extension, if instance was created from file.
      *
      * @var string
      */


### PR DESCRIPTION
Especially the 'filename' property, as the docs suggested it included the extension
http://image.intervention.io/properties/public#filename
http://php.net/manual/en/function.pathinfo.php
