### PR TITLE
Use imagecreatefromstring when imagecreatefromjpeg fail

### DIFF
--- a/src/Intervention/Image/Gd/Decoder.php
+++ b/src/Intervention/Image/Gd/Decoder.php
@@ -29,7 +29,10 @@ class Decoder extends \Intervention\Image\AbstractDecoder
                 break;
 
             case IMAGETYPE_JPEG:
-                $core = @imagecreatefromjpeg($path);
+                $core = @imagecreatefromjpeg($path); 
+                if (!$core) { 
+                    $core= @imagecreatefromstring(file_get_contents($path)); 
+                }
                 break;
 
             case IMAGETYPE_GIF:


### PR DESCRIPTION
For some image the function 'imagecreatefromstring' does'nt work beacause the image is in violation with the jpeg spec. 
https://stackoverflow.com/questions/35337709/invalid-sos-parameters-for-sequential-jpeg/43271528#43271528