### PR TITLE
FIX PNGs are now transparent when created from clones

### DIFF
--- a/src/Intervention/Image/Gd/Commands/BackupCommand.php
+++ b/src/Intervention/Image/Gd/Commands/BackupCommand.php
@@ -15,17 +15,8 @@ class BackupCommand extends \Intervention\Image\Commands\AbstractCommand
         $backupName = $this->argument(0)->value();
 
         // clone current image resource
-        $size = $image->getSize();
-        $clone = imagecreatetruecolor($size->width, $size->height);
-        imagealphablending($clone, false);
-        imagesavealpha($clone, true);
-        $transparency = imagecolorallocatealpha($clone, 0, 0, 0, 127);
-        imagefill($clone, 0, 0, $transparency);
-
-        // copy image to clone
-        imagecopy($clone, $image->getCore(), 0, 0, 0, 0, $size->width, $size->height);
-
-        $image->setBackup($clone, $backupName);
+        $clone = clone $image;
+        $image->setBackup($clone->getCore(), $backupName);
 
         return true;
     }

--- a/src/Intervention/Image/Gd/Driver.php
+++ b/src/Intervention/Image/Gd/Driver.php
@@ -76,6 +76,8 @@ class Driver extends \Intervention\Image\AbstractDriver
         $clone = imagecreatetruecolor($width, $height);
         imagealphablending($clone, false);
         imagesavealpha($clone, true);
+        $transparency = imagecolorallocatealpha($clone, 0, 0, 0, 127);
+        imagefill($clone, 0, 0, $transparency);
         
         imagecopy($clone, $core, 0, 0, 0, 0, $width, $height);
 

--- a/src/Intervention/Image/Imagick/Commands/BackupCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/BackupCommand.php
@@ -15,7 +15,8 @@ class BackupCommand extends \Intervention\Image\Commands\AbstractCommand
         $backupName = $this->argument(0)->value();
 
         // clone current image resource
-        $image->setBackup(clone $image->getCore(), $backupName);
+        $clone = clone $image;
+        $image->setBackup($clone->getCore(), $backupName);
 
         return true;
     }

--- a/tests/BackupCommandTest.php
+++ b/tests/BackupCommandTest.php
@@ -12,11 +12,11 @@ class BackupCommandTest extends PHPUnit_Framework_TestCase
 
     public function testGdWithoutName()
     {
-        $size = Mockery::mock('Intervention\Image\Size', array(800, 600));
+        $driver = Mockery::mock('Intervention\Image\Gd\Driver');
+        $driver->shouldReceive('cloneCore')->once();
         $resource = imagecreatefromjpeg(__DIR__.'/images/test.jpg');
-        $image = Mockery::mock('Intervention\Image\Image');
+        $image = Mockery::mock('Intervention\Image\Image', array($driver));
         $image->shouldReceive('getCore')->once()->andReturn($resource);
-        $image->shouldReceive('getSize')->once()->andReturn($size);
         $image->shouldReceive('setBackup')->once();
         $command = new BackupGd(array());
         $result = $command->execute($image);
@@ -25,11 +25,11 @@ class BackupCommandTest extends PHPUnit_Framework_TestCase
 
     public function testGdWithName()
     {
-        $size = Mockery::mock('Intervention\Image\Size', array(800, 600));
+        $driver = Mockery::mock('Intervention\Image\Gd\Driver');
+        $driver->shouldReceive('cloneCore')->once();
         $resource = imagecreatefromjpeg(__DIR__.'/images/test.jpg');
-        $image = Mockery::mock('Intervention\Image\Image');
+        $image = Mockery::mock('Intervention\Image\Image', array($driver));
         $image->shouldReceive('getCore')->once()->andReturn($resource);
-        $image->shouldReceive('getSize')->once()->andReturn($size);
         $image->shouldReceive('setBackup')->once();
         $command = new BackupGd(array('name' => 'fooBackup'));
         $result = $command->execute($image);
@@ -38,8 +38,10 @@ class BackupCommandTest extends PHPUnit_Framework_TestCase
 
     public function testImagickWithoutName()
     {
+        $driver = Mockery::mock('Intervention\Image\Imagick\Driver');
+        $driver->shouldReceive('cloneCore')->once();
         $imagick = Mockery::mock('Imagick');
-        $image = Mockery::mock('Intervention\Image\Image');
+        $image = Mockery::mock('Intervention\Image\Image', array($driver));
         $image->shouldReceive('getCore')->once()->andReturn($imagick);
         $image->shouldReceive('setBackup')->once();
         $command = new BackupImagick(array());
@@ -49,8 +51,10 @@ class BackupCommandTest extends PHPUnit_Framework_TestCase
 
     public function testImagickWithName()
     {
+        $driver = Mockery::mock('Intervention\Image\Imagick\Driver');
+        $driver->shouldReceive('cloneCore')->once();
         $imagick = Mockery::mock('Imagick');
-        $image = Mockery::mock('Intervention\Image\Image');
+        $image = Mockery::mock('Intervention\Image\Image', array($driver));
         $image->shouldReceive('getCore')->once()->andReturn($imagick);
         $image->shouldReceive('setBackup')->once();
         $command = new BackupImagick(array('name' => 'fooBackup'));


### PR DESCRIPTION
I've been having an issue with PNGs rendering with black backgrounds and narrowed it down to an issue when cloning the image resource.

```php

$manager = new ImageManager();
$image = $manager->make('/path/to/image.png');
$newImage = clone $image;
$newImage->resize($width, $height);
$newImage->save('/path/to/newimage.png');
```

In this example newimage.png would be replacing all transparent pixels with black pixels.

This is because the new canvas which is created when `Gd\Driver::cloneCore` is called doesn't set the cloned image's background to transparent and so it stays at the default (black).

This fix makes sure that all changes are applied onto a transparent background when cloning images.