### PR TITLE
Added support for Image::fill() with array (RGB / RGBA)

### DIFF
--- a/src/Intervention/Image/AbstractDecoder.php
+++ b/src/Intervention/Image/AbstractDecoder.php
@@ -216,6 +216,10 @@ abstract class AbstractDecoder
      */
     public function isBase64()
     {
+        if (!is_string($this->data)) {
+            return false;
+        }
+
         return base64_encode(base64_decode($this->data)) === $this->data;
     }
 
@@ -238,6 +242,10 @@ abstract class AbstractDecoder
      */
     private function decodeDataUrl($data_url)
     {
+        if (!is_string($data_url)) {
+            return null;
+        }
+
         $pattern = "/^data:(?:image\/[a-zA-Z\-\.]+)(?:charset=\".+\")?;base64,(?P<data>.+)$/";
         preg_match($pattern, $data_url, $matches);
 

--- a/tests/FillCommandTest.php
+++ b/tests/FillCommandTest.php
@@ -22,6 +22,30 @@ class FillCommandTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($result);
     }
 
+    public function testGdFillArray()
+    {
+        $resource = imagecreatefromjpeg(__DIR__.'/images/test.jpg');
+        $image = Mockery::mock('Intervention\Image\Image');
+        $image->shouldReceive('getCore')->once()->andReturn($resource);
+        $image->shouldReceive('getWidth')->once()->andReturn(800);
+        $image->shouldReceive('getHeight')->once()->andReturn(600);
+        $command = new FillGd(array(array(50, 50, 50)));
+        $result = $command->execute($image);
+        $this->assertTrue($result);
+    }
+
+    public function testGdFillArrayWithAlpha()
+    {
+        $resource = imagecreatefromjpeg(__DIR__.'/images/test.jpg');
+        $image = Mockery::mock('Intervention\Image\Image');
+        $image->shouldReceive('getCore')->once()->andReturn($resource);
+        $image->shouldReceive('getWidth')->once()->andReturn(800);
+        $image->shouldReceive('getHeight')->once()->andReturn(600);
+        $command = new FillGd(array(array(50, 50, 50, .50)));
+        $result = $command->execute($image);
+        $this->assertTrue($result);
+    }
+
     public function testGdFillWithCoordinates()
     {
         $driver = Mockery::mock('\Intervention\Image\Gd\Driver');


### PR DESCRIPTION
As described in the [Color Format documentation](http://image.intervention.io/getting_started/formats) the Image::fill() accept array data for RGB and RGBA implementation. 

In fact, when using this causes Warning errors, It's ok that is not accepted as [Fill documentation](http://image.intervention.io/api/fill), but I guess now it works.

## Error Log
**RGB** *array(50, 50, 50)*
> preg_match() expects parameter 2 to be string, array given
>  /var/www/html/git/image/src/Intervention/Image/AbstractDecoder.php:242
>  /var/www/html/git/image/src/Intervention/Image/AbstractDecoder.php:207
>  /var/www/html/git/image/src/Intervention/Image/AbstractDecoder.php:287
>  /var/www/html/git/image/src/Intervention/Image/Gd/Commands/FillCommand.php:30
>  /var/www/html/git/image/tests/FillCommandTest.php:33

**RGBA** *array(50, 50, 50, 0.5)*
> preg_match() expects parameter 2 to be string, array given
>  /var/www/html/git/image/src/Intervention/Image/AbstractDecoder.php:242
>  /var/www/html/git/image/src/Intervention/Image/AbstractDecoder.php:207
>  /var/www/html/git/image/src/Intervention/Image/AbstractDecoder.php:287
>  /var/www/html/git/image/src/Intervention/Image/Gd/Commands/FillCommand.php:30
>  /var/www/html/git/image/tests/FillCommandTest.php:45