### PR TITLE
Added variables to the template classes in the config file

### DIFF
--- a/src/Intervention/Image/Filters/DemoFilter.php
+++ b/src/Intervention/Image/Filters/DemoFilter.php
@@ -32,7 +32,7 @@ class DemoFilter implements FilterInterface
      * @param  \Intervention\Image\Image $image
      * @return \Intervention\Image\Image
      */
-    public function applyFilter(\Intervention\Image\Image $image)
+    public function applyFilter(\Intervention\Image\Image $image, $args = array())
     {
         $image->pixelate($this->size);
         $image->greyscale();

--- a/src/Intervention/Image/Filters/FilterInterface.php
+++ b/src/Intervention/Image/Filters/FilterInterface.php
@@ -10,5 +10,5 @@ interface FilterInterface
      * @param  \Intervention\Image\Image $image
      * @return \Intervention\Image\Image
      */
-    public function applyFilter(\Intervention\Image\Image $image);
+    public function applyFilter(\Intervention\Image\Image $image, $args=array());
 }

--- a/src/Intervention/Image/Image.php
+++ b/src/Intervention/Image/Image.php
@@ -157,9 +157,9 @@ class Image extends File
      * @param  FiltersFilterInterface $filter
      * @return \Intervention\Image\Image
      */
-    public function filter(Filters\FilterInterface $filter)
+    public function filter(Filters\FilterInterface $filter, $args=array())
     {
-        return $filter->applyFilter($this);
+        return $filter->applyFilter($this, $args);
     }
 
     /**

--- a/src/Intervention/Image/ImageServiceProviderLaravel5.php
+++ b/src/Intervention/Image/ImageServiceProviderLaravel5.php
@@ -79,11 +79,21 @@ class ImageServiceProviderLaravel5 extends ServiceProvider
 
             $filename_pattern = '[ \w\\.\\/\\-\\@]+';
 
-            // route to access template applied image file
-            $app['router']->get(config('imagecache.route').'/{template}/{filename}', array(
-                'uses' => 'Intervention\Image\ImageCacheController@getResponse',
-                'as' => 'imagecache'
-            ))->where(array('filename' => $filename_pattern));
+            foreach (config('imagecache.templates') as $key => $value) {
+                $url = config('imagecache.route').'/'.$key.'/{filename}';
+                $options = array(
+                    'uses' => 'Intervention\Image\ImageCacheController@getResponse',
+                    'as' => 'imagecache',
+                );
+
+                if(isset($value['middleware'])){
+                    $options['middleware'] = $value['middleware'];
+                }
+
+                // route to access template applied image file
+                $app['router']->get($url, $options)->where(array('filename' => $filename_pattern));
+            }
+
         }
     }
 }


### PR DESCRIPTION
Hi,

I'm using this package together with the imagecache package.

After a few projects I noticed that I'm actually using one particular (custom) template over and over again, but the only differences are the image sizes.

I made a couple of changes in the imagecache packages (see pull request) to add arguments in the template definition.

``` php
'templates' => array(
    'small'     => 'Intervention\Image\Templates\Small',
    'medium'    => ['class'=>'Intervention\Image\Templates\Medium'],
    'large'     => ['class'=>'Intervention\Image\Templates\large', 'args'=>['w'=>200,'h'=>200]],
)
```

In this package I had to add the $args variable to the applyFilter function. The only drawback is that this update may break the custom filters because the FilterInterface.php has been modified...
