### PR TITLE
498_fix_text_top_vertical_position_multiline_imagick

### DIFF
--- a/src/Intervention/Image/Imagick/Font.php
+++ b/src/Intervention/Image/Imagick/Font.php
@@ -56,17 +56,18 @@ class Font extends \Intervention\Image\AbstractFont
         // align vertical
         if (strtolower($this->valign) != 'bottom') {
 
-            // calculate box size
-            $dimensions = $image->getCore()->queryFontMetrics($draw, $this->text);
-
             // corrections on y-position
             switch (strtolower($this->valign)) {
                 case 'center':
                 case 'middle':
+                // calculate box size
+                $dimensions = $image->getCore()->queryFontMetrics($draw, $this->text);
                 $posy = $posy + $dimensions['textHeight'] * 0.65 / 2;
                 break;
 
                 case 'top':
+                // calculate box size
+                $dimensions = $image->getCore()->queryFontMetrics($draw, $this->text, false);
                 $posy = $posy + $dimensions['textHeight'] * 0.65;
                 break;
             }


### PR DESCRIPTION
I had the same issue as described here: #498
The attached changes resolved it.

More details:

When using "$font->valign('top');" position of wrapped text (>1 lines) is broken. It is well described in the issue itself.
Solution is connected only with Imagick driver and it is about counting $dimentions connected with one line only by setting multiline param as false.

http://php.net/manual/en/imagick.queryfontmetrics.php
