### PR TITLE
Fix isEncoded() Return Value

### DIFF
--- a/src/Intervention/Image/Image.php
+++ b/src/Intervention/Image/Image.php
@@ -268,7 +268,7 @@ class Image extends File
      */
     public function isEncoded()
     {
-        return ! is_null($this->encoded);
+        return ! empty($this->encoded);
     }
 
     /**

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -43,6 +43,15 @@ class ImageTest extends PHPUnit_Framework_TestCase
         @unlink($save_as);
     }
 
+    public function testIsEncoded()
+    {
+        $image = $this->getTestImage();
+        $this->assertFalse($image->isEncoded());
+        
+        $image->setEncoded('foo');
+        $this->assertTrue($image->isEncoded());
+    }
+
     public function testFilter()
     {
         $demoFilter = Mockery::mock('\Intervention\Image\Filters\DemoFilter', array(15));


### PR DESCRIPTION
`isEncoded()` always returns true, even if no encoded image exists.

The `encoded` property of `Intervention\Image\Image` is initialised as an empty string:
```
    /**
     * Last image encoding result
     *
     * @var string
     */
    public $encoded = '';
```
But `isEncoded()` checks if it is null:
```
    /**
     * Checks if current image is already encoded
     *
     * @return boolean
     */
    public function isEncoded()
    {
        return ! is_null($this->encoded);
    }
```

Change the function to check for an empty string instead. Added unit test coverage.