### PR TITLE
Feature to add text stroke

### DIFF
--- a/src/Intervention/Image/AbstractFont.php
+++ b/src/Intervention/Image/AbstractFont.php
@@ -54,6 +54,20 @@ abstract class AbstractFont
     public $file;
 
     /**
+     * Color of the text stroke
+     *
+     * @var mixed
+     */
+    public $strokeColor = '000000';
+
+    /**
+     * Width of the stroke
+     *
+     * @var float
+     */
+    public $strokeWidth = 0;
+
+    /**
      * Draws font to given image on given position
      *
      * @param  Image   $image
@@ -66,7 +80,7 @@ abstract class AbstractFont
     /**
      * Create a new instance of Font
      *
-     * @param Strinf $text Text to be written
+     * @param string $text Text to be written
      */
     public function __construct($text = null)
     {
@@ -218,6 +232,48 @@ abstract class AbstractFont
     public function getFile()
     {
         return $this->file;
+    }
+
+    /**
+     * Set stroke width in pixels
+     *
+     * @param  float $width
+     * @return void
+     */
+    public function strokeWidth($width)
+    {
+        $this->strokeWidth = $width;
+    }
+
+    /**
+     * Get stroke width in pixels
+     *
+     * @return float
+     */
+    public function getStrokeWidth()
+    {
+        return $this->strokeWidth;
+    }
+
+    /**
+     * Set stroke color of text to be written
+     *
+     * @param  mixed $color
+     * @return void
+     */
+    public function strokeColor($color)
+    {
+        $this->strokeColor = $color;
+    }
+
+    /**
+     * Get stroke color of text
+     *
+     * @return mixed
+     */
+    public function getStrokeColor()
+    {
+        return $this->strokeColor;
     }
 
     /**

--- a/src/Intervention/Image/AbstractFont.php
+++ b/src/Intervention/Image/AbstractFont.php
@@ -309,7 +309,7 @@ abstract class AbstractFont
     {
         for ($offsetX = $posX - $this->strokeWidth; $offsetX <= $posX + $this->strokeWidth; $offsetX++) {
             for ($offsetY = $posY - $this->strokeWidth; $offsetY <= $posY + $this->strokeWidth; $offsetY++) {
-                call_user_func($function, [$offsetX, $offsetY]);
+                call_user_func($function, $offsetX, $offsetY);
             }
         }
     }

--- a/src/Intervention/Image/AbstractFont.php
+++ b/src/Intervention/Image/AbstractFont.php
@@ -58,7 +58,7 @@ abstract class AbstractFont
      *
      * @var mixed
      */
-    public $strokeColor = '000000';
+    public $strokeColor = 'FFFFFF';
 
     /**
      * Width of the stroke

--- a/src/Intervention/Image/AbstractFont.php
+++ b/src/Intervention/Image/AbstractFont.php
@@ -277,6 +277,16 @@ abstract class AbstractFont
     }
 
     /**
+     * Counts lines of text to be written
+     *
+     * @return integer
+     */
+    public function countLines()
+    {
+        return count(explode(PHP_EOL, $this->text));
+    }
+
+    /**
      * Checks if current font has access to an applicable font file
      *
      * @return boolean
@@ -291,12 +301,16 @@ abstract class AbstractFont
     }
 
     /**
-     * Counts lines of text to be written
-     *
-     * @return integer
+     * @param integer  $posX
+     * @param integer  $posY
+     * @param callable $function
      */
-    public function countLines()
+    protected function strokeDrawLoop($posX, $posY, callable $function)
     {
-        return count(explode(PHP_EOL, $this->text));
+        for ($offsetX = $posX - $this->strokeWidth; $offsetX <= $posX + $this->strokeWidth; $offsetX++) {
+            for ($offsetY = $posY - $this->strokeWidth; $offsetY <= $posY + $this->strokeWidth; $offsetY++) {
+                call_user_func($function, [$offsetX, $offsetY]);
+            }
+        }
     }
 }

--- a/src/Intervention/Image/Gd/Font.php
+++ b/src/Intervention/Image/Gd/Font.php
@@ -2,9 +2,11 @@
 
 namespace Intervention\Image\Gd;
 
