### PR TITLE
Add Gd and Imagick TextCommand classes that extend from parent

### DIFF
--- a/src/Intervention/Image/Gd/Commands/TextCommand.php
+++ b/src/Intervention/Image/Gd/Commands/TextCommand.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Intervention\Image\Gd\Commands;
+
+class TextCommand extends \Intervention\Image\Commands\TextCommand
+{
+    //
+}

--- a/src/Intervention/Image/Imagick/Commands/TextCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/TextCommand.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Intervention\Image\Imagick\Commands;
+
+class TextCommand extends \Intervention\Image\Commands\TextCommand
+{
+    //
+}


### PR DESCRIPTION
I don't know if this is something you'd want to merge, as it looks like the issue I was having in https://github.com/Intervention/image/issues/788 was due to the autoloader in Magento 1.9 that we're using.

Feel free to close this if you feel like it's not important enough, but since both Gd and Imagick drivers support this command, I felt like this is an _alright_ solution for me.

Thanks!