### PR TITLE
Fix: No need for leading slash in imports

### DIFF
--- a/src/Intervention/Image/Commands/CircleCommand.php
+++ b/src/Intervention/Image/Commands/CircleCommand.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Commands;
 
-use \Closure;
+use Closure;
 
 class CircleCommand extends \Intervention\Image\Commands\AbstractCommand
 {

--- a/src/Intervention/Image/Commands/EllipseCommand.php
+++ b/src/Intervention/Image/Commands/EllipseCommand.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Commands;
 
-use \Closure;
+use Closure;
 
 class EllipseCommand extends \Intervention\Image\Commands\AbstractCommand
 {

--- a/src/Intervention/Image/Commands/LineCommand.php
+++ b/src/Intervention/Image/Commands/LineCommand.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Commands;
 
-use \Closure;
+use Closure;
 
 class LineCommand extends \Intervention\Image\Commands\AbstractCommand
 {

--- a/src/Intervention/Image/Commands/PolygonCommand.php
+++ b/src/Intervention/Image/Commands/PolygonCommand.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Commands;
 
-use \Closure;
+use Closure;
 
 class PolygonCommand extends \Intervention\Image\Commands\AbstractCommand
 {

--- a/src/Intervention/Image/Commands/RectangleCommand.php
+++ b/src/Intervention/Image/Commands/RectangleCommand.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Commands;
 
-use \Closure;
+use Closure;
 
 class RectangleCommand extends \Intervention\Image\Commands\AbstractCommand
 {

--- a/src/Intervention/Image/Commands/ResponseCommand.php
+++ b/src/Intervention/Image/Commands/ResponseCommand.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Commands;
 
-use \Intervention\Image\Response;
+use Intervention\Image\Response;
 
 class ResponseCommand extends AbstractCommand
 {

--- a/src/Intervention/Image/Commands/TextCommand.php
+++ b/src/Intervention/Image/Commands/TextCommand.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Commands;
 
-use \Closure;
+use Closure;
 
 class TextCommand extends \Intervention\Image\Commands\AbstractCommand
 {

--- a/src/Intervention/Image/Gd/Commands/CropCommand.php
+++ b/src/Intervention/Image/Gd/Commands/CropCommand.php
@@ -2,8 +2,8 @@
 
 namespace Intervention\Image\Gd\Commands;
 
-use \Intervention\Image\Point;
-use \Intervention\Image\Size;
+use Intervention\Image\Point;
+use Intervention\Image\Size;
 
 class CropCommand extends ResizeCommand
 {

--- a/src/Intervention/Image/Gd/Commands/FitCommand.php
+++ b/src/Intervention/Image/Gd/Commands/FitCommand.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Gd\Commands;
 
-use \Intervention\Image\Size;
+use Intervention\Image\Size;
 
 class FitCommand extends ResizeCommand
 {

--- a/src/Intervention/Image/Gd/Commands/GetSizeCommand.php
+++ b/src/Intervention/Image/Gd/Commands/GetSizeCommand.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Gd\Commands;
 
-use \Intervention\Image\Size;
+use Intervention\Image\Size;
 
 class GetSizeCommand extends \Intervention\Image\Commands\AbstractCommand
 {

--- a/src/Intervention/Image/Gd/Commands/PickColorCommand.php
+++ b/src/Intervention/Image/Gd/Commands/PickColorCommand.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Gd\Commands;
 
-use \Intervention\Image\Gd\Color;
+use Intervention\Image\Gd\Color;
 
 class PickColorCommand extends \Intervention\Image\Commands\AbstractCommand
 {

--- a/src/Intervention/Image/Gd/Commands/PixelCommand.php
+++ b/src/Intervention/Image/Gd/Commands/PixelCommand.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Gd\Commands;
 
-use \Intervention\Image\Gd\Color;
+use Intervention\Image\Gd\Color;
 
 class PixelCommand extends \Intervention\Image\Commands\AbstractCommand
 {

--- a/src/Intervention/Image/Gd/Commands/ResizeCanvasCommand.php
+++ b/src/Intervention/Image/Gd/Commands/ResizeCanvasCommand.php
@@ -2,7 +2,6 @@
 
 namespace Intervention\Image\Gd\Commands;
 
-
 class ResizeCanvasCommand extends \Intervention\Image\Commands\AbstractCommand
 {
     /**

--- a/src/Intervention/Image/Gd/Commands/RotateCommand.php
+++ b/src/Intervention/Image/Gd/Commands/RotateCommand.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Gd\Commands;
 
-use \Intervention\Image\Gd\Color;
+use Intervention\Image\Gd\Color;
 
 class RotateCommand extends \Intervention\Image\Commands\AbstractCommand
 {

--- a/src/Intervention/Image/Gd/Commands/TrimCommand.php
+++ b/src/Intervention/Image/Gd/Commands/TrimCommand.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Gd\Commands;
 
-use \Intervention\Image\Gd\Color;
+use Intervention\Image\Gd\Color;
 
 class TrimCommand extends ResizeCommand
 {

--- a/src/Intervention/Image/Gd/Decoder.php
+++ b/src/Intervention/Image/Gd/Decoder.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Gd;
 
-use \Intervention\Image\Image;
+use Intervention\Image\Image;
 
 class Decoder extends \Intervention\Image\AbstractDecoder
 {

--- a/src/Intervention/Image/Gd/Driver.php
+++ b/src/Intervention/Image/Gd/Driver.php
@@ -2,7 +2,6 @@
 
 namespace Intervention\Image\Gd;
 
-
 class Driver extends \Intervention\Image\AbstractDriver
 {
     /**

--- a/src/Intervention/Image/Gd/Font.php
+++ b/src/Intervention/Image/Gd/Font.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Gd;
 
-use \Intervention\Image\Image;
+use Intervention\Image\Image;
 
 class Font extends \Intervention\Image\AbstractFont
 {

--- a/src/Intervention/Image/Gd/Shapes/CircleShape.php
+++ b/src/Intervention/Image/Gd/Shapes/CircleShape.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Gd\Shapes;
 
-use \Intervention\Image\Image;
+use Intervention\Image\Image;
 
 class CircleShape extends EllipseShape
 {

--- a/src/Intervention/Image/Gd/Shapes/EllipseShape.php
+++ b/src/Intervention/Image/Gd/Shapes/EllipseShape.php
@@ -2,8 +2,8 @@
 
 namespace Intervention\Image\Gd\Shapes;
 
-use \Intervention\Image\Image;
-use \Intervention\Image\Gd\Color;
+use Intervention\Image\Image;
+use Intervention\Image\Gd\Color;
 
 class EllipseShape extends \Intervention\Image\AbstractShape
 {

--- a/src/Intervention/Image/Gd/Shapes/LineShape.php
+++ b/src/Intervention/Image/Gd/Shapes/LineShape.php
@@ -2,8 +2,8 @@
 
 namespace Intervention\Image\Gd\Shapes;
 
-use \Intervention\Image\Image;
-use \Intervention\Image\Gd\Color;
+use Intervention\Image\Image;
+use Intervention\Image\Gd\Color;
 
 class LineShape extends \Intervention\Image\AbstractShape
 {

--- a/src/Intervention/Image/Gd/Shapes/PolygonShape.php
+++ b/src/Intervention/Image/Gd/Shapes/PolygonShape.php
@@ -2,8 +2,8 @@
 
 namespace Intervention\Image\Gd\Shapes;
 
-use \Intervention\Image\Image;
-use \Intervention\Image\Gd\Color;
+use Intervention\Image\Image;
+use Intervention\Image\Gd\Color;
 
 class PolygonShape extends \Intervention\Image\AbstractShape
 {

--- a/src/Intervention/Image/Gd/Shapes/RectangleShape.php
+++ b/src/Intervention/Image/Gd/Shapes/RectangleShape.php
@@ -2,8 +2,8 @@
 
 namespace Intervention\Image\Gd\Shapes;
 
-use \Intervention\Image\Image;
-use \Intervention\Image\Gd\Color;
+use Intervention\Image\Image;
+use Intervention\Image\Gd\Color;
 
 class RectangleShape extends \Intervention\Image\AbstractShape
 {

--- a/src/Intervention/Image/Imagick/Commands/CropCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/CropCommand.php
@@ -2,8 +2,8 @@
 
 namespace Intervention\Image\Imagick\Commands;
 
-use \Intervention\Image\Point;
-use \Intervention\Image\Size;
+use Intervention\Image\Point;
+use Intervention\Image\Size;
 
 class CropCommand extends \Intervention\Image\Commands\AbstractCommand
 {

--- a/src/Intervention/Image/Imagick/Commands/FillCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/FillCommand.php
@@ -2,9 +2,9 @@
 
 namespace Intervention\Image\Imagick\Commands;
 
-use \Intervention\Image\Image;
-use \Intervention\Image\Imagick\Decoder;
-use \Intervention\Image\Imagick\Color;
+use Intervention\Image\Image;
+use Intervention\Image\Imagick\Decoder;
+use Intervention\Image\Imagick\Color;
 
 class FillCommand extends \Intervention\Image\Commands\AbstractCommand
 {

--- a/src/Intervention/Image/Imagick/Commands/FitCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/FitCommand.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Imagick\Commands;
 
-use \Intervention\Image\Size;
+use Intervention\Image\Size;
 
 class FitCommand extends \Intervention\Image\Commands\AbstractCommand
 {

--- a/src/Intervention/Image/Imagick/Commands/GetSizeCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/GetSizeCommand.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Imagick\Commands;
 
-use \Intervention\Image\Size;
+use Intervention\Image\Size;
 
 class GetSizeCommand extends \Intervention\Image\Commands\AbstractCommand
 {

--- a/src/Intervention/Image/Imagick/Commands/PickColorCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/PickColorCommand.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Imagick\Commands;
 
-use \Intervention\Image\Imagick\Color;
+use Intervention\Image\Imagick\Color;
 
 class PickColorCommand extends \Intervention\Image\Commands\AbstractCommand
 {

--- a/src/Intervention/Image/Imagick/Commands/PixelCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/PixelCommand.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Imagick\Commands;
 
-use \Intervention\Image\Imagick\Color;
+use Intervention\Image\Imagick\Color;
 
 class PixelCommand extends \Intervention\Image\Commands\AbstractCommand
 {

--- a/src/Intervention/Image/Imagick/Commands/RotateCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/RotateCommand.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Imagick\Commands;
 
-use \Intervention\Image\Imagick\Color;
+use Intervention\Image\Imagick\Color;
 
 class RotateCommand extends \Intervention\Image\Commands\AbstractCommand
 {

--- a/src/Intervention/Image/Imagick/Commands/TrimCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/TrimCommand.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Imagick\Commands;
 
-use \Intervention\Image\Imagick\Color;
+use Intervention\Image\Imagick\Color;
 
 class TrimCommand extends \Intervention\Image\Commands\AbstractCommand
 {

--- a/src/Intervention/Image/Imagick/Decoder.php
+++ b/src/Intervention/Image/Imagick/Decoder.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Imagick;
 
-use \Intervention\Image\Image;
+use Intervention\Image\Image;
 
 class Decoder extends \Intervention\Image\AbstractDecoder
 {

--- a/src/Intervention/Image/Imagick/Driver.php
+++ b/src/Intervention/Image/Imagick/Driver.php
@@ -2,7 +2,6 @@
 
 namespace Intervention\Image\Imagick;
 
-
 class Driver extends \Intervention\Image\AbstractDriver
 {
     /**

--- a/src/Intervention/Image/Imagick/Font.php
+++ b/src/Intervention/Image/Imagick/Font.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Imagick;
 
-use \Intervention\Image\Image;
+use Intervention\Image\Image;
 
 class Font extends \Intervention\Image\AbstractFont
 {

--- a/src/Intervention/Image/Imagick/Shapes/CircleShape.php
+++ b/src/Intervention/Image/Imagick/Shapes/CircleShape.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Imagick\Shapes;
 
-use \Intervention\Image\Image;
+use Intervention\Image\Image;
 
 class CircleShape extends EllipseShape
 {

--- a/src/Intervention/Image/Imagick/Shapes/EllipseShape.php
+++ b/src/Intervention/Image/Imagick/Shapes/EllipseShape.php
@@ -2,8 +2,8 @@
 
 namespace Intervention\Image\Imagick\Shapes;
 
-use \Intervention\Image\Image;
-use \Intervention\Image\Imagick\Color;
+use Intervention\Image\Image;
+use Intervention\Image\Imagick\Color;
 
 class EllipseShape extends \Intervention\Image\AbstractShape
 {

--- a/src/Intervention/Image/Imagick/Shapes/LineShape.php
+++ b/src/Intervention/Image/Imagick/Shapes/LineShape.php
@@ -2,8 +2,8 @@
 
 namespace Intervention\Image\Imagick\Shapes;
 
-use \Intervention\Image\Image;
-use \Intervention\Image\Imagick\Color;
+use Intervention\Image\Image;
+use Intervention\Image\Imagick\Color;
 
 class LineShape extends \Intervention\Image\AbstractShape
 {

--- a/src/Intervention/Image/Imagick/Shapes/PolygonShape.php
+++ b/src/Intervention/Image/Imagick/Shapes/PolygonShape.php
@@ -2,8 +2,8 @@
 
 namespace Intervention\Image\Imagick\Shapes;
 
-use \Intervention\Image\Image;
-use \Intervention\Image\Imagick\Color;
+use Intervention\Image\Image;
+use Intervention\Image\Imagick\Color;
 
 class PolygonShape extends \Intervention\Image\AbstractShape
 {

--- a/src/Intervention/Image/Imagick/Shapes/RectangleShape.php
+++ b/src/Intervention/Image/Imagick/Shapes/RectangleShape.php
@@ -2,8 +2,8 @@
 
 namespace Intervention\Image\Imagick\Shapes;
 
-use \Intervention\Image\Image;
-use \Intervention\Image\Imagick\Color;
+use Intervention\Image\Image;
+use Intervention\Image\Imagick\Color;
 
 class RectangleShape extends \Intervention\Image\AbstractShape
 {

--- a/src/Intervention/Image/Size.php
+++ b/src/Intervention/Image/Size.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image;
 
-use \Closure;
+use Closure;
 
 class Size
 {

--- a/tests/AbstractDecoderTest.php
+++ b/tests/AbstractDecoderTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 class AbstractDecoderTest extends PHPUnit_Framework_TestCase
 {
     public function tearDown()

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use \Intervention\Image\Response;
+use Intervention\Image\Response;
 
 class ResponseTest extends PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
This PR

* [x] removes leading slashes from imports

:information_desk_person: They aren't needed!