### PR TITLE
Fix “insert” offset with center position

### DIFF
--- a/src/Intervention/Image/Size.php
+++ b/src/Intervention/Image/Size.php
@@ -337,8 +337,8 @@ class Size
             case 'middle':
             case 'center-center':
             case 'middle-middle':
-                $x = intval($this->width / 2);
-                $y = intval($this->height / 2);
+                $x = intval($this->width / 2) + $offset_x;
+                $y = intval($this->height / 2) + $offset_y;
                 break;
 
             default:


### PR DESCRIPTION
The <code>insert</code> command ignore specified <code>offset</code> if position == **center**.

An example:
```php
$canvas = Image::canvas(600, 600, '#ff0000');
$canvas1 = Image::canvas(400, 400, '#f6ff00');

$canvas->insert($canvas1, 'center', 150, 150);

return $canvas->response();
```

Wrong:
![wrong](https://user-images.githubusercontent.com/779534/31725686-3da8d2d4-b425-11e7-90e0-50318d41f7be.jpeg)

Fixed:
![fixed](https://user-images.githubusercontent.com/779534/31725702-444abbfc-b425-11e7-8271-0464df7b7a22.jpeg)
