### PR TITLE
Rewrite Gd\Color::alpha2gd for improved performance

### DIFF
--- a/src/Intervention/Image/Gd/Color.php
+++ b/src/Intervention/Image/Gd/Color.php
@@ -215,15 +215,12 @@ class Color extends AbstractColor
      */
     private function alpha2gd($input)
     {
-        $range_input = range(1, 0, 1/127);
-        $range_output = range(0, 127);
+        $oldMin = 0;
+        $oldMax = 1;
 
-        foreach ($range_input as $key => $value) {
-            if ($value <= $input) {
-                return $range_output[$key];
-            }
-        }
+        $newMin = 127;
+        $newMax = 0;
 
-        return 127;
+        return ceil(((($input- $oldMin) * ($newMax - $newMin)) / ($oldMax - $oldMin)) + $newMin);
     }
 }


### PR DESCRIPTION
This changes the Gd\Color::alpha2gd implementation from one based on iterating through arrays, to one that's more maths-based.

I've uploaded a simple benchmark that runs through 1000 conversion operations with each method, and then also runs through 10,000 conversion operations to ensure the the outputs of both methods match. http://3v4l.org/4sqOa

This really falls under the category of micro-optimisation, but I was using Intervention\Image to set each pixel of a 500x500 image, so it ended up being a pretty big performance gain in the end. (Though for the record, I ended up using gd functions directly)
