### PR TITLE
Add support for text kerning (ImageMagick only)

### DIFF
--- a/src/Intervention/Image/AbstractFont.php
+++ b/src/Intervention/Image/AbstractFont.php
@@ -47,6 +47,13 @@ abstract class AbstractFont
     public $valign;
 
     /**
+     * Space between text characters
+     *
+     * @var float
+     */
+    public $kerning = 0;
+
+    /**
      * Path to TTF or GD library internal font file of the text
      *
      * @var mixed
@@ -197,6 +204,27 @@ abstract class AbstractFont
     public function getValign()
     {
         return $this->valign;
+    }
+
+    /**
+     * Set text kerning
+     *
+     * @param  string $kerning
+     * @return void
+     */
+    public function kerning($kerning)
+    {
+        $this->kerning = $kerning;
+    }
+
+    /**
+     * Get kerning
+     *
+     * @return float
+     */
+    public function getKerning()
+    {
+        return $this->kerning;
     }
 
     /**

--- a/src/Intervention/Image/Gd/Font.php
+++ b/src/Intervention/Image/Gd/Font.php
@@ -252,4 +252,18 @@ class Font extends \Intervention\Image\AbstractFont
             imagestring($image->getCore(), $this->getInternalFont(), $posx, $posy, $this->text, $color->getInt());
         }
     }
+
+    /**
+     * Set text kerning
+     *
+     * @param  string $kerning
+     * @return void
+     */
+    public function kerning($kerning)
+    {
+        throw new \Intervention\Image\Exception\NotSupportedException(
+            "Kerning is not supported by GD driver."
+        );
+    }
+
 }

--- a/src/Intervention/Image/Imagick/Font.php
+++ b/src/Intervention/Image/Imagick/Font.php
@@ -35,6 +35,7 @@ class Font extends \Intervention\Image\AbstractFont
 
         $draw->setFontSize($this->size);
         $draw->setFillColor($color->getPixel());
+        $draw->setTextKerning($this->kerning);
 
         // align horizontal
         switch (strtolower($this->align)) {

--- a/tests/AbstractFontTest.php
+++ b/tests/AbstractFontTest.php
@@ -12,7 +12,7 @@ class AbstractFontTest extends PHPUnit_Framework_TestCase
         $font = $this->getMockForAbstractClass('\Intervention\Image\AbstractFont', array('test'));
         $this->assertEquals('test', $font->text);
     }
-    
+
     public function testText()
     {
         $font = $this->getMockForAbstractClass('\Intervention\Image\AbstractFont');
@@ -55,6 +55,13 @@ class AbstractFontTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('top', $font->valign);
     }
 
+    public function testKerning()
+    {
+        $font = $this->getMockForAbstractClass('\Intervention\Image\AbstractFont');
+        $font->kerning(10.5);
+        $this->assertEquals(10.5, $font->kerning);
+    }
+
     public function testFile()
     {
         $font = $this->getMockForAbstractClass('\Intervention\Image\AbstractFont');
@@ -66,7 +73,7 @@ class AbstractFontTest extends PHPUnit_Framework_TestCase
     {
         $font = $this->getMockForAbstractClass('\Intervention\Image\AbstractFont');
         $font->text('foo'.PHP_EOL.'bar'.PHP_EOL.'baz');
-        $this->assertEquals(3, $font->countLines());   
+        $this->assertEquals(3, $font->countLines());
         $font->text("foo\nbar\nbaz");
         $this->assertEquals(3, $font->countLines());
         $font->text('foo


### PR DESCRIPTION
This is sort of in reference to issue #619.

It doesn't appear that GD supports this sort of simple implementation out of the box, although it could be done with a more complicated algorithm if needed.
