### PR TITLE
Added being cached informations

### DIFF
--- a/src/Intervention/Image/Image.php
+++ b/src/Intervention/Image/Image.php
@@ -48,6 +48,15 @@ namespace Intervention\Image;
  */
 class Image extends File
 {
+
+    /**
+     * Indicates if the image has already been cached
+     *
+     * @var bool
+     */
+    protected $cached;
+
+
     /**
      * Instance of current image driver
      *
@@ -200,6 +209,20 @@ class Image extends File
         return $this;
     }
 
+
+    /**
+     * Sets if image is being cached (false)
+     *
+     * @param $cached
+     * @return $this
+     */
+    public function setCached($cached)
+    {
+        $this->cached = $cached;
+
+        return $this;
+    }
+
     /**
      * Returns current image backup
      *
@@ -254,6 +277,17 @@ class Image extends File
     private function backupExists($name)
     {
         return array_key_exists($name, $this->backups);
+    }
+
+
+    /**
+     * Checks if the image has already been cached or is being
+     *
+     * @return bool
+     */
+    public function isAlreadyCached()
+    {
+        return $this->cached;
     }
 
     /**

--- a/src/Intervention/Image/ImageManager.php
+++ b/src/Intervention/Image/ImageManager.php
@@ -6,8 +6,6 @@ use Closure;
 
 class ImageManager
 {
-    public $cached;
-    
     /**
      * Config
      *

--- a/src/Intervention/Image/ImageManager.php
+++ b/src/Intervention/Image/ImageManager.php
@@ -6,6 +6,8 @@ use Closure;
 
 class ImageManager
 {
+    public $cached;
+    
     /**
      * Config
      *


### PR DESCRIPTION
Allows people to know if an image has already been cached or is being cached (works along with ImageCache to set the $cached property). That way they can manage the headers (for example) being sent to the browser in case the image already exists in cache.