### PR TITLE
Use static in drivers newImage()

### DIFF
--- a/src/Intervention/Image/Gd/Driver.php
+++ b/src/Intervention/Image/Gd/Driver.php
@@ -34,7 +34,7 @@ class Driver extends \Intervention\Image\AbstractDriver
     {
         // create empty resource
         $core = imagecreatetruecolor($width, $height);
-        $image = new \Intervention\Image\Image(new self, $core);
+        $image = new \Intervention\Image\Image(new static, $core);
 
         // set background color
         $background = new Color($background);

--- a/src/Intervention/Image/Imagick/Driver.php
+++ b/src/Intervention/Image/Imagick/Driver.php
@@ -42,7 +42,7 @@ class Driver extends \Intervention\Image\AbstractDriver
         $core->setColorspace(\Imagick::COLORSPACE_UNDEFINED);
 
         // build image
-        $image = new \Intervention\Image\Image(new self, $core);
+        $image = new \Intervention\Image\Image(new static, $core);
 
         return $image;
     }


### PR DESCRIPTION
Helpful when using a custom driver which extends a base driver.