### PR TITLE
Add SplFileInfo init functionality

### DIFF
--- a/src/Intervention/Image/AbstractDecoder.php
+++ b/src/Intervention/Image/AbstractDecoder.php
@@ -37,6 +37,14 @@ abstract class AbstractDecoder
     abstract public function initFromImagick(\Imagick $object);
 
     /**
+     * Initiates new image from SplFileInfo object
+     *
+     * @param  SplFileInfo $object
+     * @return \Intervention\Image\Image
+     */
+    abstract public function initFromSplFileInfo(\SplFileInfo $object);
+
+    /**
      * Buffer of input data
      *
      * @var mixed
@@ -219,7 +227,7 @@ abstract class AbstractDecoder
                 return $this->initFromInterventionImage($this->data);
 
             case $this->isSplFileInfo():
-                return $this->initFromPath($this->data->getRealPath());
+                return $this->initFromSplFileInfo($this->data);
 
             case $this->isBinary():
                 return $this->initFromBinary($this->data);

--- a/src/Intervention/Image/File.php
+++ b/src/Intervention/Image/File.php
@@ -59,9 +59,28 @@ class File
         return $this;
     }
 
+    /**
+     * Sets all instance properties from given SplFileInfo object
+     *
+     * @param SplFileInfo $object
+     */
+    public function setFileInfoFromSplFileInfo(\SplFileInfo $object)
+    {
+        $this->dirname = $object->getPath();
+        $this->basename = $object->getBasename();
+        $this->extension = $object->getExtension();
+        $this->filename = $object->getFilename();
+
+        if ($object->getType() === 'file') {
+            $this->mime = finfo_file(finfo_open(FILEINFO_MIME_TYPE), $object->getRealPath());
+        }
+
+        return $this;
+    }
+
      /**
       * Get file size
-      * 
+      *
       * @return mixed
       */
     public function filesize()
@@ -71,7 +90,7 @@ class File
         if (file_exists($path) && is_file($path)) {
             return filesize($path);
         }
-        
+
         return false;
     }
 

--- a/src/Intervention/Image/Imagick/Decoder.php
+++ b/src/Intervention/Image/Imagick/Decoder.php
@@ -36,6 +36,35 @@ class Decoder extends \Intervention\Image\AbstractDecoder
     }
 
     /**
+     * Initiates new image from SplFileInfo object
+     *
+     * @param  SplFileInfo $object
+     * @return \Intervention\Image\Image
+     */
+    public function initFromSplFileInfo(\SplFileInfo $object)
+    {
+        $core = new \Imagick;
+        $path = $object->getRealPath();
+
+        try {
+
+            $core->readImage($path);
+            $core->setImageType(\Imagick::IMGTYPE_TRUECOLORMATTE);
+
+        } catch (\ImagickException $e) {
+            throw new \Intervention\Image\Exception\NotReadableException(
+                "Unable to read image from path ({$path})."
+            );
+        }
+
+        // build image
+        $image = $this->initFromImagick($core);
+        $image->setFileInfoFromSplFileInfo($object);
+
+        return $image;
+    }
+
+    /**
      * Initiates new image from GD resource
      *
      * @param  Resource $resource


### PR DESCRIPTION
This adds functionality for using the file info provided by an SplFileInfo object directly, rather than using only the path it provides.

The main purpose of this is to allow files that don't have extensions (for example, uploaded files) to still be interpreted and parsed correctly.
