### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "guzzlehttp/psr7": "~1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8 || ^5.7",
+        "phpunit/phpunit": "^4.8.36 || ^5.7",
         "mockery/mockery": "~0.9.2"
     },
     "suggest": {

--- a/tests/AbstractColorTest.php
+++ b/tests/AbstractColorTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class AbstractColorTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AbstractColorTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/AbstractCommandTest.php
+++ b/tests/AbstractCommandTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class AbstractCommandTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AbstractCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/AbstractDecoderTest.php
+++ b/tests/AbstractDecoderTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class AbstractDecoderTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AbstractDecoderTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/AbstractDriverTest.php
+++ b/tests/AbstractDriverTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class AbstractDriverTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AbstractDriverTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/AbstractFontTest.php
+++ b/tests/AbstractFontTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class AbstractFontTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AbstractFontTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/AbstractShapeTest.php
+++ b/tests/AbstractShapeTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class AbstractShapeTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AbstractShapeTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/ArgumentTest.php
+++ b/tests/ArgumentTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Intervention\Image\Commands\Argument;
+use PHPUnit\Framework\TestCase;
 
-class ArgumentTest extends PHPUnit_Framework_TestCase
+class ArgumentTest extends TestCase
 {
     public function testConstructor()
     {

--- a/tests/BackupCommandTest.php
+++ b/tests/BackupCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\BackupCommand as BackupGd;
 use Intervention\Image\Imagick\Commands\BackupCommand as BackupImagick;
+use PHPUnit\Framework\TestCase;
 
-class BackupCommandTest extends PHPUnit_Framework_TestCase
+class BackupCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/BlurCommandTest.php
+++ b/tests/BlurCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\BlurCommand as BlurGd;
 use Intervention\Image\Imagick\Commands\BlurCommand as BlurImagick;
+use PHPUnit\Framework\TestCase;
 
-class BlurCommandTest extends PHPUnit_Framework_TestCase
+class BlurCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/BrightnessCommandTest.php
+++ b/tests/BrightnessCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\BrightnessCommand as BrightnessGd;
 use Intervention\Image\Imagick\Commands\BrightnessCommand as BrightnessImagick;
+use PHPUnit\Framework\TestCase;
 
-class BrightnessCommandTest extends PHPUnit_Framework_TestCase
+class BrightnessCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/ChecksumCommandTest.php
+++ b/tests/ChecksumCommandTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Intervention\Image\Commands\ChecksumCommand;
+use PHPUnit\Framework\TestCase;
 
-class ChecksumCommandTest extends PHPUnit_Framework_TestCase
+class ChecksumCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/CircleCommandTest.php
+++ b/tests/CircleCommandTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Intervention\Image\Commands\CircleCommand;
+use PHPUnit\Framework\TestCase;
 
-class CircleCommandTest extends PHPUnit_Framework_TestCase
+class CircleCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/CircleShapeTest.php
+++ b/tests/CircleShapeTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Shapes\CircleShape as CircleGd;
 use Intervention\Image\Imagick\Shapes\CircleShape as CircleImagick;
+use PHPUnit\Framework\TestCase;
 
-class CircleShapeTest extends PHPUnit_Framework_TestCase
+class CircleShapeTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/ColorizeCommandTest.php
+++ b/tests/ColorizeCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\ColorizeCommand as ColorizeGd;
 use Intervention\Image\Imagick\Commands\ColorizeCommand as ColorizeImagick;
+use PHPUnit\Framework\TestCase;
 
-class ColorizeCommandTest extends PHPUnit_Framework_TestCase
+class ColorizeCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/ConstraintTest.php
+++ b/tests/ConstraintTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Intervention\Image\Constraint;
+use PHPUnit\Framework\TestCase;
 
-class ConstraintTest extends PHPUnit_Framework_TestCase
+class ConstraintTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/ContrastCommandTest.php
+++ b/tests/ContrastCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\ContrastCommand as ContrastGd;
 use Intervention\Image\Imagick\Commands\ContrastCommand as ContrastImagick;
+use PHPUnit\Framework\TestCase;
 
-class ContrastCommandTest extends PHPUnit_Framework_TestCase
+class ContrastCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/CropCommandTest.php
+++ b/tests/CropCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\CropCommand as CropGd;
 use Intervention\Image\Imagick\Commands\CropCommand as CropImagick;
+use PHPUnit\Framework\TestCase;
 
-class CropCommandTest extends PHPUnit_Framework_TestCase
+class CropCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/DestroyCommandTest.php
+++ b/tests/DestroyCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\DestroyCommand as DestroyGd;
 use Intervention\Image\Imagick\Commands\DestroyCommand as DestroyImagick;
+use PHPUnit\Framework\TestCase;
 
-class DestroyCommandTest extends PHPUnit_Framework_TestCase
+class DestroyCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/DriverTest.php
+++ b/tests/DriverTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Driver as GdDriver;
 use Intervention\Image\Imagick\Driver as ImagickDriver;
+use PHPUnit\Framework\TestCase;
 
-class DriverTest extends PHPUnit_Framework_TestCase
+class DriverTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/EllipseCommandTest.php
+++ b/tests/EllipseCommandTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Intervention\Image\Commands\EllipseCommand;
+use PHPUnit\Framework\TestCase;
 
-class EllipseCommandTest extends PHPUnit_Framework_TestCase
+class EllipseCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/EllipseShapeTest.php
+++ b/tests/EllipseShapeTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Shapes\EllipseShape as EllipseGd;
 use Intervention\Image\Imagick\Shapes\EllipseShape as EllipseImagick;
+use PHPUnit\Framework\TestCase;
 
-class EllipseShapeTest extends PHPUnit_Framework_TestCase
+class EllipseShapeTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/EncoderTest.php
+++ b/tests/EncoderTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Encoder as GdEncoder;
 use Intervention\Image\Imagick\Encoder as ImagickEncoder;
+use PHPUnit\Framework\TestCase;
 
-class EncoderTest extends PHPUnit_Framework_TestCase
+class EncoderTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/ExifCommandTest.php
+++ b/tests/ExifCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Image;
 use Intervention\Image\Commands\ExifCommand;
+use PHPUnit\Framework\TestCase;
 
-class ExifCommandTest extends PHPUnit_Framework_TestCase
+class ExifCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/FileTest.php
+++ b/tests/FileTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Intervention\Image\File;
+use PHPUnit\Framework\TestCase;
 
-class FileTest extends PHPUnit_Framework_TestCase
+class FileTest extends TestCase
 {
     public function testSetFileInfoFromPath()
     {

--- a/tests/FillCommandTest.php
+++ b/tests/FillCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\FillCommand as FillGd;
 use Intervention\Image\Imagick\Commands\FillCommand as FillImagick;
+use PHPUnit\Framework\TestCase;
 
-class FillCommandTest extends PHPUnit_Framework_TestCase
+class FillCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/FitCommandTest.php
+++ b/tests/FitCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\FitCommand as FitGd;
 use Intervention\Image\Imagick\Commands\FitCommand as FitImagick;
+use PHPUnit\Framework\TestCase;
 
-class FitCommandTest extends PHPUnit_Framework_TestCase
+class FitCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/FlipCommandTest.php
+++ b/tests/FlipCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\FlipCommand as FlipGd;
 use Intervention\Image\Imagick\Commands\FlipCommand as FlipImagick;
+use PHPUnit\Framework\TestCase;
 
-class FlipCommandTest extends PHPUnit_Framework_TestCase
+class FlipCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/GammaCommandTest.php
+++ b/tests/GammaCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\GammaCommand as GammaGd;
 use Intervention\Image\Imagick\Commands\GammaCommand as GammaImagick;
+use PHPUnit\Framework\TestCase;
 
-class GammaCommandTest extends PHPUnit_Framework_TestCase
+class GammaCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/GdColorTest.php
+++ b/tests/GdColorTest.php
@@ -4,7 +4,9 @@ use Intervention\Image\Gd\Color;
 
 // alpha - A value between 0 and 127. 0 indicates completely opaque while 127 indicates completely transparent.
 
-class GdColorTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class GdColorTest extends TestCase
 {
     public function testConstructor()
     {

--- a/tests/GdSystemTest.php
+++ b/tests/GdSystemTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class GdSystemTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class GdSystemTest extends TestCase
 {
     public function testMakeFromPath()
     {

--- a/tests/GetsizeCommandTest.php
+++ b/tests/GetsizeCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\GetSizeCommand as GetSizeGd;
 use Intervention\Image\Imagick\Commands\GetSizeCommand as GetSizeImagick;
+use PHPUnit\Framework\TestCase;
 
-class GetsizeCommandTest extends PHPUnit_Framework_TestCase
+class GetsizeCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/GreyscaleCommandTest.php
+++ b/tests/GreyscaleCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\GreyscaleCommand as GreyscaleGd;
 use Intervention\Image\Imagick\Commands\GreyscaleCommand as GreyscaleImagick;
+use PHPUnit\Framework\TestCase;
 
-class GreyscaleCommandTest extends PHPUnit_Framework_TestCase
+class GreyscaleCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/HeightenCommandTest.php
+++ b/tests/HeightenCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\HeightenCommand as HeightenGd;
 use Intervention\Image\Imagick\Commands\HeightenCommand as HeightenImagick;
+use PHPUnit\Framework\TestCase;
 
-class HeightenCommandTest extends PHPUnit_Framework_TestCase
+class HeightenCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/ImageManagerStaticTest.php
+++ b/tests/ImageManagerStaticTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Intervention\Image\ImageManagerStatic;
+use PHPUnit\Framework\TestCase;
 
-class ImageManagerStaticTest extends PHPUnit_Framework_TestCase
+class ImageManagerStaticTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/ImageManagerTest.php
+++ b/tests/ImageManagerTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Intervention\Image\ImageManager;
+use PHPUnit\Framework\TestCase;
 
-class ImageManagerTest extends PHPUnit_Framework_TestCase
+class ImageManagerTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Intervention\Image\Image;
+use PHPUnit\Framework\TestCase;
 
-class ImageTest extends PHPUnit_Framework_TestCase
+class ImageTest extends TestCase
 {
     public function tearDown()
     {
@@ -47,7 +48,7 @@ class ImageTest extends PHPUnit_Framework_TestCase
     {
         $image = $this->getTestImage();
         $this->assertFalse($image->isEncoded());
-        
+
         $image->setEncoded('foo');
         $this->assertTrue($image->isEncoded());
     }

--- a/tests/ImagickColorTest.php
+++ b/tests/ImagickColorTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Intervention\Image\Imagick\Color;
+use PHPUnit\Framework\TestCase;
 
-class ImagickColorTest extends PHPUnit_Framework_TestCase
+class ImagickColorTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/ImagickSystemTest.php
+++ b/tests/ImagickSystemTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class ImagickSystemTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ImagickSystemTest extends TestCase
 {
     public function testMakeFromPath()
     {

--- a/tests/InsertCommandTest.php
+++ b/tests/InsertCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\InsertCommand as InsertGd;
 use Intervention\Image\Imagick\Commands\InsertCommand as InsertImagick;
+use PHPUnit\Framework\TestCase;
 
-class InsertCommandTest extends PHPUnit_Framework_TestCase
+class InsertCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/InterlaceCommandTest.php
+++ b/tests/InterlaceCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\InterlaceCommand as InterlaceGd;
 use Intervention\Image\Imagick\Commands\InterlaceCommand as InterlaceImagick;
+use PHPUnit\Framework\TestCase;
 
-class InterlaceCommandTest extends PHPUnit_Framework_TestCase
+class InterlaceCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/InvertCommandTest.php
+++ b/tests/InvertCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\InvertCommand as InvertGd;
 use Intervention\Image\Imagick\Commands\InvertCommand as InvertImagick;
+use PHPUnit\Framework\TestCase;
 
-class InvertCommandTest extends PHPUnit_Framework_TestCase
+class InvertCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/IptcCommandTest.php
+++ b/tests/IptcCommandTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Intervention\Image\Commands\IptcCommand;
+use PHPUnit\Framework\TestCase;
 
-class IptcCommandTest extends PHPUnit_Framework_TestCase
+class IptcCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/LimitColorsCommandTest.php
+++ b/tests/LimitColorsCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\LimitColorsCommand as LimitColorsGd;
 use Intervention\Image\Imagick\Commands\LimitColorsCommand as LimitColorsImagick;
+use PHPUnit\Framework\TestCase;
 
-class LimitColorsCommandTest extends PHPUnit_Framework_TestCase
+class LimitColorsCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/LineCommandTest.php
+++ b/tests/LineCommandTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Intervention\Image\Commands\LineCommand;
+use PHPUnit\Framework\TestCase;
 
-class LineCommandTest extends PHPUnit_Framework_TestCase
+class LineCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/LineShapeTest.php
+++ b/tests/LineShapeTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Shapes\LineShape as LineGd;
 use Intervention\Image\Imagick\Shapes\LineShape as LineImagick;
+use PHPUnit\Framework\TestCase;
 
-class LineShapeTest extends PHPUnit_Framework_TestCase
+class LineShapeTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/MaskCommandTest.php
+++ b/tests/MaskCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\MaskCommand as MaskGd;
 use Intervention\Image\Imagick\Commands\MaskCommand as MaskImagick;
+use PHPUnit\Framework\TestCase;
 
-class MaskCommandTest extends PHPUnit_Framework_TestCase
+class MaskCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/OpacityCommandTest.php
+++ b/tests/OpacityCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\OpacityCommand as OpacityGd;
 use Intervention\Image\Imagick\Commands\OpacityCommand as OpacityImagick;
+use PHPUnit\Framework\TestCase;
 
-class OpacityCommandTest extends PHPUnit_Framework_TestCase
+class OpacityCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/OrientateCommandTest.php
+++ b/tests/OrientateCommandTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Intervention\Image\Commands\OrientateCommand;
+use PHPUnit\Framework\TestCase;
 
-class OrientateCommandTest extends PHPUnit_Framework_TestCase
+class OrientateCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/PickColorCommandTest.php
+++ b/tests/PickColorCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\PickColorCommand as PickColorGd;
 use Intervention\Image\Imagick\Commands\PickColorCommand as PickColorImagick;
+use PHPUnit\Framework\TestCase;
 
-class PickColorCommandTest extends PHPUnit_Framework_TestCase
+class PickColorCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/PixelCommandTest.php
+++ b/tests/PixelCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\PixelCommand as PixelGd;
 use Intervention\Image\Imagick\Commands\PixelCommand as PixelImagick;
+use PHPUnit\Framework\TestCase;
 
-class PixelCommandTest extends PHPUnit_Framework_TestCase
+class PixelCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/PixelateCommandTest.php
+++ b/tests/PixelateCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\PixelateCommand as PixelateGd;
 use Intervention\Image\Imagick\Commands\PixelateCommand as PixelateImagick;
+use PHPUnit\Framework\TestCase;
 
-class PixelateCommandTest extends PHPUnit_Framework_TestCase
+class PixelateCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/PointTest.php
+++ b/tests/PointTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Intervention\Image\Point;
+use PHPUnit\Framework\TestCase;
 
-class PointTest extends PHPUnit_Framework_TestCase
+class PointTest extends TestCase
 {
     public function testConstructor()
     {

--- a/tests/PolygonCommandTest.php
+++ b/tests/PolygonCommandTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Intervention\Image\Commands\PolygonCommand;
+use PHPUnit\Framework\TestCase;
 
-class PolygonCommandTest extends PHPUnit_Framework_TestCase
+class PolygonCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/PolygonShapeTest.php
+++ b/tests/PolygonShapeTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Shapes\PolygonShape as PolygonGd;
 use Intervention\Image\Imagick\Shapes\PolygonShape as PolygonImagick;
+use PHPUnit\Framework\TestCase;
 
-class PolygonShapeTest extends PHPUnit_Framework_TestCase
+class PolygonShapeTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/PsrResponseCommandTest.php
+++ b/tests/PsrResponseCommandTest.php
@@ -1,7 +1,8 @@
 <?php
 use Intervention\Image\Commands\PsrResponseCommand;
+use PHPUnit\Framework\TestCase;
 
-class PsrResponseCommandTest extends PHPUnit_Framework_TestCase
+class PsrResponseCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/RectangleCommandTest.php
+++ b/tests/RectangleCommandTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Intervention\Image\Commands\RectangleCommand;
+use PHPUnit\Framework\TestCase;
 
-class RectangleCommandTest extends PHPUnit_Framework_TestCase
+class RectangleCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/RectangleShapeTest.php
+++ b/tests/RectangleShapeTest.php
@@ -2,14 +2,15 @@
 
 use Intervention\Image\Gd\Shapes\RectangleShape as RectangleGd;
 use Intervention\Image\Imagick\Shapes\RectangleShape as RectangleImagick;
+use PHPUnit\Framework\TestCase;
 
-class RectangleShapeTest extends PHPUnit_Framework_TestCase
+class RectangleShapeTest extends TestCase
 {
     public function tearDown()
     {
         Mockery::close();
     }
-    
+
     public function testConstructor()
     {
         // gd

--- a/tests/ResetCommandTest.php
+++ b/tests/ResetCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\ResetCommand as ResetGd;
 use Intervention\Image\Imagick\Commands\ResetCommand as ResetImagick;
+use PHPUnit\Framework\TestCase;
 
-class ResetCommandTest extends PHPUnit_Framework_TestCase
+class ResetCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/ResizeCanvasCommandTest.php
+++ b/tests/ResizeCanvasCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\ResizeCanvasCommand as ResizeCanvasGd;
 use Intervention\Image\Imagick\Commands\ResizeCanvasCommand as ResizeCanvasImagick;
+use PHPUnit\Framework\TestCase;
 
-class ResizeCanvasCommandTest extends PHPUnit_Framework_TestCase
+class ResizeCanvasCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/ResizeCommandTest.php
+++ b/tests/ResizeCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\ResizeCommand as ResizeCommandGd;
 use Intervention\Image\Imagick\Commands\ResizeCommand as ResizeCommandImagick;
+use PHPUnit\Framework\TestCase;
 
-class ResizeCommandTest extends PHPUnit_Framework_TestCase
+class ResizeCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Intervention\Image\Response;
+use PHPUnit\Framework\TestCase;
 
-class ResponseTest extends PHPUnit_Framework_TestCase
+class ResponseTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/RotateCommandTest.php
+++ b/tests/RotateCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\RotateCommand as RotateGd;
 use Intervention\Image\Imagick\Commands\RotateCommand as RotateImagick;
+use PHPUnit\Framework\TestCase;
 
-class RotateCommandTest extends PHPUnit_Framework_TestCase
+class RotateCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/SharpenCommandTest.php
+++ b/tests/SharpenCommandTest.php
@@ -2,8 +2,9 @@
 
 use Intervention\Image\Gd\Commands\SharpenCommand as SharpenGd;
 use Intervention\Image\Imagick\Commands\SharpenCommand as SharpenImagick;
+use PHPUnit\Framework\TestCase;
 
-class SharpenCommandTest extends PHPUnit_Framework_TestCase
+class SharpenCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/SizeTest.php
+++ b/tests/SizeTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Intervention\Image\Size;
+use PHPUnit\Framework\TestCase;
 
-class SizeTest extends PHPUnit_Framework_TestCase
+class SizeTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/StreamCommandTest.php
+++ b/tests/StreamCommandTest.php
@@ -1,7 +1,8 @@
 <?php
 use Intervention\Image\Commands\StreamCommand;
+use PHPUnit\Framework\TestCase;
 
-class StreamCommandTest extends PHPUnit_Framework_TestCase
+class StreamCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/TextCommandTest.php
+++ b/tests/TextCommandTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Intervention\Image\Commands\TextCommand;
+use PHPUnit\Framework\TestCase;
 
-class TextCommandTest extends PHPUnit_Framework_TestCase
+class TextCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/TrimCommandTest.php
+++ b/tests/TrimCommandTest.php
@@ -2,14 +2,15 @@
 
 use Intervention\Image\Gd\Commands\TrimCommand as TrimGd;
 use Intervention\Image\Imagick\Commands\TrimCommand as TrimImagick;
+use PHPUnit\Framework\TestCase;
 
-class TrimCommandTest extends PHPUnit_Framework_TestCase
+class TrimCommandTest extends TestCase
 {
     public function tearDown()
     {
         Mockery::close();
     }
-    
+
     public function testGd()
     {
         $resource = imagecreatefromjpeg(__DIR__.'/images/test.jpg');

--- a/tests/WidenCommandTest.php
+++ b/tests/WidenCommandTest.php
@@ -2,14 +2,15 @@
 
 use Intervention\Image\Gd\Commands\WidenCommand as WidenGd;
 use Intervention\Image\Imagick\Commands\WidenCommand as WidenImagick;
+use PHPUnit\Framework\TestCase;
 
-class WidenCommandTest extends PHPUnit_Framework_TestCase
+class WidenCommandTest extends TestCase
 {
     public function tearDown()
     {
         Mockery::close();
     }
-    
+
     public function testGd()
     {
         $callback = function ($constraint) { $constraint->aspectRatio(); };


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.36`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md), that support this namespace.