### PR TITLE
Fix: Enable imagick extension on PHP5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get -y --reinstall install imagemagick
   - printf "\n" | pecl install imagick-beta
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.4" ]]; then echo "extension = imagick.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
 
 before_script:
   - composer self-update


### PR DESCRIPTION
This PR

* [x] enables the `imagick` extension on PHP5.4 after installing it

:information_desk_person: Apparently the builds currently fail because installing the extension does not automatically enable it on PHP5.4.

For reference, see 

* https://docs.travis-ci.com/user/languages/php/#Preinstalled-PHP-extensions
* http://stackoverflow.com/a/28686068/1172545