### PR TITLE
Added support for saving a file without extension.

### DIFF
--- a/src/Intervention/Image/Image.php
+++ b/src/Intervention/Image/Image.php
@@ -124,9 +124,11 @@ class Image extends File
      *
      * @param  string  $path
      * @param  integer $quality
+     * @param  string  $mime
+     * @param  boolean $guessFormat
      * @return \Intervention\Image\Image
      */
-    public function save($path = null, $quality = null)
+    public function save($path = null, $quality = null, $mime = null, $guessFormat = false)
     {
         $path = is_null($path) ? $this->basePath() : $path;
 
@@ -136,7 +138,15 @@ class Image extends File
             );
         }
 
-        $data = $this->encode(pathinfo($path, PATHINFO_EXTENSION), $quality);
+        if ($guessFormat) {
+            $format = $this->mime;
+        } elseif ($mime) {
+            $format = $mime;
+        } else {
+            $format = pathinfo($path, PATHINFO_EXTENSION);
+        }
+
+        $data = $this->encode($format, $quality);
         $saved = @file_put_contents($path, $data);
 
         if ($saved === false) {

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -43,6 +43,35 @@ class ImageTest extends PHPUnit_Framework_TestCase
         @unlink($save_as);
     }
 
+    public function testSaveWithMime()
+    {
+        $save_as = __DIR__.'/tmp/test';
+        $image = $this->getTestImage();
+        $image->getDriver()->shouldReceive('encode')->with($image, 'image/jpeg', 85)->once()->andReturn('mock');
+        $image = $image->save($save_as, 85, 'image/jpeg');
+        $this->assertInstanceOf('\Intervention\Image\Image', $image);
+        $this->assertFileExists($save_as);
+        $this->assertEquals($image->basename, 'test');
+        $this->assertEquals($image->extension, null);
+        $this->assertEquals($image->filename, 'test');
+        @unlink($save_as);
+    }
+
+    public function testSaveByGuessingFormat()
+    {
+        $save_as = __DIR__.'/tmp/test';
+        $image = $this->getTestImage();
+        $image->mime = 'image/jpeg';
+        $image->getDriver()->shouldReceive('encode')->with($image, 'image/jpeg', 85)->once()->andReturn('mock');
+        $image = $image->save($save_as, 85, null, true);
+        $this->assertInstanceOf('\Intervention\Image\Image', $image);
+        $this->assertFileExists($save_as);
+        $this->assertEquals($image->basename, 'test');
+        $this->assertEquals($image->extension, null);
+        $this->assertEquals($image->filename, 'test');
+        @unlink($save_as);
+    }
+
     public function testIsEncoded()
     {
         $image = $this->getTestImage();


### PR DESCRIPTION
Added support for saving a file without extension by replacing it with mime type.

---

So the main reason for doing this is that in my project we're omitting file extensions on all uploads. When I tried saving an image without a file extension I got an error because the `save` method uses `pathinfo` to figure out what kind of file it is.

After some digging I realized that the `process` method handles mime types as well. So what I did was to add support for the `save` method to receive a mime type.

The method `setFileInfoFromPath` actually sets the mime type if the file already exists. By using this we could let the user skip the part where they have to pass the mime type, and instead pass a parameter to make it "guess" what format it is.

---
### Save with mime type.
`image->save('path/to/file-without-extension, 85, 'image/jpeg');`

### Save by "guessing" the format
`image->save('path/to/file-without-extension, 85, null, true);`