### PR TITLE
Use Mockery 0.9.2 instead of @dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "3.*",
-        "mockery/mockery": "0.9.*@dev"
+        "mockery/mockery": "~0.9.2"
     },
     "suggest": {
         "ext-gd": "to use GD library based image processing.",


### PR DESCRIPTION
Now that Mockery 0.9.2 has been tagged you can move away from using the @dev flag in the composer.json.
