### PR TITLE
Add user agent header initFromUrl

### DIFF
--- a/src/Intervention/Image/AbstractDecoder.php
+++ b/src/Intervention/Image/AbstractDecoder.php
@@ -61,7 +61,18 @@ abstract class AbstractDecoder
      */
     public function initFromUrl($url)
     {
-        if ($data = @file_get_contents($url)) {
+        
+        $options = array(
+            'http' => array(
+                'method'=>"GET",
+                'header'=>"Accept-language: en\r\n".
+                "User-Agent: Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.2 (KHTML, like Gecko) Chrome/22.0.1216.0 Safari/537.2\r\n"
+          )
+        );
+        
+        $context  = stream_context_create($options);
+        
+        if ($data = @file_get_contents($url, false, $context)) {
             return $this->initFromBinary($data);
         }
 


### PR DESCRIPTION
Several image servers have detection for which user agent is being used. 
Since I had several times issue's with that images where unavailable for Intervention since an missing user agent, I decided to add this header to get rid of the problems.