### PR TITLE
Encoding format (image/x-ico) is not supported.

### DIFF
--- a/src/Intervention/Image/AbstractEncoder.php
+++ b/src/Intervention/Image/AbstractEncoder.php
@@ -135,6 +135,7 @@ abstract class AbstractEncoder
                 break;
 
             case 'ico':
+            case 'image/x-ico':
             case 'image/x-icon':
             case 'image/vnd.microsoft.icon':
                 $this->result = $this->processIco();


### PR DESCRIPTION
At an .ico image I got the type "image/x-ico" and not image/x-icon

```
PHP Fatal error:  Uncaught exception 'Intervention\Image\Exception\NotSupportedException' with message 'Encoding format (image/x-ico) is not supported.' in /packages/intervention/image/src/Intervention/Image/AbstractEncoder.php:149

```