### PR TITLE
Update Travis CI config to allow pass for PHP 5.4 - 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
   - 7.1
   - nightly
   - hhvm
- 
+
 matrix:
     allow_failures:
         - php: nightly
@@ -25,4 +25,4 @@ before_script:
   - composer self-update
   - composer install --prefer-source --no-interaction --dev
 
-script: phpunit
+script: vendor/bin/phpunit


### PR DESCRIPTION
Currently the Travis config runs the latest stable version of PHPUnit which is incomparable with PHP 5, causing tests to fail unnecessarily. I have made a small amend to the config so that the PHPUnit version used is the one specified in composer.json, meaning the tests pass from PHP 5.4 - PHP 7.1