### PR TITLE
Introduce base ImageException class

### DIFF
--- a/src/Intervention/Image/Exception/ImageException.php
+++ b/src/Intervention/Image/Exception/ImageException.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Exception;
 
-class NotFoundException extends \Intervention\Image\Exception\ImageException
+class ImageException extends \RuntimeException
 {
     # nothing to override
 }

--- a/src/Intervention/Image/Exception/InvalidArgumentException.php
+++ b/src/Intervention/Image/Exception/InvalidArgumentException.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Exception;
 
-class InvalidArgumentException extends \RuntimeException
+class InvalidArgumentException extends \Intervention\Image\Exception\ImageException
 {
     # nothing to override
 }

--- a/src/Intervention/Image/Exception/MissingDependencyException.php
+++ b/src/Intervention/Image/Exception/MissingDependencyException.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Exception;
 
-class MissingDependencyException extends \RuntimeException
+class MissingDependencyException extends \Intervention\Image\Exception\ImageException
 {
     # nothing to override
 }

--- a/src/Intervention/Image/Exception/NotReadableException.php
+++ b/src/Intervention/Image/Exception/NotReadableException.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Exception;
 
-class NotReadableException extends \RuntimeException
+class NotReadableException extends \Intervention\Image\Exception\ImageException
 {
     # nothing to override
 }

--- a/src/Intervention/Image/Exception/NotSupportedException.php
+++ b/src/Intervention/Image/Exception/NotSupportedException.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Exception;
 
-class NotSupportedException extends \RuntimeException
+class NotSupportedException extends \Intervention\Image\Exception\ImageException
 {
     # nothing to override
 }

--- a/src/Intervention/Image/Exception/NotWritableException.php
+++ b/src/Intervention/Image/Exception/NotWritableException.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Exception;
 
-class NotWritableException extends \RuntimeException
+class NotWritableException extends \Intervention\Image\Exception\ImageException
 {
     # nothing to override
 }

--- a/src/Intervention/Image/Exception/RuntimeException.php
+++ b/src/Intervention/Image/Exception/RuntimeException.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image\Exception;
 
-class RuntimeException extends \RuntimeException
+class RuntimeException extends \Intervention\Image\Exception\ImageException
 {
     # nothing to override
 }


### PR DESCRIPTION
Base `Exception` class allows to catch all exceptions belonging to `Intervention\Image` without unrelated `\RuntimeException`s.

Naming and namespace are a proposition.