### PR TITLE
[FIX] File name is longer than the maximum allowed path length in some OS

### DIFF
--- a/src/Intervention/Image/AbstractDecoder.php
+++ b/src/Intervention/Image/AbstractDecoder.php
@@ -186,7 +186,11 @@ abstract class AbstractDecoder
     public function isFilePath()
     {
         if (is_string($this->data)) {
-            return is_file($this->data);
+            try {
+                return is_file($this->data);
+            } catch (\Exception $e) {
+                return false;
+            }
         }
 
         return false;
@@ -322,14 +326,14 @@ abstract class AbstractDecoder
             case $this->isStream():
                 return $this->initFromStream($this->data);
 
-            case $this->isFilePath():
-                return $this->initFromPath($this->data);
-
             case $this->isDataUrl():
                 return $this->initFromBinary($this->decodeDataUrl($this->data));
 
             case $this->isBase64():
                 return $this->initFromBinary(base64_decode($this->data));
+
+            case $this->isFilePath():
+                return $this->initFromPath($this->data);
 
             default:
                 throw new Exception\NotReadableException("Image source not readable");


### PR DESCRIPTION
exchange positiion checking isFilePath and isBase64 and catch the error while checking is_file