### PR TITLE
Add AbstractDriver type to $driver argument on constructor

### DIFF
--- a/src/Intervention/Image/Image.php
+++ b/src/Intervention/Image/Image.php
@@ -38,7 +38,7 @@ class Image extends File
      * @param Driver $driver
      * @param mixed  $core
      */
-    public function __construct($driver = null, $core = null)
+    public function __construct(AbstractDriver $driver = null, $core = null)
     {
         $this->driver = $driver;
         $this->core = $core;


### PR DESCRIPTION
Prevents fatal errors if $driver is not an object that implements AbstractDriver.