+use Intervention\Image\AbstractFont;
+use Intervention\Image\Exception\NotSupportedException;
 use Intervention\Image\Image;
 
-class Font extends \Intervention\Image\AbstractFont
+class Font extends AbstractFont
 {
     /**
      * Get font size in points
@@ -26,8 +28,8 @@ class Font extends \Intervention\Image\AbstractFont
         $internalfont = is_null($this->file) ? 1 : $this->file;
         $internalfont = is_numeric($internalfont) ? $internalfont : false;
 
-        if ( ! in_array($internalfont, array(1, 2, 3, 4, 5))) {
-            throw new \Intervention\Image\Exception\NotSupportedException(
+        if (!in_array($internalfont, [1, 2, 3, 4, 5])) {
+            throw new NotSupportedException(
                 sprintf('Internal GD font (%s) not available. Use only 1-5.', $internalfont)
             );
         }
@@ -73,7 +75,7 @@ class Font extends \Intervention\Image\AbstractFont
     /**
      * Calculates bounding box of current font setting
      *
-     * @return Array
+     * @return array
      */
     public function getBoxSize()
     {
@@ -248,8 +250,18 @@ class Font extends \Intervention\Image\AbstractFont
                     break;
             }
 
+            $font = $this->getInternalFont();
+            if ($this->strokeWidth > 0) {
+                $strokeColor = new Color($this->strokeColor);
+                for($c1 = ($posx - $this->strokeWidth); $c1 <= ($posy + $this->strokeWidth); $c1++) {
+                    for ($c2 = ($posy - $this->strokeWidth); $c2 <= ($posy + $this->strokeWidth); $c2++) {
+                        imagestring($image->getCore(), $font, $c1, $c2, $this->text, $strokeColor->getInt());
+                    }
+                }
+            }
+
             // draw text
-            imagestring($image->getCore(), $this->getInternalFont(), $posx, $posy, $this->text, $color->getInt());
+            imagestring($image->getCore(), $font, $posx, $posy, $this->text, $color->getInt());
         }
     }
 }

