### PR TITLE
Forcing format on save

### DIFF
--- a/src/Intervention/Image/Image.php
+++ b/src/Intervention/Image/Image.php
@@ -124,9 +124,10 @@ class Image extends File
      *
      * @param  string  $path
      * @param  integer $quality
+     * @param  string  $format
      * @return \Intervention\Image\Image
      */
-    public function save($path = null, $quality = null)
+    public function save($path = null, $quality = null, $format = null)
     {
         $path = is_null($path) ? $this->basePath() : $path;
 
@@ -136,7 +137,11 @@ class Image extends File
             );
         }
 
-        $data = $this->encode(pathinfo($path, PATHINFO_EXTENSION), $quality);
+        if ($format === null) {
+            $format = pathinfo($path, PATHINFO_EXTENSION);
+        }
+
+        $data = $this->encode($format, $quality);
         $saved = @file_put_contents($path, $data);
 
         if ($saved === false) {

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -43,6 +43,23 @@ class ImageTest extends PHPUnit_Framework_TestCase
         @unlink($save_as);
     }
 
+    public function testSaveWithFormat()
+    {
+        $save_as = __DIR__.'/tmp/test.jpg';
+
+        $image = $this->getTestImage();
+        $image->getDriver()->shouldReceive('encode')->with($image, 'png', 85)->once()->andReturn('mock');
+        $image = $image->save($save_as, 85, 'png');
+
+        $this->assertInstanceOf('\Intervention\Image\Image', $image);
+        $this->assertFileExists($save_as);
+        $this->assertEquals($image->basename, 'test.jpg');
+        $this->assertEquals($image->extension, 'jpg');
+        $this->assertEquals($image->filename, 'test');
+
+        @unlink($save_as);
+    }
+
     public function testIsEncoded()
     {
         $image = $this->getTestImage();


### PR DESCRIPTION
Little modification that will allow us to specify format on \Intervention\Image\Image::save() like it's possible with \Intervention\Image\Image::encode()