### PR TITLE
Align the behaviour of Imagick crop command with GD

### DIFF
--- a/src/Intervention/Image/Imagick/Commands/CropCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/CropCommand.php
@@ -35,7 +35,7 @@ class CropCommand extends \Intervention\Image\Commands\AbstractCommand
         }
 
         // crop image core
-        $image->getCore()->cropImage($cropped->width, $cropped->height, $position->x, $position->y);
+        $image->getCore()->extentImage($cropped->width, $cropped->height, $position->x, $position->y);
         $image->getCore()->setImagePage(0,0,0,0);
 
         return true;

--- a/tests/CropCommandTest.php
+++ b/tests/CropCommandTest.php
@@ -24,7 +24,7 @@ class CropCommandTest extends PHPUnit_Framework_TestCase
     public function testImagick()
     {
         $imagick = Mockery::mock('Imagick');
-        $imagick->shouldReceive('extentImage')->with(100, 150, 10, 20)->andReturn(true);
+        $imagick->shouldReceive('extentimage')->with(100, 150, 10, 20)->andReturn(true);
         $imagick->shouldReceive('setimagepage')->with(0, 0, 0, 0)->once();
         $image = Mockery::mock('Intervention\Image\Image');
         $image->shouldReceive('getCore')->times(2)->andReturn($imagick);

--- a/tests/CropCommandTest.php
+++ b/tests/CropCommandTest.php
@@ -9,7 +9,7 @@ class CropCommandTest extends PHPUnit_Framework_TestCase
     {
         Mockery::close();
     }
-    
+
     public function testGd()
     {
         $resource = imagecreatefromjpeg(__DIR__.'/images/test.jpg');
@@ -24,7 +24,7 @@ class CropCommandTest extends PHPUnit_Framework_TestCase
     public function testImagick()
     {
         $imagick = Mockery::mock('Imagick');
-        $imagick->shouldReceive('cropimage')->with(100, 150, 10, 20)->andReturn(true);
+        $imagick->shouldReceive('extentImage')->with(100, 150, 10, 20)->andReturn(true);
         $imagick->shouldReceive('setimagepage')->with(0, 0, 0, 0)->once();
         $image = Mockery::mock('Intervention\Image\Image');
         $image->shouldReceive('getCore')->times(2)->andReturn($imagick);


### PR DESCRIPTION
The GD crop command creates a new canvas for when cropping. The upshot is that if you pass the start position -x, the image starts at x on the new canvas. ImageMagick does not have this behaviour in crop, which starts strictly at 0,0. extentImage however will duplicate the behaviour of the crop command in the GD driver, meaning both now perform exactly the same with negative input values.