### PR TITLE
Fix fully qualified class names in PHP docblocks

### DIFF
--- a/src/Intervention/Image/AbstractColor.php
+++ b/src/Intervention/Image/AbstractColor.php
@@ -8,7 +8,7 @@ abstract class AbstractColor
      * Initiates color object from integer
      *
      * @param  integer $value
-     * @return Intervention\Image\AbstractColor
+     * @return \Intervention\Image\AbstractColor
      */
     abstract public function initFromInteger($value);
 
@@ -16,7 +16,7 @@ abstract class AbstractColor
      * Initiates color object from given array
      *
      * @param  array $value
-     * @return Intervention\Image\AbstractColor
+     * @return \Intervention\Image\AbstractColor
      */
     abstract public function initFromArray($value);
 
@@ -24,7 +24,7 @@ abstract class AbstractColor
      * Initiates color object from given string
      *
      * @param  string $value
-     * @return Intervention\Image\AbstractColor
+     * @return \Intervention\Image\AbstractColor
      */
     abstract public function initFromString($value);
 
@@ -32,7 +32,7 @@ abstract class AbstractColor
      * Initiates color object from given ImagickPixel object
      *
      * @param  ImagickPixel $value
-     * @return Intervention\Image\AbstractColor
+     * @return \Intervention\Image\AbstractColor
      */
     abstract public function initFromObject($value);
 
@@ -42,7 +42,7 @@ abstract class AbstractColor
      * @param  integer $r
      * @param  integer $g
      * @param  integer $b
-     * @return Intervention\Image\AbstractColor
+     * @return \Intervention\Image\AbstractColor
      */
     abstract public function initFromRgb($r, $g, $b);
 
@@ -53,7 +53,7 @@ abstract class AbstractColor
      * @param  integer $g
      * @param  integer $b
      * @param  float   $a
-     * @return Intervention\Image\AbstractColor
+     * @return \Intervention\Image\AbstractColor
      */
     abstract public function initFromRgba($r, $g, $b, $a);
 
@@ -109,7 +109,7 @@ abstract class AbstractColor
      * Parses given value as color
      *
      * @param  mixed $value
