### PR TITLE
Support for filenames with 'special' characters

### DIFF
--- a/src/Intervention/Image/Image.php
+++ b/src/Intervention/Image/Image.php
@@ -104,7 +104,7 @@ class Image
 
             } elseif (is_file($source)) {
 
-                // image properties come from image file
+                // image properties come from existing image file
                 $this->initFromPath($source);
 
             } elseif ($this->isBinary($source)) {
@@ -116,7 +116,11 @@ class Image
 
                 // image will be fetched from url before init
                 $this->initFromString(file_get_contents($source));
-            } 
+            } else {
+
+                // image properties come from potentially existing image file
+                $this->initFromPath($source);
+            }
 
         } else {
 


### PR DESCRIPTION
A (local) filename that contains characters other than ASCII 32-126 like '/tmp/maïs.jpg' was processed as being binary data, since the [check for printable characters](http://www.php.net/manual/en/function.ctype-print.php) in isBinary() failed.

In the [extended ASCII table](http://www.asciitable.com/), we can see that this excludes a lot of characters that 'can' occur in a filename.
