### PR TITLE
Transparent Background for Images read from Blob

### DIFF
--- a/src/Intervention/Image/Imagick/Decoder.php
+++ b/src/Intervention/Image/Imagick/Decoder.php
@@ -79,6 +79,7 @@ class Decoder extends \Intervention\Image\AbstractDecoder
         $core = new \Imagick;
 
         try {
+            $core->setBackgroundColor(new \ImagickPixel('transparent'));
 
             $core->readImageBlob($binary);
 


### PR DESCRIPTION
Like in issue #580 for read from file - setting the background to transparent is needed when reading SVG from Blob to avoid a white backround