### PR TITLE
added support for @ in filename

### DIFF
--- a/src/Intervention/Image/ImageServiceProviderLaravel5.php
+++ b/src/Intervention/Image/ImageServiceProviderLaravel5.php
@@ -78,7 +78,7 @@ class ImageServiceProviderLaravel5 extends ServiceProvider
         // imagecache route
         if (is_string(config('imagecache.route'))) {
 
-            $filename_pattern = '[ \w\\.\\/\\-]+';
+            $filename_pattern = '[ \w\\.\\/\\-\\@]+';
 
             // route to access template applied image file
             $app['router']->get(config('imagecache.route').'/{template}/{filename}', array(


### PR DESCRIPTION
A specific, well-known javascript library requires retina images to be postfixed by '@2x'.

Intervention-image doesn't allow for '@' as a possible character in the filename, making both unusable together.

Currently, I've made the change in forks of your project which I use as repositories, but if you think the change might be useful, here it is.