### PR TITLE
Fix clones of transparent GD images with a color palette

### DIFF
--- a/src/Intervention/Image/Gd/Driver.php
+++ b/src/Intervention/Image/Gd/Driver.php
@@ -71,12 +71,53 @@ class Driver extends \Intervention\Image\AbstractDriver
      */
     public function cloneCore($core)
     {
+        if (imageistruecolor($core)) {
+            return $this->cloneTrueColorCore($core);
+        }
+
+        return $this->cloneColorPaletteCore($core);
+    }
+
+    /**
+     * Returns clone of a true color core
+     *
+     * @return mixed
+     */
+    protected function cloneTrueColorCore($core)
+    {
         $width = imagesx($core);
         $height = imagesy($core);
         $clone = imagecreatetruecolor($width, $height);
         imagealphablending($clone, false);
         imagesavealpha($clone, true);
-        
+
+        imagecopy($clone, $core, 0, 0, 0, 0, $width, $height);
+
+        return $clone;
+    }
+
+    /**
+     * Returns clone of a core with a color palette
+     *
+     * @return mixed
+     */
+    protected function cloneColorPaletteCore($core)
+    {
+        $width = imagesx($core);
+        $height = imagesy($core);
+        $clone = imagecreate($width, $height);
+        imagesavealpha($clone, true);
+
+        $rgb = imagecolorsforindex($core, imagecolortransparent($core));
+        $alpha = imagecolorallocatealpha(
+            $clone,
+            $rgb['red'],
+            $rgb['green'],
+            $rgb['blue'],
+            $rgb['alpha']
+        );
+        imagefill($clone, 0, 0, $alpha);
+
         imagecopy($clone, $core, 0, 0, 0, 0, $width, $height);
 
         return $clone;

--- a/tests/GdSystemTest.php
+++ b/tests/GdSystemTest.php
@@ -1058,7 +1058,7 @@ class GdSystemTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Intervention\Image\Image', $img);
         $this->assertEquals('a9e2b15452b2a4637b65625188d206f6', $img->checksum());
 
-        
+
         $img = $this->manager()->canvas(16, 16, 'ffffff');
         $img = $img->text('0', 8, 2, function($font) {
             $font->align('center');
@@ -1067,7 +1067,7 @@ class GdSystemTest extends PHPUnit_Framework_TestCase
         });
         $this->assertInstanceOf('Intervention\Image\Image', $img);
         $this->assertEquals('649f3f529d3931c56601155fd2680959', $img->checksum());
-        
+
         $img = $this->manager()->canvas(16, 16, 'ffffff');
         $img = $img->text('0', 8, 8, function($font) {
             $font->align('right');
@@ -1188,7 +1188,7 @@ class GdSystemTest extends PHPUnit_Framework_TestCase
         $this->assertColorAtPosition('#0c02b4', $img, 6, 12);
         $this->assertColorAtPosition('#fcbe04', $img, 22, 24);
     }
-    
+
     public function testLimitColorsKeepTransparencyWithMatte()
     {
         $img = $this->manager()->make('tests/images/star.png');
@@ -1257,7 +1257,7 @@ class GdSystemTest extends PHPUnit_Framework_TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->limitColors(200);
-        
+
         $c = $img->pickColor(0, 0);
         $this->assertEquals(180, $c[0]);
         $this->assertEquals(226, $c[1]);
@@ -1319,7 +1319,7 @@ class GdSystemTest extends PHPUnit_Framework_TestCase
         $this->assertColorAtPosition('#66ee70', $img, 0, 0);
         $this->assertColorAtPosition('#ffe600', $img, 24, 24);
     }
-    
+
     public function testTrimGradient()
     {
         $canvas = $this->manager()->make('tests/images/gradient.png');
@@ -1410,7 +1410,7 @@ class GdSystemTest extends PHPUnit_Framework_TestCase
     public function testTrimWithFeather()
     {
         $canvas = $this->manager()->make('tests/images/trim.png');
-        
+
         $img = clone $canvas;
         $feather = 5;
         $img->trim(null, null, null, $feather);
@@ -1581,7 +1581,7 @@ class GdSystemTest extends PHPUnit_Framework_TestCase
         $img = $this->manager()->canvas(16, 16, '#ff0000');
         $img->save($path);
         $img->destroy();
-        
+
         // open test image again
         $img = $this->manager()->make($path);
         $this->assertColorAtPosition('#ff0000', $img, 0, 0);
@@ -1640,6 +1640,39 @@ class GdSystemTest extends PHPUnit_Framework_TestCase
         // clone should be still intact
         $this->assertInstanceOf('Intervention\Image\Image', $cln);
         $this->assertInternalType('resource', $cln->getCore());
+    }
+
+    public function testCloneTransparentTrueColorImageObject()
+    {
+        $img = $this->manager()->make('tests/images/star.png');
+        $cln = clone $img;
+
+        // destroy original
+        $img->destroy();
+        unset($img);
+
+        // clone should be still intact
+        $this->assertInstanceOf('Intervention\Image\Image', $cln);
+        $this->assertInternalType('resource', $cln->getCore());
+        $this->assertTransparentPosition($cln, 0, 0);
+        $this->assertTrue(imageistruecolor($cln->getCore()));
+    }
+
+    public function testCloneTransparentColorPaletteImageObject()
+    {
+        $img = $this->manager()->make('tests/images/star.png');
+        $img->limitColors(256);
+        $cln = clone $img;
+
+        // destroy original
+        $img->destroy();
+        unset($img);
+
+        // clone should be still intact
+        $this->assertInstanceOf('Intervention\Image\Image', $cln);
+        $this->assertInternalType('resource', $cln->getCore());
+        $this->assertTransparentPosition($cln, 0, 0);
+        $this->assertFalse(imageistruecolor($cln->getCore()));
     }
 
     public function testGifConversionKeepsTransparency()


### PR DESCRIPTION
Currently, cloning a transparent GD image with a color palette results in the transparency being changed to black. This happens because of an incorrect conversion to true color, while also not setting the appropriate transparency color.

With this PR, cloned GD color palette images would no longer be converted to true color and keep their transparency intact.