-     * @return Intervention\Image\AbstractColor
+     * @return \Intervention\Image\AbstractColor
      */
     public function parse($value)
     {

--- a/src/Intervention/Image/AbstractDecoder.php
+++ b/src/Intervention/Image/AbstractDecoder.php
@@ -8,7 +8,7 @@ abstract class AbstractDecoder
      * Initiates new image from path in filesystem
      *
      * @param  string $path
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     abstract public function initFromPath($path);
 
@@ -16,7 +16,7 @@ abstract class AbstractDecoder
      * Initiates new image from binary data
      *
      * @param  string $data
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     abstract public function initFromBinary($data);
 
@@ -24,7 +24,7 @@ abstract class AbstractDecoder
      * Initiates new image from GD resource
      *
      * @param  Resource $resource
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     abstract public function initFromGdResource($resource);
 
@@ -32,7 +32,7 @@ abstract class AbstractDecoder
      * Initiates new image from Imagick object
      *
      * @param  Imagick $object
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     abstract public function initFromImagick(\Imagick $object);
 
@@ -140,7 +140,7 @@ abstract class AbstractDecoder
      * Initiates new Image from Intervention\Image\Image
      *
      * @param  Image $object
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     public function initFromInterventionImage($object)
     {
@@ -151,7 +151,7 @@ abstract class AbstractDecoder
      * Initiates new image from mixed data
      *
      * @param  mixed $data
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     public function init($data)
     {

--- a/src/Intervention/Image/AbstractDriver.php
+++ b/src/Intervention/Image/AbstractDriver.php
@@ -7,14 +7,14 @@ abstract class AbstractDriver
     /**
      * Decoder instance to init images from
      *
-     * @var Intervention\Image\AbstractDecoder
+     * @var \Intervention\Image\AbstractDecoder
      */
     public $decoder;
 
     /**
      * Image encoder instance
      *
-     * @var Intervention\Image\AbstractEncoder
+     * @var \Intervention\Image\AbstractEncoder
      */
     public $encoder;
 
@@ -24,7 +24,7 @@ abstract class AbstractDriver
      * @param  integer $width
      * @param  integer $height
      * @param  string  $background
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     abstract public function newImage($width, $height, $background);
 
@@ -57,7 +57,7 @@ abstract class AbstractDriver
      * Initiates new image from given input
      *
      * @param  mixed $data
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     public function init($data)
     {
@@ -70,7 +70,7 @@ abstract class AbstractDriver
      * @param  Image   $image
      * @param  string  $format
      * @param  integer $quality
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     public function encode($image, $format, $quality)
     {
@@ -83,7 +83,7 @@ abstract class AbstractDriver
      * @param  Image  $image
      * @param  string $name
      * @param  array $arguments
-     * @return Intervention\Image\Commands\AbstractCommand
+     * @return \Intervention\Image\Commands\AbstractCommand
      */
     public function executeCommand($image, $name, $arguments)
     {

--- a/src/Intervention/Image/Commands/AbstractCommand.php
+++ b/src/Intervention/Image/Commands/AbstractCommand.php
@@ -21,7 +21,7 @@ abstract class AbstractCommand
     /**
      * Executes current command on given image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return mixed
      */
     abstract public function execute($image);
@@ -40,7 +40,7 @@ abstract class AbstractCommand
      * Creates new argument instance from given argument key
      *
      * @param  integer $key
-     * @return Intervention\Image\Commands\Argument
+     * @return \Intervention\Image\Commands\Argument
      */
     public function argument($key)
     {

--- a/src/Intervention/Image/Commands/Argument.php
+++ b/src/Intervention/Image/Commands/Argument.php
@@ -59,7 +59,7 @@ class Argument
     /**
      * Defines current argument as required
      *
-     * @return Intervention\Image\Commands\Argument
+     * @return \Intervention\Image\Commands\Argument
      */
     public function required()
     {
@@ -75,7 +75,7 @@ class Argument
     /**
      * Determines that current argument must be of given type
      *
-     * @return Intervention\Image\Commands\Argument
+     * @return \Intervention\Image\Commands\Argument
      */
     public function type($type)
     {
@@ -144,7 +144,7 @@ class Argument
     /**
      * Determines that current argument value must be numeric between given values
      *
-     * @return Intervention\Image\Commands\Argument
+     * @return \Intervention\Image\Commands\Argument
      */
     public function between($x, $y)
     {
@@ -169,7 +169,7 @@ class Argument
     /**
      * Determines that current argument must be over a minimum value
      *
-     * @return Intervention\Image\Commands\Argument
+     * @return \Intervention\Image\Commands\Argument
      */
     public function min($value)
     {
@@ -191,7 +191,7 @@ class Argument
     /**
      * Determines that current argument must be under a maxiumum value
      *
-     * @return Intervention\Image\Commands\Argument
+     * @return \Intervention\Image\Commands\Argument
      */
     public function max($value)
     {

--- a/src/Intervention/Image/Commands/ChecksumCommand.php
+++ b/src/Intervention/Image/Commands/ChecksumCommand.php
@@ -7,7 +7,7 @@ class ChecksumCommand extends AbstractCommand
     /**
      * Calculates checksum of given image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Commands/CircleCommand.php
+++ b/src/Intervention/Image/Commands/CircleCommand.php
@@ -9,7 +9,7 @@ class CircleCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Draw a circle centered on given image
      *
-     * @param  Intervention\Image\image $image
+     * @param  \Intervention\Image\image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Commands/EllipseCommand.php
+++ b/src/Intervention/Image/Commands/EllipseCommand.php
@@ -9,7 +9,7 @@ class EllipseCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Draws ellipse on given image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Commands/ExifCommand.php
+++ b/src/Intervention/Image/Commands/ExifCommand.php
@@ -10,7 +10,7 @@ class ExifCommand extends AbstractCommand
      * Note: Windows PHP Users - in order to use this method you will need to
      * enable the mbstring and exif extensions within the php.ini file.
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Commands/LineCommand.php
+++ b/src/Intervention/Image/Commands/LineCommand.php
@@ -9,7 +9,7 @@ class LineCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Draws line on given image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Commands/OrientateCommand.php
+++ b/src/Intervention/Image/Commands/OrientateCommand.php
@@ -7,7 +7,7 @@ class OrientateCommand extends AbstractCommand
     /**
      * Correct image orientation according to Exif data
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Commands/PolygonCommand.php
+++ b/src/Intervention/Image/Commands/PolygonCommand.php
@@ -9,7 +9,7 @@ class PolygonCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Draw a polygon on given image
      *
-     * @param  Intervention\Image\image $image
+     * @param  \Intervention\Image\image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Commands/RectangleCommand.php
+++ b/src/Intervention/Image/Commands/RectangleCommand.php
@@ -9,7 +9,7 @@ class RectangleCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Draws rectangle on given image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Commands/ResponseCommand.php
+++ b/src/Intervention/Image/Commands/ResponseCommand.php
@@ -9,7 +9,7 @@ class ResponseCommand extends AbstractCommand
     /**
      * Builds HTTP response from given image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Commands/TextCommand.php
+++ b/src/Intervention/Image/Commands/TextCommand.php
@@ -8,7 +8,7 @@ class TextCommand extends \Intervention\Image\Commands\AbstractCommand
 {
     /**
      * Write text on given image
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Constraint.php
+++ b/src/Intervention/Image/Constraint.php
@@ -17,7 +17,7 @@ class Constraint
     /**
      * Constraint size
      *
-     * @var Intervention\Image\Size
+     * @var \Intervention\Image\Size
      */
     private $size;
 
@@ -41,7 +41,7 @@ class Constraint
     /**
      * Returns current size of constraint
      *
-     * @return Intervention\Image\Size
+     * @return \Intervention\Image\Size
      */
     public function getSize()
     {

--- a/src/Intervention/Image/Filters/DemoFilter.php
+++ b/src/Intervention/Image/Filters/DemoFilter.php
@@ -29,8 +29,8 @@ class DemoFilter implements FilterInterface
     /**
      * Applies filter effects to given image
      *
-     * @param  Intervention\Image\Image $image
-     * @return Intervention\Image\Image
+     * @param  \Intervention\Image\Image $image
+     * @return \Intervention\Image\Image
      */
     public function applyFilter(\Intervention\Image\Image $image)
     {

--- a/src/Intervention/Image/Filters/FilterInterface.php
+++ b/src/Intervention/Image/Filters/FilterInterface.php
@@ -7,8 +7,8 @@ interface FilterInterface
     /**
      * Applies filter to given image
      *
-     * @param  Intervention\Image\Image $image
-     * @return Intervention\Image\Image
+     * @param  \Intervention\Image\Image $image
+     * @return \Intervention\Image\Image
      */
     public function applyFilter(\Intervention\Image\Image $image);
 }

--- a/src/Intervention/Image/Gd/Color.php
+++ b/src/Intervention/Image/Gd/Color.php
@@ -38,7 +38,7 @@ class Color extends AbstractColor
      * Initiates color object from integer
      *
      * @param  integer $value
-     * @return Intervention\Image\AbstractColor
+     * @return \Intervention\Image\AbstractColor
      */
     public function initFromInteger($value)
     {
@@ -52,7 +52,7 @@ class Color extends AbstractColor
      * Initiates color object from given array
      *
      * @param  array $value
-     * @return Intervention\Image\AbstractColor
+     * @return \Intervention\Image\AbstractColor
      */
     public function initFromArray($array)
     {
@@ -81,7 +81,7 @@ class Color extends AbstractColor
      * Initiates color object from given string
      *
      * @param  string $value
-     * @return Intervention\Image\AbstractColor
+     * @return \Intervention\Image\AbstractColor
      */
     public function initFromString($value)
     {
@@ -99,7 +99,7 @@ class Color extends AbstractColor
      * @param  integer $r
      * @param  integer $g
      * @param  integer $b
-     * @return Intervention\Image\AbstractColor
+     * @return \Intervention\Image\AbstractColor
      */
     public function initFromRgb($r, $g, $b)
     {
@@ -116,7 +116,7 @@ class Color extends AbstractColor
      * @param  integer $g
      * @param  integer $b
      * @param  float   $a
-     * @return Intervention\Image\AbstractColor
+     * @return \Intervention\Image\AbstractColor
      */
     public function initFromRgba($r, $g, $b, $a = 1)
     {
@@ -130,7 +130,7 @@ class Color extends AbstractColor
      * Initiates color object from given ImagickPixel object
      *
      * @param  ImagickPixel $value
-     * @return Intervention\Image\AbstractColor
+     * @return \Intervention\Image\AbstractColor
      */
     public function initFromObject($value)
     {

--- a/src/Intervention/Image/Gd/Commands/BackupCommand.php
+++ b/src/Intervention/Image/Gd/Commands/BackupCommand.php
@@ -7,7 +7,7 @@ class BackupCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Saves a backups of current state of image core
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/BlurCommand.php
+++ b/src/Intervention/Image/Gd/Commands/BlurCommand.php
@@ -7,7 +7,7 @@ class BlurCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Applies blur effect on image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/BrightnessCommand.php
+++ b/src/Intervention/Image/Gd/Commands/BrightnessCommand.php
@@ -7,7 +7,7 @@ class BrightnessCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Changes image brightness
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/ColorizeCommand.php
+++ b/src/Intervention/Image/Gd/Commands/ColorizeCommand.php
@@ -7,7 +7,7 @@ class ColorizeCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Changes balance of different RGB color channels
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/ContrastCommand.php
+++ b/src/Intervention/Image/Gd/Commands/ContrastCommand.php
@@ -7,7 +7,7 @@ class ContrastCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Changes contrast of image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/CropCommand.php
+++ b/src/Intervention/Image/Gd/Commands/CropCommand.php
@@ -10,7 +10,7 @@ class CropCommand extends ResizeCommand
     /**
      * Crop an image instance
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/DestroyCommand.php
+++ b/src/Intervention/Image/Gd/Commands/DestroyCommand.php
@@ -7,7 +7,7 @@ class DestroyCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Destroys current image core and frees up memory
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/FillCommand.php
+++ b/src/Intervention/Image/Gd/Commands/FillCommand.php
@@ -10,7 +10,7 @@ class FillCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Fills image with color or pattern
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/FitCommand.php
+++ b/src/Intervention/Image/Gd/Commands/FitCommand.php
@@ -10,7 +10,7 @@ class FitCommand extends ResizeCommand
     /**
      * Crops and resized an image at the same time
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/FlipCommand.php
+++ b/src/Intervention/Image/Gd/Commands/FlipCommand.php
@@ -7,7 +7,7 @@ class FlipCommand extends ResizeCommand
     /**
      * Mirrors an image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/GammaCommand.php
+++ b/src/Intervention/Image/Gd/Commands/GammaCommand.php
@@ -7,7 +7,7 @@ class GammaCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Applies gamma correction to a given image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/GetSizeCommand.php
+++ b/src/Intervention/Image/Gd/Commands/GetSizeCommand.php
@@ -9,7 +9,7 @@ class GetSizeCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Reads size of given image instance in pixels
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/GreyscaleCommand.php
+++ b/src/Intervention/Image/Gd/Commands/GreyscaleCommand.php
@@ -7,7 +7,7 @@ class GreyscaleCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Turns an image into a greyscale version
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/HeightenCommand.php
+++ b/src/Intervention/Image/Gd/Commands/HeightenCommand.php
@@ -7,7 +7,7 @@ class HeightenCommand extends ResizeCommand
     /**
      * Resize image proportionally to given height
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/InsertCommand.php
+++ b/src/Intervention/Image/Gd/Commands/InsertCommand.php
@@ -7,7 +7,7 @@ class InsertCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Insert another image into given image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/InterlaceCommand.php
+++ b/src/Intervention/Image/Gd/Commands/InterlaceCommand.php
@@ -7,7 +7,7 @@ class InterlaceCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Toggles interlaced encoding mode
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/InvertCommand.php
+++ b/src/Intervention/Image/Gd/Commands/InvertCommand.php
@@ -7,7 +7,7 @@ class InvertCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Inverts colors of an image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/LimitColorsCommand.php
+++ b/src/Intervention/Image/Gd/Commands/LimitColorsCommand.php
@@ -9,7 +9,7 @@ class LimitColorsCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Reduces colors of a given image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/MaskCommand.php
+++ b/src/Intervention/Image/Gd/Commands/MaskCommand.php
@@ -7,7 +7,7 @@ class MaskCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Applies an alpha mask to an image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/OpacityCommand.php
+++ b/src/Intervention/Image/Gd/Commands/OpacityCommand.php
@@ -7,7 +7,7 @@ class OpacityCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Defines opacity of an image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/PickColorCommand.php
+++ b/src/Intervention/Image/Gd/Commands/PickColorCommand.php
@@ -9,7 +9,7 @@ class PickColorCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Read color information from a certain position
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/PixelCommand.php
+++ b/src/Intervention/Image/Gd/Commands/PixelCommand.php
@@ -9,7 +9,7 @@ class PixelCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Draws one pixel to a given image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/PixelateCommand.php
+++ b/src/Intervention/Image/Gd/Commands/PixelateCommand.php
@@ -7,7 +7,7 @@ class PixelateCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Applies a pixelation effect to a given image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/ResetCommand.php
+++ b/src/Intervention/Image/Gd/Commands/ResetCommand.php
@@ -7,7 +7,7 @@ class ResetCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Resets given image to its backup state
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/ResizeCanvasCommand.php
+++ b/src/Intervention/Image/Gd/Commands/ResizeCanvasCommand.php
@@ -10,7 +10,7 @@ class ResizeCanvasCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Resizes image boundaries
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/ResizeCommand.php
+++ b/src/Intervention/Image/Gd/Commands/ResizeCommand.php
@@ -7,7 +7,7 @@ class ResizeCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Resizes image dimensions
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/RotateCommand.php
+++ b/src/Intervention/Image/Gd/Commands/RotateCommand.php
@@ -9,7 +9,7 @@ class RotateCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Rotates image counter clockwise
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/SharpenCommand.php
+++ b/src/Intervention/Image/Gd/Commands/SharpenCommand.php
@@ -7,7 +7,7 @@ class SharpenCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Sharpen image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/TrimCommand.php
+++ b/src/Intervention/Image/Gd/Commands/TrimCommand.php
@@ -9,7 +9,7 @@ class TrimCommand extends ResizeCommand
     /**
      * Trims away parts of an image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Commands/WidenCommand.php
+++ b/src/Intervention/Image/Gd/Commands/WidenCommand.php
@@ -7,7 +7,7 @@ class WidenCommand extends ResizeCommand
     /**
      * Resize image proportionally to given width
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Gd/Decoder.php
+++ b/src/Intervention/Image/Gd/Decoder.php
@@ -11,7 +11,7 @@ class Decoder extends \Intervention\Image\AbstractDecoder
      * Initiates new image from path in filesystem
      *
      * @param  string $path
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     public function initFromPath($path)
     {
@@ -57,7 +57,7 @@ class Decoder extends \Intervention\Image\AbstractDecoder
      * Initiates new image from GD resource
      *
      * @param  Resource $resource
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     public function initFromGdResource($resource)
     {
@@ -68,7 +68,7 @@ class Decoder extends \Intervention\Image\AbstractDecoder
      * Initiates new image from Imagick object
      *
      * @param  Imagick $object
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     public function initFromImagick(\Imagick $object)
     {
@@ -81,7 +81,7 @@ class Decoder extends \Intervention\Image\AbstractDecoder
      * Initiates new image from binary data
      *
      * @param  string $data
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     public function initFromBinary($binary)
     {

--- a/src/Intervention/Image/Gd/Driver.php
+++ b/src/Intervention/Image/Gd/Driver.php
@@ -30,7 +30,7 @@ class Driver extends \Intervention\Image\AbstractDriver
      * @param  integer $width
      * @param  integer $height
      * @param  string  $background
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     public function newImage($width, $height, $background = null)
     {

--- a/src/Intervention/Image/Image.php
+++ b/src/Intervention/Image/Image.php
@@ -63,7 +63,7 @@ class Image extends File
      *
      * @param  string  $format
      * @param  integer $quality
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     public function encode($format = null, $quality = 90)
     {
@@ -75,7 +75,7 @@ class Image extends File
      *
      * @param  string  $path
      * @param  integer $quality
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     public function save($path = null, $quality = null)
     {
@@ -106,7 +106,7 @@ class Image extends File
      * Runs a given filter on current image
      *
      * @param  FiltersFilterInterface $filter
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     public function filter(Filters\FilterInterface $filter)
     {
@@ -116,7 +116,7 @@ class Image extends File
     /**
      * Returns current image driver
      *
-     * @return Intervention\Image\AbstractDriver
+     * @return \Intervention\Image\AbstractDriver
      */
     public function getDriver()
     {

--- a/src/Intervention/Image/ImageManager.php
+++ b/src/Intervention/Image/ImageManager.php
@@ -42,7 +42,7 @@ class ImageManager
      *
      * @param  mixed $data
      *
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     public function make($data)
     {
@@ -56,7 +56,7 @@ class ImageManager
      * @param  integer $height
      * @param  mixed $background
      *
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     public function canvas($width, $height, $background = null)
     {
@@ -95,7 +95,7 @@ class ImageManager
     /**
      * Creates a driver instance according to config settings
      *
-     * @return Intervention\Image\AbstractDriver
+     * @return \Intervention\Image\AbstractDriver
      */
     private function createDriver()
     {

--- a/src/Intervention/Image/ImageManagerStatic.php
+++ b/src/Intervention/Image/ImageManagerStatic.php
@@ -50,7 +50,7 @@ class ImageManagerStatic
      *
      * @param  mixed $data
      *
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     public static function make($data)
     {
@@ -64,7 +64,7 @@ class ImageManagerStatic
      * @param  integer $height
      * @param  mixed $background
      *
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     public static function canvas($width, $height, $background = null)
     {

--- a/src/Intervention/Image/Imagick/Color.php
+++ b/src/Intervention/Image/Imagick/Color.php
@@ -15,7 +15,7 @@ class Color extends \Intervention\Image\AbstractColor
      * Initiates color object from integer
      *
      * @param  integer $value
-     * @return Intervention\Image\AbstractColor
+     * @return \Intervention\Image\AbstractColor
      */
     public function initFromInteger($value)
     {
@@ -32,7 +32,7 @@ class Color extends \Intervention\Image\AbstractColor
      * Initiates color object from given array
      *
      * @param  array $value
-     * @return Intervention\Image\AbstractColor
+     * @return \Intervention\Image\AbstractColor
      */
     public function initFromArray($array)
     {
@@ -58,7 +58,7 @@ class Color extends \Intervention\Image\AbstractColor
      *
      * @param  string $value
      *
-     * @return Intervention\Image\AbstractColor
+     * @return \Intervention\Image\AbstractColor
      */
     public function initFromString($value)
     {
@@ -72,7 +72,7 @@ class Color extends \Intervention\Image\AbstractColor
      *
      * @param  ImagickPixel $value
      *
-     * @return Intervention\Image\AbstractColor
+     * @return \Intervention\Image\AbstractColor
      */
     public function initFromObject($value)
     {
@@ -88,7 +88,7 @@ class Color extends \Intervention\Image\AbstractColor
      * @param  integer $g
      * @param  integer $b
      *
-     * @return Intervention\Image\AbstractColor
+     * @return \Intervention\Image\AbstractColor
      */
     public function initFromRgb($r, $g, $b)
     {
@@ -103,7 +103,7 @@ class Color extends \Intervention\Image\AbstractColor
      * @param  integer $b
      * @param  float   $a
      *
-     * @return Intervention\Image\AbstractColor
+     * @return \Intervention\Image\AbstractColor
      */
     public function initFromRgba($r, $g, $b, $a)
     {

--- a/src/Intervention/Image/Imagick/Commands/BackupCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/BackupCommand.php
@@ -7,7 +7,7 @@ class BackupCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Saves a backups of current state of image core
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/BlurCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/BlurCommand.php
@@ -7,7 +7,7 @@ class BlurCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Applies blur effect on image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/BrightnessCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/BrightnessCommand.php
@@ -7,7 +7,7 @@ class BrightnessCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Changes image brightness
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/ColorizeCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/ColorizeCommand.php
@@ -7,7 +7,7 @@ class ColorizeCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Changes balance of different RGB color channels
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/ContrastCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/ContrastCommand.php
@@ -7,7 +7,7 @@ class ContrastCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Changes contrast of image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/CropCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/CropCommand.php
@@ -10,7 +10,7 @@ class CropCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Crop an image instance
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/DestroyCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/DestroyCommand.php
@@ -7,7 +7,7 @@ class DestroyCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Destroys current image core and frees up memory
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/FillCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/FillCommand.php
@@ -11,7 +11,7 @@ class FillCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Fills image with color or pattern
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/FitCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/FitCommand.php
@@ -9,7 +9,7 @@ class FitCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Crops and resized an image at the same time
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/FlipCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/FlipCommand.php
@@ -7,7 +7,7 @@ class FlipCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Mirrors an image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/GammaCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/GammaCommand.php
@@ -7,7 +7,7 @@ class GammaCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Applies gamma correction to a given image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/GetSizeCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/GetSizeCommand.php
@@ -9,7 +9,7 @@ class GetSizeCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Reads size of given image instance in pixels
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/GreyscaleCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/GreyscaleCommand.php
@@ -7,7 +7,7 @@ class GreyscaleCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Turns an image into a greyscale version
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/HeightenCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/HeightenCommand.php
@@ -7,7 +7,7 @@ class HeightenCommand extends ResizeCommand
     /**
      * Resize image proportionally to given height
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/InsertCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/InsertCommand.php
@@ -7,7 +7,7 @@ class InsertCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Insert another image into given image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/InterlaceCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/InterlaceCommand.php
@@ -7,7 +7,7 @@ class InterlaceCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Toggles interlaced encoding mode
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/InvertCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/InvertCommand.php
@@ -7,7 +7,7 @@ class InvertCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Inverts colors of an image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/LimitColorsCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/LimitColorsCommand.php
@@ -7,7 +7,7 @@ class LimitColorsCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Reduces colors of a given image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/MaskCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/MaskCommand.php
@@ -7,7 +7,7 @@ class MaskCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Applies an alpha mask to an image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/OpacityCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/OpacityCommand.php
@@ -7,7 +7,7 @@ class OpacityCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Defines opacity of an image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/PickColorCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/PickColorCommand.php
@@ -9,7 +9,7 @@ class PickColorCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Read color information from a certain position
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/PixelCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/PixelCommand.php
@@ -9,7 +9,7 @@ class PixelCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Draws one pixel to a given image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/PixelateCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/PixelateCommand.php
@@ -7,7 +7,7 @@ class PixelateCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Applies a pixelation effect to a given image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/ResetCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/ResetCommand.php
@@ -7,7 +7,7 @@ class ResetCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Resets given image to its backup state
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/ResizeCanvasCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/ResizeCanvasCommand.php
@@ -7,7 +7,7 @@ class ResizeCanvasCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Resizes image boundaries
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/ResizeCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/ResizeCommand.php
@@ -7,7 +7,7 @@ class ResizeCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Resizes image dimensions
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/RotateCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/RotateCommand.php
@@ -9,7 +9,7 @@ class RotateCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Rotates image counter clockwise
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/SharpenCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/SharpenCommand.php
@@ -7,7 +7,7 @@ class SharpenCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Sharpen image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/TrimCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/TrimCommand.php
@@ -9,7 +9,7 @@ class TrimCommand extends \Intervention\Image\Commands\AbstractCommand
     /**
      * Trims away parts of an image
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Commands/WidenCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/WidenCommand.php
@@ -7,7 +7,7 @@ class WidenCommand extends ResizeCommand
     /**
      * Resize image proportionally to given width
      *
-     * @param  Intervention\Image\Image $image
+     * @param  \Intervention\Image\Image $image
      * @return boolean
      */
     public function execute($image)

--- a/src/Intervention/Image/Imagick/Decoder.php
+++ b/src/Intervention/Image/Imagick/Decoder.php
@@ -11,7 +11,7 @@ class Decoder extends \Intervention\Image\AbstractDecoder
      * Initiates new image from path in filesystem
      *
      * @param  string $path
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     public function initFromPath($path)
     {
@@ -39,7 +39,7 @@ class Decoder extends \Intervention\Image\AbstractDecoder
      * Initiates new image from GD resource
      *
      * @param  Resource $resource
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     public function initFromGdResource($resource)
     {
@@ -52,7 +52,7 @@ class Decoder extends \Intervention\Image\AbstractDecoder
      * Initiates new image from Imagick object
      *
      * @param  Imagick $object
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     public function initFromImagick(\Imagick $object)
     {
@@ -70,7 +70,7 @@ class Decoder extends \Intervention\Image\AbstractDecoder
      * Initiates new image from binary data
      *
      * @param  string $data
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     public function initFromBinary($binary)
     {

--- a/src/Intervention/Image/Imagick/Driver.php
+++ b/src/Intervention/Image/Imagick/Driver.php
@@ -30,7 +30,7 @@ class Driver extends \Intervention\Image\AbstractDriver
      * @param  integer $width
      * @param  integer $height
      * @param  string  $background
-     * @return Intervention\Image\Image
+     * @return \Intervention\Image\Image
      */
     public function newImage($width, $height, $background = null)
     {

--- a/src/Intervention/Image/Size.php
+++ b/src/Intervention/Image/Size.php
@@ -206,7 +206,7 @@ class Size
      * based on the pivot point settings of both sizes.
      *
      * @param  Size   $size
-     * @return Intervention\Image\Point
+     * @return \Intervention\Image\Point
      */
     public function relativePosition(Size $size)
     {
@@ -220,7 +220,7 @@ class Size
      * Resize given Size to best fitting size of current size.
      *
      * @param  Size   $size
-     * @return Intervention\Image\Size
+     * @return \Intervention\Image\Size
      */
     public function fit(Size $size)
     {
@@ -273,7 +273,7 @@ class Size
      * @param  string  $position
      * @param  integer $offset_x
      * @param  integer $offset_y
-     * @return Intervention\Image\Size
+     * @return \Intervention\Image\Size
      */
     public function align($position, $offset_x = 0, $offset_y = 0)
     {
@@ -358,7 +358,7 @@ class Size
      * Runs constraints on current size
      *
      * @param  Closure $callback
-     * @return Intervention\Image\Constraint
+     * @return \Intervention\Image\Constraint
      */
     private function getConstraint(Closure $callback = null)
     {


### PR DESCRIPTION
This fixes #208 by adding the "\" prefix to fully qualified class names (`Intervention\...`) in the PHP docblocks.
