### PR TITLE
Change Imagick method for fitCommand

### DIFF
--- a/src/Intervention/Image/Imagick/Commands/FitCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/FitCommand.php
@@ -33,7 +33,7 @@ class FitCommand extends \Intervention\Image\Commands\AbstractCommand
         );
 
         // resize image
-        $image->getCore()->resizeImage($resized->getWidth(), $resized->getHeight(), \Imagick::FILTER_BOX, 1);
+        $image->getCore()->scaleImage($resized->getWidth(), $resized->getHeight());
         $image->getCore()->setImagePage(0,0,0,0);
 
         return true;

--- a/tests/FitCommandTest.php
+++ b/tests/FitCommandTest.php
@@ -59,7 +59,7 @@ class FitCommandTest extends PHPUnit_Framework_TestCase
         $original_size->shouldReceive('fit')->with(Mockery::any(), 'center')->once()->andReturn($cropped_size);
         $imagick = Mockery::mock('Imagick');
         $imagick->shouldReceive('cropimage')->with(800, 400, 0, 100)->andReturn(true);
-        $imagick->shouldReceive('resizeimage')->with(200, 100, \Imagick::FILTER_BOX, 1)->andReturn(true);
+        $imagick->shouldReceive('scaleimage')->with(200, 100)->once()->andReturn(true);
         $imagick->shouldReceive('setimagepage')->with(0, 0, 0, 0)->andReturn(true);
         $image = Mockery::mock('Intervention\Image\Image');
         $image->shouldReceive('getSize')->once()->andReturn($original_size);
@@ -80,7 +80,7 @@ class FitCommandTest extends PHPUnit_Framework_TestCase
         $original_size->shouldReceive('fit')->with(Mockery::any(), 'top-left')->once()->andReturn($cropped_size);
         $imagick = Mockery::mock('Imagick');
         $imagick->shouldReceive('cropimage')->with(800, 400, 0, 100)->andReturn(true);
-        $imagick->shouldReceive('resizeimage')->with(200, 100, \Imagick::FILTER_BOX, 1)->andReturn(true);
+        $imagick->shouldReceive('scaleimage')->with(200, 100)->once()->andReturn(true);
         $imagick->shouldReceive('setimagepage')->with(0, 0, 0, 0)->andReturn(true);
         $image = Mockery::mock('Intervention\Image\Image');
         $image->shouldReceive('getSize')->once()->andReturn($original_size);


### PR DESCRIPTION
Same fix as in #353, Fit command used resize with FILTER_BOX filter instead of scale.