### PR TITLE
Use \Illuminate\Support\Facades\Response instead of the \Response alias

### DIFF
--- a/src/Intervention/Image/Response.php
+++ b/src/Intervention/Image/Response.php
@@ -53,7 +53,7 @@ class Response
 
         if (function_exists('app') && is_a($app = app(), 'Illuminate\Foundation\Application')) {
 
-            $response = \Response::make($data);
+            $response = \Illuminate\Support\Facades\Response::make($data);
             $response->header('Content-Type', $mime);
             $response->header('Content-Length', $length);
 


### PR DESCRIPTION
Using the full name avoids problems where the user has commented out the Laravel aliases or has aliased "Response" to something else.

I, for one, don't use Laravel's aliases and have commented them out. But this library currently expects the alias to be there.