### PR TITLE
filenames can now contain slashes - this allows the use of subdirectories to store images

### DIFF
--- a/src/Intervention/Image/ImageServiceProvider.php
+++ b/src/Intervention/Image/ImageServiceProvider.php
@@ -95,7 +95,7 @@ class ImageServiceProvider extends ServiceProvider
                         'Etag' => md5($content)
                     ));
 
-                }))->where(array('template' => join('|', array_keys($config['templates'])), 'filename' => '^[\w.-]+$'));
+                }))->where(array('template' => join('|', array_keys($config['templates'])), 'filename' => '^[\/\w.-]+$'));
             }
         }
     }


### PR DESCRIPTION
This 2-character change allows one to use a hierarchy of subdirectories to store images in, so that you don't have to put too many images in one directory. For instance, see this Stack Overflow question:

http://stackoverflow.com/questions/12256835/folder-structure-for-storing-millions-of-images

I did not add a test, but all the tests currently run. Let me know if you need a test for this.
