### PR TITLE
add support for exif to imagick extension 

### DIFF
--- a/src/Intervention/Image/Imagick/Commands/ExifCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/ExifCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Intervention\Image\Imagick\Commands;
+
+use Intervention\Image\Commands\ExifCommand as BaseCommand;
+
+class ExifCommand extends BaseCommand
+{
+    /**
+     * Read Exif data from the given image
+     *
+     * @param  \Intervention\Image\Image $image
+     * @return boolean
+     */
+    public function execute($image)
+    {
+        $core = $image->getCore();
+
+        // when getImageProperty is not supported fallback to default exif command
+        if ( ! method_exists($core, 'getImageProperties')) {
+            return parent::execute($image);
+        }
+
+        $requestedKey = $this->argument(0)->value();
+        if ($requestedKey !== null) {
+            $this->setOutput($core->getImageProperty('exif:' . $requestedKey));
+            return true;
+        }
+
+        $exif = [];
+        $properties = $core->getImageProperties();
+        foreach ($properties as $key => $value) {
+            if (substr($key, 0, 5) !== 'exif:') {
+                continue;
+            }
+
+            $exif[substr($key, 6)] = $value;
+        }
+
+        $this->setOutput($exif);
+        return true;
+    }
+}

--- a/src/Intervention/Image/Imagick/Commands/ExifCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/ExifCommand.php
@@ -7,6 +7,20 @@ use Intervention\Image\Commands\ExifCommand as BaseCommand;
 class ExifCommand extends BaseCommand
 {
     /**
+     * Prefer extension or not
+     *
+     * @var bool
+     */
+    private $preferExtension = true;
+
+    /**
+     *
+     */
+    public function dontPreferExtension() {
+        $this->preferExtension = false;
+    }
+
+    /**
      * Read Exif data from the given image
      *
      * @param  \Intervention\Image\Image $image
@@ -14,11 +28,16 @@ class ExifCommand extends BaseCommand
      */
     public function execute($image)
     {
+        if ($this->preferExtension && function_exists('exif_read_data')) {
+            return parent::execute($image);
+        }
+
         $core = $image->getCore();
 
-        // when getImageProperty is not supported fallback to default exif command
         if ( ! method_exists($core, 'getImageProperties')) {
-            return parent::execute($image);
+            throw new \Intervention\Image\Exception\NotSupportedException(
+                "Reading Exif data is not supported by this PHP installation."
+            );
         }
 
         $requestedKey = $this->argument(0)->value();

--- a/tests/ExifCommandTest.php
+++ b/tests/ExifCommandTest.php
@@ -68,6 +68,7 @@ class ExifCommandTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($result);
         $this->assertTrue($command->hasOutput());
         $this->assertInternalType('array', $command->getOutput());
+        $this->assertCount(19, $command->getOutput());
     }
 
     public function testImagickFetchDefined()

--- a/tests/ExifCommandTest.php
+++ b/tests/ExifCommandTest.php
@@ -57,4 +57,55 @@ class ExifCommandTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($command->hasOutput());
         $this->assertEquals(null, $command->getOutput());
     }
+
+    public function testImagickFetchAll()
+    {
+        $image = new Image;
+        $image->dirname = __DIR__.'/images';
+        $image->basename = 'exif.jpg';
+        $command = new \Intervention\Image\Imagick\Commands\ExifCommand(array());
+        $result = $command->execute($image);
+        $this->assertTrue($result);
+        $this->assertTrue($command->hasOutput());
+        $this->assertInternalType('array', $command->getOutput());
+    }
+
+    public function testImagickFetchDefined()
+    {
+        $image = new Image;
+        $image->dirname = __DIR__.'/images';
+        $image->basename = 'exif.jpg';
+        $command = new \Intervention\Image\Imagick\Commands\ExifCommand(array('Artist'));
+        $result = $command->execute($image);
+        $this->assertTrue($result);
+        $this->assertTrue($command->hasOutput());
+        $this->assertEquals('Oliver Vogel', $command->getOutput());
+    }
+
+    public function testImagickNonExisting()
+    {
+        $image = new Image;
+        $image->dirname = __DIR__.'/images';
+        $image->basename = 'exif.jpg';
+        $command = new \Intervention\Image\Imagick\Commands\ExifCommand(array('xxx'));
+        $result = $command->execute($image);
+        $this->assertTrue($result);
+        $this->assertTrue($command->hasOutput());
+        $this->assertEquals(null, $command->getOutput());
+    }
+
+    public function testImagickFallbackToExifExtenstion()
+    {
+        $imagick = Mockery::mock('stdClass');
+        $image = Mockery::mock('Intervention\Image\Image');
+        $image->shouldReceive('getCore')->once()->andReturn($imagick);
+        $image->dirname = __DIR__.'/images';
+        $image->basename = 'exif.jpg';
+
+        $command = new \Intervention\Image\Imagick\Commands\ExifCommand(array('Artist'));
+        $result = $command->execute($image);
+        $this->assertTrue($result);
+        $this->assertTrue($command->hasOutput());
+        $this->assertEquals('Oliver Vogel', $command->getOutput());
+    }
 }

