### PR TITLE
make getBoxSize() a public method

### DIFF
--- a/src/Intervention/Image/Gd/Font.php
+++ b/src/Intervention/Image/Gd/Font.php
@@ -124,7 +124,7 @@ class Font extends \Intervention\Image\AbstractFont
      *
      * @return Array
      */
-    protected function getBoxSize()
+    public function getBoxSize()
     {
         $box = array();
 


### PR DESCRIPTION
Can I request this is made a public method.

I was using it within the v1 api implementation, the function below allows me to calculate the font size required to fit the image width provided

``` php
    private function calculateFontSize($width, $text = '', $fontFile, $fontSize = 80) {
        $font = new \Intervention\Image\Gd\Font($text);
        $font->file($fontFile);
        $font->size($fontSize);
        $font->align('center');
        $font->valign('center');

        $box = $font->getBoxSize();

        do {
            (int)$fontSize -= 2;
            $font->size($fontSize);
            $box = $font->getBoxSize();
        } while (($box['width'] >= ($width - 20)));

        return $fontSize;
    }
```
