### PR TITLE
Chain Imagick exceptions instead of hiding

### DIFF
--- a/src/Intervention/Image/Imagick/Decoder.php
+++ b/src/Intervention/Image/Imagick/Decoder.php
@@ -23,7 +23,9 @@ class Decoder extends \Intervention\Image\AbstractDecoder
 
         } catch (\ImagickException $e) {
             throw new \Intervention\Image\Exception\NotReadableException(
-                "Unable to read image from path ({$path})."
+                "Unable to read image from path ({$path}).",
+                0,
+                $e
             );
         }
 
@@ -81,7 +83,9 @@ class Decoder extends \Intervention\Image\AbstractDecoder
 
         } catch (\ImagickException $e) {
             throw new \Intervention\Image\Exception\NotReadableException(
-                "Unable to read image from binary data."
+                "Unable to read image from binary data.",
+                0,
+                $e
             );
         }
 


### PR DESCRIPTION
Hi!  :v: Throwing an Exception from a `catch` block hides the original exception message. Sometimes Imagick exceptions contain useful information, like if your installation isn't compiled with PNG support. Changing this to point to the original exception using PHP's Exception chaining could make such problems more clear.

This is the only place where a different exception is thrown from a `catch` block, so I didn't touch anything else :)