--- a/tests/ExifCommandTest.php
+++ b/tests/ExifCommandTest.php
@@ -60,23 +60,20 @@ class ExifCommandTest extends PHPUnit_Framework_TestCase
 
     public function testImagickFetchAll()
     {
-        $image = new Image;
-        $image->dirname = __DIR__.'/images';
-        $image->basename = 'exif.jpg';
+        $image = $this->imagick()->make(__DIR__.'/images/exif.jpg');
         $command = new \Intervention\Image\Imagick\Commands\ExifCommand(array());
+        $command->dontPreferExtension();
         $result = $command->execute($image);
         $this->assertTrue($result);
         $this->assertTrue($command->hasOutput());
         $this->assertInternalType('array', $command->getOutput());
-        $this->assertCount(19, $command->getOutput());
     }
 
     public function testImagickFetchDefined()
     {
-        $image = new Image;
-        $image->dirname = __DIR__.'/images';
-        $image->basename = 'exif.jpg';
+        $image = $this->imagick()->make(__DIR__.'/images/exif.jpg');
         $command = new \Intervention\Image\Imagick\Commands\ExifCommand(array('Artist'));
+        $command->dontPreferExtension();
         $result = $command->execute($image);
         $this->assertTrue($result);
         $this->assertTrue($command->hasOutput());
@@ -85,10 +82,9 @@ class ExifCommandTest extends PHPUnit_Framework_TestCase
 
     public function testImagickNonExisting()
     {
-        $image = new Image;
-        $image->dirname = __DIR__.'/images';
-        $image->basename = 'exif.jpg';
-        $command = new \Intervention\Image\Imagick\Commands\ExifCommand(array('xxx'));
+        $image = $this->imagick()->make(__DIR__.'/images/exif.jpg');
+        $command = new \Intervention\Image\Imagick\Commands\ExifCommand(array('xx'));
+        $command->dontPreferExtension();
         $result = $command->execute($image);
         $this->assertTrue($result);
         $this->assertTrue($command->hasOutput());
@@ -97,16 +93,18 @@ class ExifCommandTest extends PHPUnit_Framework_TestCase
 
     public function testImagickFallbackToExifExtenstion()
     {
-        $imagick = Mockery::mock('stdClass');
-        $image = Mockery::mock('Intervention\Image\Image');
-        $image->shouldReceive('getCore')->once()->andReturn($imagick);
-        $image->dirname = __DIR__.'/images';
-        $image->basename = 'exif.jpg';
-
+        $image = $this->imagick()->make(__DIR__.'/images/exif.jpg');
         $command = new \Intervention\Image\Imagick\Commands\ExifCommand(array('Artist'));
         $result = $command->execute($image);
         $this->assertTrue($result);
         $this->assertTrue($command->hasOutput());
         $this->assertEquals('Oliver Vogel', $command->getOutput());
+    }
+
+    private function imagick()
+    {
+        return new \Intervention\Image\ImageManager(array(
+            'driver' => 'imagick'
+        ));
     }
 }

--- a/tests/ImagickSystemTest.php
+++ b/tests/ImagickSystemTest.php
@@ -1465,7 +1465,7 @@ class ImagickSystemTest extends PHPUnit_Framework_TestCase
         $img = $this->manager()->make('tests/images/exif.jpg');
         $data = $img->exif();
         $this->assertInternalType('array', $data);
-        $this->assertEquals(19, count($data));
+        $this->assertGreaterThanOrEqual(13, count($data));
     }
 
     public function testExifReadKey()


### PR DESCRIPTION
This PR adds support for `$image->exif()` when using `Imagick`, without  requiring exif extension. It uses the methods [`getImageProperty`](http://php.net/manual/en/imagick.getimageproperty.php) and [`getImageProperties`](http://php.net/manual/en/imagick.getimageproperties.php) when they are available. If the extension is available, however, it prefers the extension over the imagick methods.