### PR TITLE
allow intervention to use own drivers

### DIFF
--- a/src/Intervention/Image/ImageManager.php
+++ b/src/Intervention/Image/ImageManager.php
@@ -100,15 +100,25 @@ class ImageManager
      */
     private function createDriver()
     {
-        $drivername = ucfirst($this->config['driver']);
-        $driverclass = sprintf('Intervention\\Image\\%s\\Driver', $drivername);
+        if (is_string($this->config['driver'])) {
+            $drivername = ucfirst($this->config['driver']);
+            $driverclass = sprintf('Intervention\\Image\\%s\\Driver', $drivername);
 
-        if (class_exists($driverclass)) {
-            return new $driverclass;
+            if (class_exists($driverclass)) {
+                return new $driverclass;
+            }
+
+            throw new \Intervention\Image\Exception\NotSupportedException(
+                "Driver ({$drivername}) could not be instantiated."
+            );
+        }
+
+        if ($this->config['driver'] instanceof AbstractDriver) {
+            return $this->config['driver'];
         }
 
         throw new \Intervention\Image\Exception\NotSupportedException(
-            "Driver ({$drivername}) could not be instantiated."
+            "Unknown driver type."
         );
     }
 

--- a/tests/ImageManagerTest.php
+++ b/tests/ImageManagerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Intervention\Image\Image;
 use Intervention\Image\ImageManager;
 
 class ImageManagerTest extends PHPUnit_Framework_TestCase
@@ -25,5 +26,15 @@ class ImageManagerTest extends PHPUnit_Framework_TestCase
         $manager->configure($config);
         $this->assertEquals('foo', $manager->config['driver']);
         $this->assertEquals('baz', $manager->config['bar']);
+    }
+
+    public function testConfigureObject()
+    {
+        $config = array('driver' => new Intervention\Image\Imagick\Driver());
+        $manager = new ImageManager($config);
+
+        $image = $manager->make('data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7');
+        $this->assertInstanceOf(Image::class, $image);
+        $this->assertInstanceOf(Imagick::class, $image->getCore());
     }
 }

--- a/tests/ImageManagerTest.php
+++ b/tests/ImageManagerTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Intervention\Image\Image;
 use Intervention\Image\ImageManager;
 
 class ImageManagerTest extends PHPUnit_Framework_TestCase
@@ -34,7 +33,7 @@ class ImageManagerTest extends PHPUnit_Framework_TestCase
         $manager = new ImageManager($config);
 
         $image = $manager->make('data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7');
-        $this->assertInstanceOf(Image::class, $image);
-        $this->assertInstanceOf(Imagick::class, $image->getCore());
+        $this->assertInstanceOf('Intervention\Image\Image', $image);
+        $this->assertInstanceOf('Imagick', $image->getCore());
     }
 }


### PR DESCRIPTION
I want to extend some of the drivers. More specifically, since exif extension does not have support for streams, I must use the Imagick driver. However, in PR #659 I choose to prefer the exif extension over Imagick to prevent any possible BC break.

So I want to implement my own driver that just extends the Imagick driver a little bit. Currently, that is not possible. With this PR, you can also pass an object to the `driver` key in the `config` array.