### PR TITLE
Changed behaviour of 'isFilePath'

### DIFF
--- a/src/Intervention/Image/AbstractDecoder.php
+++ b/src/Intervention/Image/AbstractDecoder.php
@@ -2,6 +2,8 @@
 
 namespace Intervention\Image;
 
+use Config;
+
 abstract class AbstractDecoder
 {
     /**
@@ -153,7 +155,7 @@ abstract class AbstractDecoder
     public function isFilePath()
     {
         if (is_string($this->data)) {
-            return is_file($this->data);
+            return is_file($this->data) || strtolower(Config::get('image.driver', '')) === 'imagick' && is_file(preg_replace('/\[[0-9]+\]$/', '', $this->data));
         }
 
         return false;

--- a/tests/AbstractDecoderTest.php
+++ b/tests/AbstractDecoderTest.php
@@ -34,8 +34,47 @@ class AbstractDecoderTest extends PHPUnit_Framework_TestCase
 
     public function testIsFilepath()
     {
+        require_once 'Config.mock.php';
+        $mock = $this->getMock('Config', array('get'));
+ 
+        $mock->expects($this->any())
+              ->method('get')
+              ->will($this->returnValue('gd'));
+
+        Config::setStaticExpectations($mock);
+
         $source = $this->getTestDecoder(__DIR__.'/AbstractDecoderTest.php');
         $this->assertTrue($source->isFilepath());
+
+        $source = $this->getTestDecoder(__DIR__.'/AbstractDecoderTest.php[0]');
+        $this->assertfalse($source->isFilepath());
+
+        $source = $this->getTestDecoder(null);
+        $this->assertFalse($source->isFilepath());
+
+        $source = $this->getTestDecoder(array());
+        $this->assertFalse($source->isFilepath());
+
+        $source = $this->getTestDecoder(new stdClass);
+        $this->assertFalse($source->isFilepath());
+    }
+
+    public function testIsFilepathImagick()
+    {
+        require_once 'Config.mock.php';
+        $mock = $this->getMock('Config', array('get'));
+ 
+        $mock->expects($this->any())
+              ->method('get')
+              ->will($this->returnValue('imagick'));
+
+        Config::setStaticExpectations($mock);
+
+        $source = $this->getTestDecoder(__DIR__.'/AbstractDecoderTest.php');
+        $this->assertTrue($source->isFilepath());
+
+        $source = $this->getTestDecoder(__DIR__.'/AbstractDecoderTest.php[0]');
+        $this->asserttrue($source->isFilepath());
 
         $source = $this->getTestDecoder(null);
         $this->assertFalse($source->isFilepath());

--- a/tests/Config.mock.php
+++ b/tests/Config.mock.php
@@ -1,0 +1,7 @@
+<?php
+
+include_once('MockProxy.php');
+
+// Mocked Config class
+class Config extends MockProxy 
+{}

--- a/tests/MockProxy.php
+++ b/tests/MockProxy.php
@@ -1,0 +1,19 @@
+<?php
+
+// Mockproxy which can be used to mock static method calls
+// Taken from: https://www.deanspot.org/alex/2011/10/25/mocking-static-method-calls-phpunit.html
+class MockProxy 
+{
+    private static $mock;
+
+    public static function setStaticExpectations($mock) 
+    {
+        self::$mock = $mock;
+    }
+
+    // Any static calls we get are passed along to self::$mock. public static
+    public static function __callStatic($name, $args) 
+    {
+        return call_user_func_array(array(self::$mock,$name), $args);
+    }
+}


### PR DESCRIPTION
When Imagick is installed and used as the driver it can work with a
pageselect in the imagepath, note that this only works if ghostscript
is installed. But it then allows the library to quickly load a single
page instead of having to load the entire document; therefor
increasing the parsing speed of the document quite dramatically. When
ghostscript is not installed it will not break when imagick is used.

We also added another testcase to make sure this works. To get this
to work we had to mock the 'Config' facade, which has been done using
a mock proxy.