### PR TITLE
Fix: Case-insensitive method calls and class names

### DIFF
--- a/src/Intervention/Image/Imagick/Driver.php
+++ b/src/Intervention/Image/Imagick/Driver.php
@@ -40,7 +40,7 @@ class Driver extends \Intervention\Image\AbstractDriver
         $core = new \Imagick;
         $core->newImage($width, $height, $background->getPixel(), 'png');
         $core->setType(\Imagick::IMGTYPE_UNDEFINED);
-        $core->setImagetype(\Imagick::IMGTYPE_UNDEFINED);
+        $core->setImageType(\Imagick::IMGTYPE_UNDEFINED);
         $core->setColorspace(\Imagick::COLORSPACE_UNDEFINED);
 
         // build image

--- a/tests/AbstractDecoderTest.php
+++ b/tests/AbstractDecoderTest.php
@@ -14,7 +14,7 @@ class AbstractDecoderTest extends PHPUnit_Framework_TestCase
         $source = $this->getTestDecoder(new \Imagick);
         $this->assertTrue($source->isImagick());
 
-        $source = $this->getTestDecoder(new StdClass);
+        $source = $this->getTestDecoder(new stdClass);
         $this->assertFalse($source->isImagick());
 
         $source = $this->getTestDecoder(null);
@@ -45,7 +45,7 @@ class AbstractDecoderTest extends PHPUnit_Framework_TestCase
         $source = $this->getTestDecoder(array());
         $this->assertFalse($source->isFilepath());
 
-        $source = $this->getTestDecoder(new StdClass);
+        $source = $this->getTestDecoder(new stdClass);
         $this->assertFalse($source->isFilepath());
     }
 
@@ -84,7 +84,7 @@ class AbstractDecoderTest extends PHPUnit_Framework_TestCase
         $source = $this->getTestDecoder(array(1,2,3));
         $this->assertFalse($source->isBinary());
 
-        $source = $this->getTestDecoder(new StdClass);
+        $source = $this->getTestDecoder(new stdClass);
         $this->assertFalse($source->isBinary());
     }
 


### PR DESCRIPTION
:exclamation: Blocked by #491.

This PR

* [x] fixes a case-insensitive method call
* [x] fixes case-insensitive class names