### PR TITLE
Make AbstractFont a fluent interface

### DIFF
--- a/src/Intervention/Image/AbstractFont.php
+++ b/src/Intervention/Image/AbstractFont.php
@@ -82,6 +82,8 @@ abstract class AbstractFont
     public function text($text)
     {
         $this->text = $text;
+
+        return $this;
     }
 
     /**
@@ -103,6 +105,8 @@ abstract class AbstractFont
     public function size($size)
     {
         $this->size = $size;
+
+        return $this;
     }
 
     /**
@@ -124,6 +128,8 @@ abstract class AbstractFont
     public function color($color)
     {
         $this->color = $color;
+
+        return $this;
     }
 
     /**
@@ -145,6 +151,8 @@ abstract class AbstractFont
     public function angle($angle)
     {
         $this->angle = $angle;
+
+        return $this;
     }
 
     /**
@@ -166,6 +174,8 @@ abstract class AbstractFont
     public function align($align)
     {
         $this->align = $align;
+
+        return $this;
     }
 
     /**
@@ -187,6 +197,8 @@ abstract class AbstractFont
     public function valign($valign)
     {
         $this->valign = $valign;
+
+        return $this;
     }
 
     /**
@@ -208,6 +220,8 @@ abstract class AbstractFont
     public function file($file)
     {
         $this->file = $file;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
This allows a nicer experience when manipulating the font.

Before:

```php
function(AbstractFont $font) {
    $font->font('font.otf');
    $font->size(16);
    $font->color('#fff');
}
```

After:

```php
function(AbstractFont $font) {
    $font->font('font.otf')
         ->size(16)
         ->color('#fff');
}
```