### PR TITLE
replace get_class with instanceof for $this->app

### DIFF
--- a/src/Intervention/Image/ImageServiceProvider.php
+++ b/src/Intervention/Image/ImageServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Intervention\Image;
 
-use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 
 class ImageServiceProvider extends ServiceProvider
@@ -61,9 +60,9 @@ class ImageServiceProvider extends ServiceProvider
      */
     private function getProvider()
     {
-        if (get_class($this->app) == 'Laravel\Lumen\Application') {
+        if ($this->app instanceof \Laravel\Lumen\Application) {
             $provider = '\Intervention\Image\ImageServiceProviderLumen';
-        } elseif (version_compare(Application::VERSION, '5.0', '<')) {
+        } elseif (version_compare(\Illuminate\Foundation\Application::VERSION, '5.0', '<')) {
             $provider = '\Intervention\Image\ImageServiceProviderLaravel4';
         } else {
             $provider = '\Intervention\Image\ImageServiceProviderLaravel5';


### PR DESCRIPTION
When using get_class, in Lumen the $this->app could only be an instance of the \Laravel\Lumen\Application and not an instance of a class extending from \Laravel\Lumen\Application. When using the instanceof check people can use a custom application class extending from the main Lumen Application class. To make this work i had to remove the use statements at the top and replace the references in getProvider with the full paths.