### PR TITLE
Get travis working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: php
 
+sudo: false
+
+dist: trusty
+
 php:
   - 5.4
   - 5.5
@@ -14,16 +18,9 @@ matrix:
         - php: nightly
         - php: hhvm
 
-before_install:
-  - sudo add-apt-repository -y ppa:moti-p/cc
-  - sudo apt-get clean
-  - sudo apt-get update
-  - sudo apt-get -y --reinstall install imagemagick
-  - yes | pecl install imagick-beta
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.4" ]]; then echo "extension = imagick.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
-
 before_script:
-  - composer self-update
-  - composer install --prefer-source --no-interaction --dev
+  - printf "\n" | pecl install imagick
+  - composer self-update || true
+  - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader
 
 script: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "guzzlehttp/psr7": "~1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.*",
+        "phpunit/phpunit": "^4.8 || ^5.7",
         "mockery/mockery": "~0.9.2"
     },
     "suggest": {


### PR DESCRIPTION
These changes get travis working on my fork.

~~There's a test failure, but that's out of scope for a PR just intended to get the tests running.~~

`sudo: false` - to get us on the new infrastructure
Removed apt-get installs (can't do that on `sudo: false` and they failed anyway - I'm not sure if they are really needed?
Install imagick with pecl
`composer self-update || true` stops the build failing if we can't update composer for whatever reason
`composer install`:
 - `--prefer-dist` it's faster than from source
 - `--no-progress` we don't need progress for our builds so lets turn it off for more succinct output 
 - `--no-suggest` as above, we don't need this output for builds
 - `--optimize-autoloader` to hopefully speed up builds by making the autoloader a bit faster