### PR TITLE
Bugfix: File path strings are always evaluated as Base64-data

### DIFF
--- a/src/Intervention/Image/AbstractDecoder.php
+++ b/src/Intervention/Image/AbstractDecoder.php
@@ -329,11 +329,11 @@ abstract class AbstractDecoder
             case $this->isDataUrl():
                 return $this->initFromBinary($this->decodeDataUrl($this->data));
 
-            case $this->isBase64():
-                return $this->initFromBinary(base64_decode($this->data));
-
             case $this->isFilePath():
                 return $this->initFromPath($this->data);
+
+            case $this->isBase64():
+                return $this->initFromBinary(base64_decode($this->data));
 
             default:
                 throw new Exception\NotReadableException("Image source not readable");


### PR DESCRIPTION
Since 2.3.12, a bug seems to have been introduced to `AbstractDecoder.php` that prevents loading images from file paths. I believe it was introduced [in this commit](https://github.com/Intervention/image/commit/58881f0bc8d32c25aff5d97a6433bc067a128fdb).

If I pass in a valid file path, such as `/tmp/MyImageFile`, line 332 of `AbstractDecoder.php` interprets it as base-64 text, and subsequently tries to decode an image from the file path string:

```
case $this->isBase64():
    return $this->initFromBinary(base64_decode($this->data));

case $this->isFilePath():
    return $this->initFromPath($this->data);
```

I think the `$this->isFilePath()` evaluation should come *before* the `$this->isBase64()` evaluation - as a file path string will always evaluate to Base 64.