### PR TITLE
Restrict the maximum rotation value to 360 degrees

### DIFF
--- a/src/Intervention/Image/Gd/Commands/RotateCommand.php
+++ b/src/Intervention/Image/Gd/Commands/RotateCommand.php
@@ -18,6 +18,9 @@ class RotateCommand extends \Intervention\Image\Commands\AbstractCommand
         $color = $this->argument(1)->value();
         $color = new Color($color);
 
+        // restrict rotations beyond 360 degrees, since the end result is the same
+        $angle %= 360;
+
         // rotate image
         $image->setCore(imagerotate($image->getCore(), $angle, $color->getInt()));
 

--- a/src/Intervention/Image/Imagick/Commands/RotateCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/RotateCommand.php
@@ -18,6 +18,9 @@ class RotateCommand extends \Intervention\Image\Commands\AbstractCommand
         $color = $this->argument(1)->value();
         $color = new Color($color);
 
+        // restrict rotations beyond 360 degrees, since the end result is the same
+        $angle %= 360;
+
         // rotate image
         $image->getCore()->rotateImage($color->getPixel(), ($angle * -1));
 

--- a/tests/RotateCommandTest.php
+++ b/tests/RotateCommandTest.php
@@ -32,4 +32,16 @@ class RotateCommandTest extends PHPUnit_Framework_TestCase
         $result = $command->execute($image);
         $this->assertTrue($result);
     }
+
+    public function testImagickWithLargeRotation()
+    {
+        $rotation = 45;
+        $imagick = Mockery::mock('Imagick');
+        $imagick->shouldReceive('rotateimage')->with(Mockery::type('object'), -$rotation)->andReturn(true);
+        $image = Mockery::mock('Intervention\Image\Image');
+        $image->shouldReceive('getCore')->once()->andReturn($imagick);
+        $command = new RotateImagick([$rotation + (360 * 1000), '#b53717']);
+        $result = $command->execute($image);
+        $this->assertTrue($result);
+    }
 }


### PR DESCRIPTION
Applying a rotation value more than this may use unnecessary server side resources. For example, rotating an image by 9999999999 degrees causes the PHP process to continue indefinitely for me.