--- a/src/Intervention/Image/Gd/Font.php
+++ b/src/Intervention/Image/Gd/Font.php
@@ -136,9 +136,7 @@ class Font extends AbstractFont
         $color = new Color($this->color);
 
         if ($this->hasApplicableFontFile()) {
-
             if ($this->angle != 0 || is_string($this->align) || is_string($this->valign)) {
-
                 $box = $this->getBoxSize();
 
                 $align = is_null($this->align) ? 'left' : strtolower($this->align);
@@ -200,11 +198,36 @@ class Font extends AbstractFont
             // enable alphablending for imagettftext
             imagealphablending($image->getCore(), true);
 
+            if ($this->strokeWidth > 0) {
+                $strokeColor = new Color($this->strokeColor);
+                for ($c1 = ($posx - $this->strokeWidth); $c1 <= ($posx + $this->strokeWidth); $c1++) {
+                    for ($c2 = ($posy - $this->strokeWidth); $c2 <= ($posy + $this->strokeWidth); $c2++) {
+                        imagettftext(
+                            $image->getCore(),
+                            $this->getPointSize(),
+                            $this->angle,
+                            $c1,
+                            $c2,
+                            $strokeColor->getInt(),
+                            $this->file,
+                            $this->text
+                        );
+                    }
+                }
+            }
+
             // draw ttf text
-            imagettftext($image->getCore(), $this->getPointSize(), $this->angle, $posx, $posy, $color->getInt(), $this->file, $this->text);
-
+            imagettftext(
+                $image->getCore(),
+                $this->getPointSize(),
+                $this->angle,
+                $posx,
+                $posy,
+                $color->getInt(),
+                $this->file,
+                $this->text
+            );
         } else {
-
             // get box size
             $box = $this->getBoxSize();
             $width = $box['width'];
@@ -253,7 +276,7 @@ class Font extends AbstractFont
             $font = $this->getInternalFont();
             if ($this->strokeWidth > 0) {
                 $strokeColor = new Color($this->strokeColor);
-                for($c1 = ($posx - $this->strokeWidth); $c1 <= ($posy + $this->strokeWidth); $c1++) {
+                for ($c1 = ($posx - $this->strokeWidth); $c1 <= ($posx + $this->strokeWidth); $c1++) {
                     for ($c2 = ($posy - $this->strokeWidth); $c2 <= ($posy + $this->strokeWidth); $c2++) {
                         imagestring($image->getCore(), $font, $c1, $c2, $this->text, $strokeColor->getInt());
                     }

--- a/src/Intervention/Image/Gd/Font.php
+++ b/src/Intervention/Image/Gd/Font.php
@@ -200,20 +200,18 @@ class Font extends AbstractFont
 
             if ($this->strokeWidth > 0) {
                 $strokeColor = new Color($this->strokeColor);
-                for ($c1 = ($posx - $this->strokeWidth); $c1 <= ($posx + $this->strokeWidth); $c1++) {
-                    for ($c2 = ($posy - $this->strokeWidth); $c2 <= ($posy + $this->strokeWidth); $c2++) {
-                        imagettftext(
-                            $image->getCore(),
-                            $this->getPointSize(),
-                            $this->angle,
-                            $c1,
-                            $c2,
-                            $strokeColor->getInt(),
-                            $this->file,
-                            $this->text
-                        );
-                    }
-                }
+                $this->strokeDrawLoop($posx, $posy, function($posX, $posY) use ($image, $strokeColor) {
+                    imagettftext(
+                        $image->getCore(),
+                        $this->getPointSize(),
+                        $this->angle,
+                        $posX,
+                        $posY,
+                        $strokeColor->getInt(),
+                        $this->file,
+                        $this->text
+                    );
+                });
             }
 
             // draw ttf text
@@ -276,11 +274,9 @@ class Font extends AbstractFont
             $font = $this->getInternalFont();
             if ($this->strokeWidth > 0) {
                 $strokeColor = new Color($this->strokeColor);
-                for ($c1 = ($posx - $this->strokeWidth); $c1 <= ($posx + $this->strokeWidth); $c1++) {
-                    for ($c2 = ($posy - $this->strokeWidth); $c2 <= ($posy + $this->strokeWidth); $c2++) {
-                        imagestring($image->getCore(), $font, $c1, $c2, $this->text, $strokeColor->getInt());
-                    }
-                }
+                $this->strokeDrawLoop($posx, $posy, function($posX, $posY) use ($image, $font, $strokeColor) {
+                    imagestring($image->getCore(), $font, $posX, $posY, $this->text, $strokeColor->getInt());
+                });
             }
 
             // draw text

--- a/src/Intervention/Image/Imagick/Font.php
+++ b/src/Intervention/Image/Imagick/Font.php
@@ -84,11 +84,9 @@ class Font extends AbstractFont
             } else {
                 $originalFillColor = $draw->getFillColor();
                 $draw->setFillColor($strokeColor->getPixel());
-                for ($c1 = ($posx - $this->strokeWidth); $c1 <= ($posx + $this->strokeWidth); $c1++) {
-                    for ($c2 = ($posy - $this->strokeWidth); $c2 <= ($posy + $this->strokeWidth); $c2++) {
-                        $image->getCore()->annotateImage($draw, $c1, $c2, $this->angle * (-1), $this->text);
-                    }
-                }
+                $this->strokeDrawLoop($posx, $posy, function($posX, $posY) use ($image, $draw) {
+                    $image->getCore()->annotateImage($draw, $posX, $posY, $this->angle * (-1), $this->text);
+                });
 
                 $draw->setFillColor($originalFillColor);
             }

--- a/src/Intervention/Image/Imagick/Font.php
+++ b/src/Intervention/Image/Imagick/Font.php
@@ -2,9 +2,11 @@
 
 namespace Intervention\Image\Imagick;
 
+use Intervention\Image\AbstractFont;
+use Intervention\Image\Exception\RuntimeException;
 use Intervention\Image\Image;
 
-class Font extends \Intervention\Image\AbstractFont
+class Font extends AbstractFont
 {
     /**
      * Draws font to given image at given position
@@ -21,11 +23,17 @@ class Font extends \Intervention\Image\AbstractFont
         $draw->setStrokeAntialias(true);
         $draw->setTextAntialias(true);
 
+        if ($this->strokeWidth > 0) {
+            $strokeColor = new Color($this->strokeColor);
+            $draw->setStrokeWidth($this->strokeWidth);
+            $draw->setStrokeColor($strokeColor->getPixel());
+        }
+
         // set font file
         if ($this->hasApplicableFontFile()) {
             $draw->setFont($this->file);
         } else {
-            throw new \Intervention\Image\Exception\RuntimeException(
+            throw new RuntimeException(
                 "Font file must be provided to apply text to image."
             );
         }

--- a/src/Intervention/Image/Imagick/Font.php
+++ b/src/Intervention/Image/Imagick/Font.php
@@ -8,7 +8,7 @@ use Intervention\Image\Image;
 
 class Font extends AbstractFont
 {
-    public $isUseInternalImagickStroke = false;
+    public $isUseBuiltInImagickStroke = false;
 
     /**
      * Draws font to given image at given position
@@ -78,7 +78,7 @@ class Font extends AbstractFont
 
         if ($this->strokeWidth > 0) {
             $strokeColor = new Color($this->strokeColor);
-            if ($this->isUseInternalImagickStroke) {
+            if ($this->isUseBuiltInImagickStroke) {
                 $draw->setStrokeWidth($this->strokeWidth);
                 $draw->setStrokeColor($strokeColor->getPixel());
             } else {
@@ -101,8 +101,8 @@ class Font extends AbstractFont
      *
      * @return void
      */
-    public function drawStrokeByInternalMethod()
+    public function drawStrokeByBuiltInMethods()
     {
-        $this->isUseInternalImagickStroke = true;
+        $this->isUseBuiltInImagickStroke = true;
     }
 }

--- a/tests/AbstractFontTest.php
+++ b/tests/AbstractFontTest.php
@@ -62,6 +62,22 @@ class AbstractFontTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('test.ttf', $font->file);
     }
 
+    public function testStrokeWidth()
+    {
+        /** @var \Intervention\Image\AbstractFont|\PHPUnit_Framework_MockObject_MockObject $font */
+        $font = $this->getMockForAbstractClass('\Intervention\Image\AbstractFont');
+        $font->strokeWidth(2);
+        $this->assertEquals(2, $font->strokeWidth);
+    }
+
+    public function testStrokeColor()
+    {
+        /** @var \Intervention\Image\AbstractFont|\PHPUnit_Framework_MockObject_MockObject $font */
+        $font = $this->getMockForAbstractClass('\Intervention\Image\AbstractFont');
+        $font->strokeColor('#FFFFFF');
+        $this->assertEquals('#FFFFFF', $font->strokeColor);
+    }
+
     public function testCountLines()
     {
         $font = $this->getMockForAbstractClass('\Intervention\Image\AbstractFont');


### PR DESCRIPTION
This feature allows you to draw text on image with stroke. Work in GD and Imagick ([this PR work only with Imagick and do this badly](https://github.com/Intervention/image/pull/289).

Usage:

``` php
$image->text('My string', $posX, $posY, function(AbstractFont $font) {
    $font->file(__DIR__ . '/RobotoCondensed-Regular.ttf');
    $font->size(24);
    $font->strokeWidth(2);
});
```

**Note:** Imagick has built in functions `setStrokeWidth()` and `setStrokeColor()`, but they draw stroke not the way you'd expect. So in both cases (Imagick and GD) stroke drawing by loop, that extracted into `AbstractFont` class. If you want to use Imagick built-in functions, you may switch to it:

``` php
$image->text('My string', $posX, $posY, function(\Intervention\Image\Imagick\Font $font) {
    $font->file(__DIR__ . '/RobotoCondensed-Regular.ttf');
    $font->size(24);
    $font->strokeWidth(2);
    $font->drawStrokeByBuiltInMethods();
});
```
