### PR TITLE
Allow parenthesis in Laravel5 filename when using imagecache

### DIFF
--- a/src/Intervention/Image/ImageServiceProviderLaravel5.php
+++ b/src/Intervention/Image/ImageServiceProviderLaravel5.php
@@ -77,7 +77,7 @@ class ImageServiceProviderLaravel5 extends ServiceProvider
         // imagecache route
         if (is_string(config('imagecache.route'))) {
 
-            $filename_pattern = '[ \w\\.\\/\\-\\@]+';
+            $filename_pattern = '[ \w\\.\\/\\-\\@\(\)]+';
 
             // route to access template applied image file
             $app['router']->get(config('imagecache.route').'/{template}/{filename}', array(


### PR DESCRIPTION
Discovered a bug where filenames with parenthesis are not supported.
E.g. example(1).jpg

I think there are probably other valid filename characters that aren't supported - I've not put in any more research. 
This pull request fixes the issue for parenthesis.