### PR TITLE
Fixed the type hints in the phpDoc blocks

### DIFF
--- a/src/Intervention/Image/AbstractColor.php
+++ b/src/Intervention/Image/AbstractColor.php
@@ -7,7 +7,7 @@ abstract class AbstractColor
     /**
      * Initiates color object from integer
      *
-     * @param  integer $value
+     * @param  int $value
      * @return \Intervention\Image\AbstractColor
      */
     abstract public function initFromInteger($value);
@@ -39,9 +39,9 @@ abstract class AbstractColor
     /**
      * Initiates color object from given R, G and B values
      *
-     * @param  integer $r
-     * @param  integer $g
-     * @param  integer $b
+     * @param  int $r
+     * @param  int $g
+     * @param  int $b
      * @return \Intervention\Image\AbstractColor
      */
     abstract public function initFromRgb($r, $g, $b);
@@ -49,9 +49,9 @@ abstract class AbstractColor
     /**
      * Initiates color object from given R, G, B and A values
      *
-     * @param  integer $r
-     * @param  integer $g
-     * @param  integer $b
+     * @param  int $r
+     * @param  int $g
+     * @param  int $b
      * @param  float   $a
      * @return \Intervention\Image\AbstractColor
      */
@@ -60,7 +60,7 @@ abstract class AbstractColor
     /**
      * Calculates integer value of current color instance
      *
-     * @return integer
+     * @return int
      */
     abstract public function getInt();
 
@@ -90,7 +90,7 @@ abstract class AbstractColor
      * Determines if current color is different from given color
      *
      * @param  AbstractColor $color
-     * @param  integer       $tolerance
+     * @param  int           $tolerance
      * @return boolean
      */
     abstract public function differs(AbstractColor $color, $tolerance = 0);

--- a/src/Intervention/Image/AbstractDriver.php
+++ b/src/Intervention/Image/AbstractDriver.php
@@ -21,8 +21,8 @@ abstract class AbstractDriver
     /**
      * Creates new image instance
      *
-     * @param  integer $width
-     * @param  integer $height
+     * @param  int     $width
+     * @param  int     $height
      * @param  string  $background
      * @return \Intervention\Image\Image
      */
@@ -69,7 +69,7 @@ abstract class AbstractDriver
      *
      * @param  Image   $image
      * @param  string  $format
-     * @param  integer $quality
+     * @param  int     $quality
      * @return \Intervention\Image\Image
      */
     public function encode($image, $format, $quality)

--- a/src/Intervention/Image/AbstractEncoder.php
+++ b/src/Intervention/Image/AbstractEncoder.php
@@ -28,7 +28,7 @@ abstract class AbstractEncoder
     /**
      * Output quality of encoder instance
      *
-     * @var integer
+     * @var int
      */
     public $quality;
     
@@ -86,7 +86,7 @@ abstract class AbstractEncoder
      *
      * @param  Image   $image
      * @param  string  $format
-     * @param  integer $quality
+     * @param  int     $quality
      * @return Image
      */
     public function process(Image $image, $format = null, $quality = null)
@@ -214,7 +214,7 @@ abstract class AbstractEncoder
     /**
      * Determines output quality
      *
-     * @param integer $quality
+     * @param int $quality
      */
     protected function setQuality($quality)
     {

--- a/src/Intervention/Image/AbstractFont.php
+++ b/src/Intervention/Image/AbstractFont.php
@@ -14,7 +14,7 @@ abstract class AbstractFont
     /**
      * Text size in pixels
      *
-     * @var integer
+     * @var int
      */
     public $size = 12;
 
@@ -28,7 +28,7 @@ abstract class AbstractFont
     /**
      * Rotation angle of the text
      *
-     * @var integer
+     * @var int
      */
     public $angle = 0;
 
@@ -57,8 +57,8 @@ abstract class AbstractFont
      * Draws font to given image on given position
      *
      * @param  Image   $image
-     * @param  integer $posx
-     * @param  integer $posy
+     * @param  int     $posx
+     * @param  int     $posy
      * @return boolean
      */
     abstract public function applyToImage(Image $image, $posx = 0, $posy = 0);
@@ -106,7 +106,7 @@ abstract class AbstractFont
     /**
      * Set font size in pixels
      *
-     * @param  integer $size
+     * @param  int $size
      * @return void
      */
     public function size($size)
@@ -119,7 +119,7 @@ abstract class AbstractFont
     /**
      * Get font size in pixels
      *
-     * @return integer
+     * @return int
      */
     public function getSize()
     {
@@ -152,7 +152,7 @@ abstract class AbstractFont
     /**
      * Set rotation angle of text
      *
-     * @param  integer $angle
+     * @param  int $angle
      * @return void
      */
     public function angle($angle)
@@ -165,7 +165,7 @@ abstract class AbstractFont
     /**
      * Get rotation angle of text
      *
-     * @return integer
+     * @return int
      */
     public function getAngle()
     {
@@ -258,7 +258,7 @@ abstract class AbstractFont
     /**
      * Counts lines of text to be written
      *
-     * @return integer
+     * @return int
      */
     public function countLines()
     {

--- a/src/Intervention/Image/AbstractShape.php
+++ b/src/Intervention/Image/AbstractShape.php
@@ -21,7 +21,7 @@ abstract class AbstractShape
     /**
      * Border width of shape
      *
-     * @var integer
+     * @var int
      */
     public $border_width = 0;
 
@@ -29,8 +29,8 @@ abstract class AbstractShape
      * Draws shape to given image on given position
      *
      * @param  Image   $image
-     * @param  integer $posx
-     * @param  integer $posy
+     * @param  int     $posx
+     * @param  int     $posy
      * @return boolean
      */
     abstract public function applyToImage(Image $image, $posx = 0, $posy = 0);
@@ -49,7 +49,7 @@ abstract class AbstractShape
     /**
      * Set border width and color of current shape
      *
-     * @param  integer $width
+     * @param  int     $width
      * @param  string  $color
      * @return void
      */

--- a/src/Intervention/Image/Commands/AbstractCommand.php
+++ b/src/Intervention/Image/Commands/AbstractCommand.php
@@ -39,7 +39,7 @@ abstract class AbstractCommand
     /**
      * Creates new argument instance from given argument key
      *
-     * @param  integer $key
+     * @param  int $key
      * @return \Intervention\Image\Commands\Argument
      */
     public function argument($key)

--- a/src/Intervention/Image/Commands/Argument.php
+++ b/src/Intervention/Image/Commands/Argument.php
@@ -14,7 +14,7 @@ class Argument
     /**
      * Key of argument in array
      *
-     * @var integer
+     * @var int
      */
     public $key;
 
@@ -22,7 +22,7 @@ class Argument
      * Creates new instance from given command and key
      *
      * @param AbstractCommand $command
-     * @param integer         $key
+     * @param int             $key
      */
     public function __construct(AbstractCommand $command, $key = 0)
     {

--- a/src/Intervention/Image/Constraint.php
+++ b/src/Intervention/Image/Constraint.php
@@ -24,7 +24,7 @@ class Constraint
     /**
      * Integer value of fixed parameters
      *
-     * @var integer
+     * @var int
      */
     private $fixed = 0;
 
@@ -51,7 +51,7 @@ class Constraint
     /**
      * Fix the given argument in current constraint
      *
-     * @param  integer $type
+     * @param  int $type
      * @return void
      */
     public function fix($type)
@@ -62,7 +62,7 @@ class Constraint
     /**
      * Checks if given argument is fixed in current constraint
      *
-     * @param  integer  $type
+     * @param  int  $type
      * @return boolean
      */
     public function isFixed($type)

--- a/src/Intervention/Image/Filters/DemoFilter.php
+++ b/src/Intervention/Image/Filters/DemoFilter.php
@@ -12,14 +12,14 @@ class DemoFilter implements FilterInterface
     /**
      * Size of filter effects
      *
-     * @var integer
+     * @var int
      */
     private $size;
 
     /**
      * Creates new instance of filter
      *
-     * @param integer $size
+     * @param int $size
      */
     public function __construct($size = null)
     {

--- a/src/Intervention/Image/Gd/Color.php
+++ b/src/Intervention/Image/Gd/Color.php
@@ -9,21 +9,21 @@ class Color extends AbstractColor
     /**
      * RGB Red value of current color instance
      *
-     * @var integer
+     * @var int
      */
     public $r;
 
     /**
      * RGB Green value of current color instance
      *
-     * @var integer
+     * @var int
      */
     public $g;
 
     /**
      * RGB Blue value of current color instance
      *
-     * @var integer
+     * @var int
      */
     public $b;
 
@@ -37,7 +37,7 @@ class Color extends AbstractColor
     /**
      * Initiates color object from integer
      *
-     * @param  integer $value
+     * @param  int $value
      * @return \Intervention\Image\AbstractColor
      */
     public function initFromInteger($value)
@@ -96,9 +96,9 @@ class Color extends AbstractColor
     /**
      * Initiates color object from given R, G and B values
      *
-     * @param  integer $r
-     * @param  integer $g
-     * @param  integer $b
+     * @param  int $r
+     * @param  int $g
+     * @param  int $b
      * @return \Intervention\Image\AbstractColor
      */
     public function initFromRgb($r, $g, $b)
@@ -112,9 +112,9 @@ class Color extends AbstractColor
     /**
      * Initiates color object from given R, G, B and A values
      *
-     * @param  integer $r
-     * @param  integer $g
-     * @param  integer $b
+     * @param  int     $r
+     * @param  int     $g
+     * @param  int     $b
      * @param  float   $a
      * @return \Intervention\Image\AbstractColor
      */
@@ -142,7 +142,7 @@ class Color extends AbstractColor
     /**
      * Calculates integer value of current color instance
      *
-     * @return integer
+     * @return int
      */
     public function getInt()
     {
@@ -184,7 +184,7 @@ class Color extends AbstractColor
      * Determines if current color is different from given color
      *
      * @param  AbstractColor $color
-     * @param  integer       $tolerance
+     * @param  int       $tolerance
      * @return boolean
      */
     public function differs(AbstractColor $color, $tolerance = 0)

--- a/src/Intervention/Image/Gd/Commands/ResizeCommand.php
+++ b/src/Intervention/Image/Gd/Commands/ResizeCommand.php
@@ -29,14 +29,14 @@ class ResizeCommand extends \Intervention\Image\Commands\AbstractCommand
      * Wrapper function for 'imagecopyresampled'
      *
      * @param  Image   $image
-     * @param  integer $dst_x
-     * @param  integer $dst_y
-     * @param  integer $src_x
-     * @param  integer $src_y
-     * @param  integer $dst_w
-     * @param  integer $dst_h
-     * @param  integer $src_w
-     * @param  integer $src_h
+     * @param  int     $dst_x
+     * @param  int     $dst_y
+     * @param  int     $src_x
+     * @param  int     $src_y
+     * @param  int     $dst_w
+     * @param  int     $dst_h
+     * @param  int     $src_w
+     * @param  int     $src_h
      * @return boolean
      */
     protected function modify($image, $dst_x, $dst_y, $src_x, $src_y, $dst_w, $dst_h, $src_w, $src_h)

--- a/src/Intervention/Image/Gd/Driver.php
+++ b/src/Intervention/Image/Gd/Driver.php
@@ -25,8 +25,8 @@ class Driver extends \Intervention\Image\AbstractDriver
     /**
      * Creates new image instance
      *
-     * @param  integer $width
-     * @param  integer $height
+     * @param  int     $width
+     * @param  int     $height
      * @param  mixed   $background
      * @return \Intervention\Image\Image
      */

--- a/src/Intervention/Image/Gd/Font.php
+++ b/src/Intervention/Image/Gd/Font.php
@@ -9,7 +9,7 @@ class Font extends \Intervention\Image\AbstractFont
     /**
      * Get font size in points
      *
-     * @return integer
+     * @return int
      */
     protected function getPointSize()
     {
@@ -19,7 +19,7 @@ class Font extends \Intervention\Image\AbstractFont
     /**
      * Filter function to access internal integer font values
      *
-     * @return integer
+     * @return int
      */
     private function getInternalFont()
     {
@@ -38,7 +38,7 @@ class Font extends \Intervention\Image\AbstractFont
     /**
      * Get width of an internal font character
      *
-     * @return integer
+     * @return int
      */
     private function getInternalFontWidth()
     {
@@ -48,7 +48,7 @@ class Font extends \Intervention\Image\AbstractFont
     /**
      * Get height of an internal font character
      *
-     * @return integer
+     * @return int
      */
     private function getInternalFontHeight()
     {
@@ -124,8 +124,8 @@ class Font extends \Intervention\Image\AbstractFont
      * Draws font to given image at given position
      *
      * @param  Image   $image
-     * @param  integer $posx
-     * @param  integer $posy
+     * @param  int     $posx
+     * @param  int     $posy
      * @return void
      */
     public function applyToImage(Image $image, $posx = 0, $posy = 0)

--- a/src/Intervention/Image/Gd/Shapes/CircleShape.php
+++ b/src/Intervention/Image/Gd/Shapes/CircleShape.php
@@ -9,14 +9,14 @@ class CircleShape extends EllipseShape
     /**
      * Diameter of circle in pixels
      *
-     * @var integer
+     * @var int
      */
     public $diameter = 100;
 
     /**
      * Create new instance of circle
      *
-     * @param integer $diameter
+     * @param int $diameter
      */
     public function __construct($diameter = null)
     {
@@ -29,8 +29,8 @@ class CircleShape extends EllipseShape
      * Draw current circle on given image
      *
      * @param  Image   $image
-     * @param  integer $x
-     * @param  integer $y
+     * @param  int     $x
+     * @param  int     $y
      * @return boolean
      */
     public function applyToImage(Image $image, $x = 0, $y = 0)

--- a/src/Intervention/Image/Gd/Shapes/EllipseShape.php
+++ b/src/Intervention/Image/Gd/Shapes/EllipseShape.php
@@ -10,22 +10,22 @@ class EllipseShape extends \Intervention\Image\AbstractShape
     /**
      * Width of ellipse in pixels
      *
-     * @var integer
+     * @var int
      */
     public $width = 100;
 
     /**
      * Height of ellipse in pixels
      *
-     * @var integer
+     * @var int
      */
     public $height = 100;
 
     /**
      * Create new ellipse instance
      *
-     * @param integer $width
-     * @param integer $height
+     * @param int $width
+     * @param int $height
      */
     public function __construct($width = null, $height = null)
     {
@@ -37,8 +37,8 @@ class EllipseShape extends \Intervention\Image\AbstractShape
      * Draw ellipse instance on given image
      *
      * @param  Image   $image
-     * @param  integer $x
-     * @param  integer $y
+     * @param  int     $x
+     * @param  int     $y
      * @return boolean
      */
     public function applyToImage(Image $image, $x = 0, $y = 0)

--- a/src/Intervention/Image/Gd/Shapes/LineShape.php
+++ b/src/Intervention/Image/Gd/Shapes/LineShape.php
@@ -10,14 +10,14 @@ class LineShape extends \Intervention\Image\AbstractShape
     /**
      * Starting point x-coordinate of line
      *
-     * @var integer
+     * @var int
      */
     public $x = 0;
 
     /**
      * Starting point y-coordinate of line
      *
-     * @var integer
+     * @var int
      */
     public $y = 0;
 
@@ -31,15 +31,15 @@ class LineShape extends \Intervention\Image\AbstractShape
     /**
      * Width of line in pixels
      *
-     * @var integer
+     * @var int
      */
     public $width = 1;
 
     /**
      * Create new line shape instance
      *
-     * @param integer $x
-     * @param integer $y
+     * @param int $x
+     * @param int $y
      */
     public function __construct($x = null, $y = null)
     {
@@ -61,7 +61,7 @@ class LineShape extends \Intervention\Image\AbstractShape
     /**
      * Set current line width in pixels
      *
-     * @param  integer $width
+     * @param  int $width
      * @return void
      */
     public function width($width)
@@ -75,8 +75,8 @@ class LineShape extends \Intervention\Image\AbstractShape
      * Draw current instance of line to given endpoint on given image
      *
      * @param  Image   $image
-     * @param  integer $x
-     * @param  integer $y
+     * @param  int     $x
+     * @param  int     $y
      * @return boolean
      */
     public function applyToImage(Image $image, $x = 0, $y = 0)

--- a/src/Intervention/Image/Gd/Shapes/PolygonShape.php
+++ b/src/Intervention/Image/Gd/Shapes/PolygonShape.php
@@ -10,7 +10,7 @@ class PolygonShape extends \Intervention\Image\AbstractShape
     /**
      * Array of points of polygon
      *
-     * @var integer
+     * @var int
      */
     public $points;
 
@@ -28,8 +28,8 @@ class PolygonShape extends \Intervention\Image\AbstractShape
      * Draw polygon on given image
      *
      * @param  Image   $image
-     * @param  integer $x
-     * @param  integer $y
+     * @param  int     $x
+     * @param  int     $y
      * @return boolean
      */
     public function applyToImage(Image $image, $x = 0, $y = 0)

--- a/src/Intervention/Image/Gd/Shapes/RectangleShape.php
+++ b/src/Intervention/Image/Gd/Shapes/RectangleShape.php
@@ -10,38 +10,38 @@ class RectangleShape extends \Intervention\Image\AbstractShape
     /**
      * X-Coordinate of top-left point
      *
-     * @var integer
+     * @var int
      */
     public $x1 = 0;
 
     /**
      * Y-Coordinate of top-left point
      *
-     * @var integer
+     * @var int
      */
     public $y1 = 0;
 
     /**
      * X-Coordinate of bottom-right point
      *
-     * @var integer
+     * @var int
      */
     public $x2 = 0;
 
     /**
      * Y-Coordinate of bottom-right point
      *
-     * @var integer
+     * @var int
      */
     public $y2 = 0;
 
     /**
      * Create new rectangle shape instance
      *
-     * @param integer $x1
-     * @param integer $y1
-     * @param integer $x2
-     * @param integer $y2
+     * @param int $x1
+     * @param int $y1
+     * @param int $x2
+     * @param int $y2
      */
     public function __construct($x1 = null, $y1 = null, $x2 = null, $y2 = null)
     {
@@ -55,8 +55,8 @@ class RectangleShape extends \Intervention\Image\AbstractShape
      * Draw rectangle to given image at certain position
      *
      * @param  Image   $image
-     * @param  integer $x
-     * @param  integer $y
+     * @param  int     $x
+     * @param  int     $y
      * @return boolean
      */
     public function applyToImage(Image $image, $x = 0, $y = 0)

--- a/src/Intervention/Image/Image.php
+++ b/src/Intervention/Image/Image.php
@@ -7,49 +7,49 @@ use Psr\Http\Message\StreamInterface;
 
 /**
  * @method \Intervention\Image\Image backup(string $name = 'default')                                                                                                     Backups current image state as fallback for reset method under an optional name. Overwrites older state on every call, unless a different name is passed.
- * @method \Intervention\Image\Image blur(integer $amount = 1)                                                                                                            Apply a gaussian blur filter with a optional amount on the current image. Use values between 0 and 100.
- * @method \Intervention\Image\Image brightness(integer $level)                                                                                                           Changes the brightness of the current image by the given level. Use values between -100 for min. brightness. 0 for no change and +100 for max. brightness.
- * @method \Intervention\Image\Image cache(\Closure $callback, integer $lifetime = null, boolean $returnObj = false)                                                      Method to create a new cached image instance from a Closure callback. Pass a lifetime in minutes for the callback and decide whether you want to get an Intervention Image instance as return value or just receive the image stream.
- * @method \Intervention\Image\Image canvas(integer $width, integer $height, mixed $bgcolor = null)                                                                       Factory method to create a new empty image instance with given width and height. You can define a background-color optionally. By default the canvas background is transparent.
- * @method \Intervention\Image\Image circle(integer $radius, integer $x, integer $y, \Closure $callback = null)                                                           Draw a circle at given x, y, coordinates with given radius. You can define the appearance of the circle by an optional closure callback.
- * @method \Intervention\Image\Image colorize(integer $red, integer $green, integer $blue)                                                                                Change the RGB color values of the current image on the given channels red, green and blue. The input values are normalized so you have to include parameters from 100 for maximum color value. 0 for no change and -100 to take out all the certain color on the image.
- * @method \Intervention\Image\Image contrast(integer $level)                                                                                                             Changes the contrast of the current image by the given level. Use values between -100 for min. contrast 0 for no change and +100 for max. contrast.
- * @method \Intervention\Image\Image crop(integer $width, integer $height, integer $x = null, integer $y = null)                                                          Cut out a rectangular part of the current image with given width and height. Define optional x,y coordinates to move the top-left corner of the cutout to a certain position.
+ * @method \Intervention\Image\Image blur(int $amount = 1)                                                                                                            Apply a gaussian blur filter with a optional amount on the current image. Use values between 0 and 100.
+ * @method \Intervention\Image\Image brightness(int $level)                                                                                                           Changes the brightness of the current image by the given level. Use values between -100 for min. brightness. 0 for no change and +100 for max. brightness.
+ * @method \Intervention\Image\Image cache(\Closure $callback, int $lifetime = null, boolean $returnObj = false)                                                      Method to create a new cached image instance from a Closure callback. Pass a lifetime in minutes for the callback and decide whether you want to get an Intervention Image instance as return value or just receive the image stream.
+ * @method \Intervention\Image\Image canvas(int $width, int $height, mixed $bgcolor = null)                                                                       Factory method to create a new empty image instance with given width and height. You can define a background-color optionally. By default the canvas background is transparent.
+ * @method \Intervention\Image\Image circle(int $radius, int $x, int $y, \Closure $callback = null)                                                           Draw a circle at given x, y, coordinates with given radius. You can define the appearance of the circle by an optional closure callback.
+ * @method \Intervention\Image\Image colorize(int $red, int $green, int $blue)                                                                                Change the RGB color values of the current image on the given channels red, green and blue. The input values are normalized so you have to include parameters from 100 for maximum color value. 0 for no change and -100 to take out all the certain color on the image.
+ * @method \Intervention\Image\Image contrast(int $level)                                                                                                             Changes the contrast of the current image by the given level. Use values between -100 for min. contrast 0 for no change and +100 for max. contrast.
+ * @method \Intervention\Image\Image crop(int $width, int $height, int $x = null, int $y = null)                                                          Cut out a rectangular part of the current image with given width and height. Define optional x,y coordinates to move the top-left corner of the cutout to a certain position.
  * @method void                      destroy()                                                                                                                            Frees memory associated with the current image instance before the PHP script ends. Normally resources are destroyed automatically after the script is finished.
- * @method \Intervention\Image\Image ellipse(integer $width, integer $height, integer $x, integer $y, \Closure $callback = null)                                          Draw a colored ellipse at given x, y, coordinates. You can define width and height and set the appearance of the circle by an optional closure callback.
+ * @method \Intervention\Image\Image ellipse(int $width, int $height, int $x, int $y, \Closure $callback = null)                                          Draw a colored ellipse at given x, y, coordinates. You can define width and height and set the appearance of the circle by an optional closure callback.
  * @method mixed                     exif(string $key = null)                                                                                                             Read Exif meta data from current image.
  * @method mixed                     iptc(string $key = null)                                                                                                             Read Iptc meta data from current image.
- * @method \Intervention\Image\Image fill(mixed $filling, integer $x = null, integer $y = null)                                                                           Fill current image with given color or another image used as tile for filling. Pass optional x, y coordinates to start at a certain point.
+ * @method \Intervention\Image\Image fill(mixed $filling, int $x = null, int $y = null)                                                                           Fill current image with given color or another image used as tile for filling. Pass optional x, y coordinates to start at a certain point.
  * @method \Intervention\Image\Image flip(string $mode = 'h')                                                                                                             Mirror the current image horizontally or vertically by specifying the mode.
- * @method \Intervention\Image\Image fit(integer $width, integer $height = null, \Closure $callback = null, string $position = 'center')                                  Combine cropping and resizing to format image in a smart way. The method will find the best fitting aspect ratio of your given width and height on the current image automatically, cut it out and resize it to the given dimension. You may pass an optional Closure callback as third parameter, to prevent possible upsizing and a custom position of the cutout as fourth parameter.
+ * @method \Intervention\Image\Image fit(int $width, int $height = null, \Closure $callback = null, string $position = 'center')                                  Combine cropping and resizing to format image in a smart way. The method will find the best fitting aspect ratio of your given width and height on the current image automatically, cut it out and resize it to the given dimension. You may pass an optional Closure callback as third parameter, to prevent possible upsizing and a custom position of the cutout as fourth parameter.
  * @method \Intervention\Image\Image gamma(float $correction)                                                                                                             Performs a gamma correction operation on the current image.
  * @method \Intervention\Image\Image greyscale()                                                                                                                          Turns image into a greyscale version.
- * @method \Intervention\Image\Image heighten(integer $height, \Closure $callback = null)                                                                                 Resizes the current image to new height, constraining aspect ratio. Pass an optional Closure callback as third parameter, to apply additional constraints like preventing possible upsizing.
- * @method \Intervention\Image\Image insert(mixed $source, string $position = 'top-left', integer $x = 0, integer $y = 0)                                                 Paste a given image source over the current image with an optional position and a offset coordinate. This method can be used to apply another image as watermark because the transparency values are maintained.
+ * @method \Intervention\Image\Image heighten(int $height, \Closure $callback = null)                                                                                 Resizes the current image to new height, constraining aspect ratio. Pass an optional Closure callback as third parameter, to apply additional constraints like preventing possible upsizing.
+ * @method \Intervention\Image\Image insert(mixed $source, string $position = 'top-left', int $x = 0, int $y = 0)                                                 Paste a given image source over the current image with an optional position and a offset coordinate. This method can be used to apply another image as watermark because the transparency values are maintained.
  * @method \Intervention\Image\Image interlace(boolean $interlace = true)                                                                                                 Determine whether an image should be encoded in interlaced or standard mode by toggling interlace mode with a boolean parameter. If an JPEG image is set interlaced the image will be processed as a progressive JPEG.
  * @method \Intervention\Image\Image invert()                                                                                                                             Reverses all colors of the current image.
- * @method \Intervention\Image\Image limitColors(integer $count, mixed $matte = null)                                                                                     Method converts the existing colors of the current image into a color table with a given maximum count of colors. The function preserves as much alpha channel information as possible and blends transarent pixels against a optional matte color.
- * @method \Intervention\Image\Image line(integer $x1, integer $y1, integer $x2, integer $y2, \Closure $callback = null)                                                  Draw a line from x,y point 1 to x,y point 2 on current image. Define color and/or width of line in an optional Closure callback.
+ * @method \Intervention\Image\Image limitColors(int $count, mixed $matte = null)                                                                                     Method converts the existing colors of the current image into a color table with a given maximum count of colors. The function preserves as much alpha channel information as possible and blends transarent pixels against a optional matte color.
+ * @method \Intervention\Image\Image line(int $x1, int $y1, int $x2, int $y2, \Closure $callback = null)                                                  Draw a line from x,y point 1 to x,y point 2 on current image. Define color and/or width of line in an optional Closure callback.
  * @method \Intervention\Image\Image make(mixed $source)                                                                                                                  Universal factory method to create a new image instance from source, which can be a filepath, a GD image resource, an Imagick object or a binary image data.
  * @method \Intervention\Image\Image mask(mixed $source, boolean $mask_with_alpha)                                                                                        Apply a given image source as alpha mask to the current image to change current opacity. Mask will be resized to the current image size. By default a greyscale version of the mask is converted to alpha values, but you can set mask_with_alpha to apply the actual alpha channel. Any transparency values of the current image will be maintained.
- * @method \Intervention\Image\Image opacity(integer $transparency)                                                                                                       Set the opacity in percent of the current image ranging from 100% for opaque and 0% for full transparency.
+ * @method \Intervention\Image\Image opacity(int $transparency)                                                                                                       Set the opacity in percent of the current image ranging from 100% for opaque and 0% for full transparency.
  * @method \Intervention\Image\Image orientate()                                                                                                                          This method reads the EXIF image profile setting 'Orientation' and performs a rotation on the image to display the image correctly.
- * @method mixed                     pickColor(integer $x, integer $y, string $format = 'array')                                                                          Pick a color at point x, y out of current image and return in optional given format.
- * @method \Intervention\Image\Image pixel(mixed $color, integer $x, integer $y)                                                                                          Draw a single pixel in given color on x, y position.
- * @method \Intervention\Image\Image pixelate(integer $size)                                                                                                              Applies a pixelation effect to the current image with a given size of pixels.
+ * @method mixed                     pickColor(int $x, int $y, string $format = 'array')                                                                          Pick a color at point x, y out of current image and return in optional given format.
+ * @method \Intervention\Image\Image pixel(mixed $color, int $x, int $y)                                                                                          Draw a single pixel in given color on x, y position.
+ * @method \Intervention\Image\Image pixelate(int $size)                                                                                                              Applies a pixelation effect to the current image with a given size of pixels.
  * @method \Intervention\Image\Image polygon(array $points, \Closure $callback = null)                                                                                    Draw a colored polygon with given points. You can define the appearance of the polygon by an optional closure callback.
- * @method \Intervention\Image\Image rectangle(integer $x1, integer $y1, integer $x2, integer $y2, \Closure $callback = null)                                             Draw a colored rectangle on current image with top-left corner on x,y point 1 and bottom-right corner at x,y point 2. Define the overall appearance of the shape by passing a Closure callback as an optional parameter.
+ * @method \Intervention\Image\Image rectangle(int $x1, int $y1, int $x2, int $y2, \Closure $callback = null)                                             Draw a colored rectangle on current image with top-left corner on x,y point 1 and bottom-right corner at x,y point 2. Define the overall appearance of the shape by passing a Closure callback as an optional parameter.
  * @method \Intervention\Image\Image reset(string $name = 'default')                                                                                                      Resets all of the modifications to a state saved previously by backup under an optional name.
- * @method \Intervention\Image\Image resize(integer $width, integer $height, \Closure $callback = null)                                                                   Resizes current image based on given width and/or height. To contraint the resize command, pass an optional Closure callback as third parameter.
- * @method \Intervention\Image\Image resizeCanvas(integer $width, integer $height, string $anchor = 'center', boolean $relative = false, mixed $bgcolor = null)           Resize the boundaries of the current image to given width and height. An anchor can be defined to determine from what point of the image the resizing is going to happen. Set the mode to relative to add or subtract the given width or height to the actual image dimensions. You can also pass a background color for the emerging area of the image.
- * @method mixed                     response(string $format = null, integer $quality = 90)                                                                               Sends HTTP response with current image in given format and quality.
+ * @method \Intervention\Image\Image resize(int $width, int $height, \Closure $callback = null)                                                                   Resizes current image based on given width and/or height. To contraint the resize command, pass an optional Closure callback as third parameter.
+ * @method \Intervention\Image\Image resizeCanvas(int $width, int $height, string $anchor = 'center', boolean $relative = false, mixed $bgcolor = null)           Resize the boundaries of the current image to given width and height. An anchor can be defined to determine from what point of the image the resizing is going to happen. Set the mode to relative to add or subtract the given width or height to the actual image dimensions. You can also pass a background color for the emerging area of the image.
+ * @method mixed                     response(string $format = null, int $quality = 90)                                                                               Sends HTTP response with current image in given format and quality.
  * @method \Intervention\Image\Image rotate(float $angle, mixed $bgcolor = null)                                                                                          Rotate the current image counter-clockwise by a given angle. Optionally define a background color for the uncovered zone after the rotation.
- * @method \Intervention\Image\Image sharpen(integer $amount = 10)                                                                                                        Sharpen current image with an optional amount. Use values between 0 and 100.
- * @method \Intervention\Image\Image text(string $text, integer $x = 0, integer $y = 0, \Closure $callback = null)                                                        Write a text string to the current image at an optional x,y basepoint position. You can define more details like font-size, font-file and alignment via a callback as the fourth parameter.
- * @method \Intervention\Image\Image trim(string $base = 'top-left', array $away = array('top', 'bottom', 'left', 'right'), integer $tolerance = 0, integer $feather = 0) Trim away image space in given color. Define an optional base to pick a color at a certain position and borders that should be trimmed away. You can also set an optional tolerance level, to trim similar colors and add a feathering border around the trimed image.
- * @method \Intervention\Image\Image widen(integer $width, \Closure $callback = null)                                                                                     Resizes the current image to new width, constraining aspect ratio. Pass an optional Closure callback as third parameter, to apply additional constraints like preventing possible upsizing.
- * @method StreamInterface           stream(string $format = null, integer $quality = 90)                                                                                 Build PSR-7 compatible StreamInterface with current image in given format and quality.
- * @method ResponseInterface         psrResponse(string $format = null, integer $quality = 90)                                                                            Build PSR-7 compatible ResponseInterface with current image in given format and quality.
+ * @method \Intervention\Image\Image sharpen(int $amount = 10)                                                                                                        Sharpen current image with an optional amount. Use values between 0 and 100.
+ * @method \Intervention\Image\Image text(string $text, int $x = 0, int $y = 0, \Closure $callback = null)                                                        Write a text string to the current image at an optional x,y basepoint position. You can define more details like font-size, font-file and alignment via a callback as the fourth parameter.
+ * @method \Intervention\Image\Image trim(string $base = 'top-left', array $away = array('top', 'bottom', 'left', 'right'), int $tolerance = 0, int $feather = 0) Trim away image space in given color. Define an optional base to pick a color at a certain position and borders that should be trimmed away. You can also set an optional tolerance level, to trim similar colors and add a feathering border around the trimed image.
+ * @method \Intervention\Image\Image widen(int $width, \Closure $callback = null)                                                                                     Resizes the current image to new width, constraining aspect ratio. Pass an optional Closure callback as third parameter, to apply additional constraints like preventing possible upsizing.
+ * @method StreamInterface           stream(string $format = null, int $quality = 90)                                                                                 Build PSR-7 compatible StreamInterface with current image in given format and quality.
+ * @method ResponseInterface         psrResponse(string $format = null, int $quality = 90)                                                                            Build PSR-7 compatible ResponseInterface with current image in given format and quality.
  */
 class Image extends File
 {
@@ -111,7 +111,7 @@ class Image extends File
      * Starts encoding of current image
      *
      * @param  string  $format
-     * @param  integer $quality
+     * @param  int     $quality
      * @return \Intervention\Image\Image
      */
     public function encode($format = null, $quality = 90)
@@ -123,7 +123,7 @@ class Image extends File
      * Saves encoded image in filesystem
      *
      * @param  string  $path
-     * @param  integer $quality
+     * @param  int     $quality
      * @return \Intervention\Image\Image
      */
     public function save($path = null, $quality = null)
@@ -296,7 +296,7 @@ class Image extends File
     /**
      * Calculates current image width
      *
-     * @return integer
+     * @return int
      */
     public function getWidth()
     {
@@ -306,7 +306,7 @@ class Image extends File
     /**
      * Alias of getWidth()
      *
-     * @return integer
+     * @return int
      */
     public function width()
     {
@@ -316,7 +316,7 @@ class Image extends File
     /**
      * Calculates current image height
      *
-     * @return integer
+     * @return int
      */
     public function getHeight()
     {
@@ -326,7 +326,7 @@ class Image extends File
     /**
      * Alias of getHeight
      *
-     * @return integer
+     * @return int
      */
     public function height()
     {

--- a/src/Intervention/Image/ImageManager.php
+++ b/src/Intervention/Image/ImageManager.php
@@ -53,8 +53,8 @@ class ImageManager
     /**
      * Creates an empty image canvas
      *
-     * @param  integer $width
-     * @param  integer $height
+     * @param  int   $width
+     * @param  int   $height
      * @param  mixed $background
      *
      * @return \Intervention\Image\Image
@@ -69,7 +69,7 @@ class ImageManager
      * (requires additional package intervention/imagecache)
      *
      * @param Closure $callback
-     * @param integer $lifetime
+     * @param int     $lifetime
      * @param boolean $returnObj
      *
      * @return Image

--- a/src/Intervention/Image/ImageManagerStatic.php
+++ b/src/Intervention/Image/ImageManagerStatic.php
@@ -60,8 +60,8 @@ class ImageManagerStatic
     /**
      * Statically creates an empty image canvas
      *
-     * @param  integer $width
-     * @param  integer $height
+     * @param  int   $width
+     * @param  int   $height
      * @param  mixed $background
      *
      * @return \Intervention\Image\Image
@@ -75,7 +75,7 @@ class ImageManagerStatic
      * Create new cached image and run callback statically
      *
      * @param  Closure  $callback
-     * @param  integer  $lifetime
+     * @param  int      $lifetime
      * @param  boolean  $returnObj
      *
      * @return mixed

--- a/src/Intervention/Image/Imagick/Color.php
+++ b/src/Intervention/Image/Imagick/Color.php
@@ -14,7 +14,7 @@ class Color extends \Intervention\Image\AbstractColor
     /**
      * Initiates color object from integer
      *
-     * @param  integer $value
+     * @param  int $value
      * @return \Intervention\Image\AbstractColor
      */
     public function initFromInteger($value)
@@ -84,9 +84,9 @@ class Color extends \Intervention\Image\AbstractColor
     /**
      * Initiates color object from given R, G and B values
      *
-     * @param  integer $r
-     * @param  integer $g
-     * @param  integer $b
+     * @param  int $r
+     * @param  int $g
+     * @param  int $b
      *
      * @return \Intervention\Image\AbstractColor
      */
@@ -98,9 +98,9 @@ class Color extends \Intervention\Image\AbstractColor
     /**
      * Initiates color object from given R, G, B and A values
      *
-     * @param  integer $r
-     * @param  integer $g
-     * @param  integer $b
+     * @param  int     $r
+     * @param  int     $g
+     * @param  int     $b
      * @param  float   $a
      *
      * @return \Intervention\Image\AbstractColor
@@ -113,7 +113,7 @@ class Color extends \Intervention\Image\AbstractColor
     /**
      * Calculates integer value of current color instance
      *
-     * @return integer
+     * @return int
      */
     public function getInt()
     {
@@ -175,7 +175,7 @@ class Color extends \Intervention\Image\AbstractColor
      * Determines if current color is different from given color
      *
      * @param  AbstractColor $color
-     * @param  integer       $tolerance
+     * @param  int           $tolerance
      * @return boolean
      */
     public function differs(\Intervention\Image\AbstractColor $color, $tolerance = 0)
@@ -201,7 +201,7 @@ class Color extends \Intervention\Image\AbstractColor
     /**
      * Returns RGB red value of current color
      *
-     * @return integer
+     * @return int
      */
     public function getRedValue()
     {
@@ -211,7 +211,7 @@ class Color extends \Intervention\Image\AbstractColor
     /**
      * Returns RGB green value of current color
      *
-     * @return integer
+     * @return int
      */
     public function getGreenValue()
     {
@@ -221,7 +221,7 @@ class Color extends \Intervention\Image\AbstractColor
     /**
      * Returns RGB blue value of current color
      *
-     * @return integer
+     * @return int
      */
     public function getBlueValue()
     {
@@ -265,7 +265,7 @@ class Color extends \Intervention\Image\AbstractColor
     /**
      * Calculates RGA integer alpha value into float value
      *
-     * @param  integer $value
+     * @param  int $value
      * @return float
      */
     private function rgb2alpha($value)

--- a/src/Intervention/Image/Imagick/Driver.php
+++ b/src/Intervention/Image/Imagick/Driver.php
@@ -25,8 +25,8 @@ class Driver extends \Intervention\Image\AbstractDriver
     /**
      * Creates new image instance
      *
-     * @param  integer $width
-     * @param  integer $height
+     * @param  int     $width
+     * @param  int     $height
      * @param  mixed   $background
      * @return \Intervention\Image\Image
      */

--- a/src/Intervention/Image/Imagick/Font.php
+++ b/src/Intervention/Image/Imagick/Font.php
@@ -10,8 +10,8 @@ class Font extends \Intervention\Image\AbstractFont
      * Draws font to given image at given position
      *
      * @param  Image   $image
-     * @param  integer $posx
-     * @param  integer $posy
+     * @param  int     $posx
+     * @param  int     $posy
      * @return void
      */
     public function applyToImage(Image $image, $posx = 0, $posy = 0)

--- a/src/Intervention/Image/Imagick/Shapes/CircleShape.php
+++ b/src/Intervention/Image/Imagick/Shapes/CircleShape.php
@@ -9,14 +9,14 @@ class CircleShape extends EllipseShape
     /**
      * Diameter of circle in pixels
      *
-     * @var integer
+     * @var int
      */
     public $diameter = 100;
 
     /**
      * Create new instance of circle
      *
-     * @param integer $diameter
+     * @param int $diameter
      */
     public function __construct($diameter = null)
     {
@@ -29,8 +29,8 @@ class CircleShape extends EllipseShape
      * Draw current circle on given image
      *
      * @param  Image   $image
-     * @param  integer $x
-     * @param  integer $y
+     * @param  int     $x
+     * @param  int     $y
      * @return boolean
      */
     public function applyToImage(Image $image, $x = 0, $y = 0)

--- a/src/Intervention/Image/Imagick/Shapes/EllipseShape.php
+++ b/src/Intervention/Image/Imagick/Shapes/EllipseShape.php
@@ -10,22 +10,22 @@ class EllipseShape extends \Intervention\Image\AbstractShape
     /**
      * Width of ellipse in pixels
      *
-     * @var integer
+     * @var int
      */
     public $width = 100;
 
     /**
      * Height of ellipse in pixels
      *
-     * @var integer
+     * @var int
      */
     public $height = 100;
 
     /**
      * Create new ellipse instance
      *
-     * @param integer $width
-     * @param integer $height
+     * @param int $width
+     * @param int $height
      */
     public function __construct($width = null, $height = null)
     {
@@ -37,8 +37,8 @@ class EllipseShape extends \Intervention\Image\AbstractShape
      * Draw ellipse instance on given image
      *
      * @param  Image   $image
-     * @param  integer $x
-     * @param  integer $y
+     * @param  int     $x
+     * @param  int     $y
      * @return boolean
      */
     public function applyToImage(Image $image, $x = 0, $y = 0)

--- a/src/Intervention/Image/Imagick/Shapes/LineShape.php
+++ b/src/Intervention/Image/Imagick/Shapes/LineShape.php
@@ -10,14 +10,14 @@ class LineShape extends \Intervention\Image\AbstractShape
     /**
      * Starting point x-coordinate of line
      *
-     * @var integer
+     * @var int
      */
     public $x = 0;
 
     /**
      * Starting point y-coordinate of line
      *
-     * @var integer
+     * @var int
      */
     public $y = 0;
 
@@ -31,15 +31,15 @@ class LineShape extends \Intervention\Image\AbstractShape
     /**
      * Width of line in pixels
      *
-     * @var integer
+     * @var int
      */
     public $width = 1;
 
     /**
      * Create new line shape instance
      *
-     * @param integer $x
-     * @param integer $y
+     * @param int $x
+     * @param int $y
      */
     public function __construct($x = null, $y = null)
     {
@@ -61,7 +61,7 @@ class LineShape extends \Intervention\Image\AbstractShape
     /**
      * Set current line width in pixels
      *
-     * @param  integer $width
+     * @param  int $width
      * @return void
      */
     public function width($width)
@@ -73,8 +73,8 @@ class LineShape extends \Intervention\Image\AbstractShape
      * Draw current instance of line to given endpoint on given image
      *
      * @param  Image   $image
-     * @param  integer $x
-     * @param  integer $y
+     * @param  int     $x
+     * @param  int     $y
      * @return boolean
      */
     public function applyToImage(Image $image, $x = 0, $y = 0)

--- a/src/Intervention/Image/Imagick/Shapes/PolygonShape.php
+++ b/src/Intervention/Image/Imagick/Shapes/PolygonShape.php
@@ -28,8 +28,8 @@ class PolygonShape extends \Intervention\Image\AbstractShape
      * Draw polygon on given image
      *
      * @param  Image   $image
-     * @param  integer $x
-     * @param  integer $y
+     * @param  int     $x
+     * @param  int     $y
      * @return boolean
      */
     public function applyToImage(Image $image, $x = 0, $y = 0)

--- a/src/Intervention/Image/Imagick/Shapes/RectangleShape.php
+++ b/src/Intervention/Image/Imagick/Shapes/RectangleShape.php
@@ -10,38 +10,38 @@ class RectangleShape extends \Intervention\Image\AbstractShape
     /**
      * X-Coordinate of top-left point
      *
-     * @var integer
+     * @var int
      */
     public $x1 = 0;
 
     /**
      * Y-Coordinate of top-left point
      *
-     * @var integer
+     * @var int
      */
     public $y1 = 0;
 
     /**
      * X-Coordinate of bottom-right point
      *
-     * @var integer
+     * @var int
      */
     public $x2 = 0;
 
     /**
      * Y-Coordinate of bottom-right point
      *
-     * @var integer
+     * @var int
      */
     public $y2 = 0;
 
     /**
      * Create new rectangle shape instance
      *
-     * @param integer $x1
-     * @param integer $y1
-     * @param integer $x2
-     * @param integer $y2
+     * @param int $x1
+     * @param int $y1
+     * @param int $x2
+     * @param int $y2
      */
     public function __construct($x1 = null, $y1 = null, $x2 = null, $y2 = null)
     {
@@ -55,8 +55,8 @@ class RectangleShape extends \Intervention\Image\AbstractShape
      * Draw rectangle to given image at certain position
      *
      * @param  Image   $image
-     * @param  integer $x
-     * @param  integer $y
+     * @param  int     $x
+     * @param  int     $y
      * @return boolean
      */
     public function applyToImage(Image $image, $x = 0, $y = 0)

--- a/src/Intervention/Image/Point.php
+++ b/src/Intervention/Image/Point.php
@@ -7,22 +7,22 @@ class Point
     /**
      * X coordinate
      *
-     * @var integer
+     * @var int
      */
     public $x;
 
     /**
      * Y coordinate
      *
-     * @var integer
+     * @var int
      */
     public $y;
 
     /**
      * Creates a new instance
      *
-     * @param integer $x
-     * @param integer $y
+     * @param int $x
+     * @param int $y
      */
     public function __construct($x = null, $y = null)
     {
@@ -33,7 +33,7 @@ class Point
     /**
      * Sets X coordinate
      *
-     * @param integer $x
+     * @param int $x
      */
     public function setX($x)
     {
@@ -43,7 +43,7 @@ class Point
     /**
      * Sets Y coordinate
      *
-     * @param integer $y
+     * @param int $y
      */
     public function setY($y)
     {
@@ -53,8 +53,8 @@ class Point
     /**
      * Sets both X and Y coordinate
      *
-     * @param integer $x
-     * @param integer $y
+     * @param int $x
+     * @param int $y
      */
     public function setPosition($x, $y)
     {

--- a/src/Intervention/Image/Response.php
+++ b/src/Intervention/Image/Response.php
@@ -21,7 +21,7 @@ class Response
     /**
      * Quality of displayed image
      *
-     * @var integer
+     * @var int
      */
     public $quality;
 
@@ -30,7 +30,7 @@ class Response
      *
      * @param Image   $image
      * @param string  $format
-     * @param integer $quality
+     * @param int     $quality
      */
     public function __construct(Image $image, $format = null, $quality = null)
     {

--- a/src/Intervention/Image/Size.php
+++ b/src/Intervention/Image/Size.php
@@ -9,14 +9,14 @@ class Size
     /**
      * Width
      *
-     * @var integer
+     * @var int
      */
     public $width;
 
     /**
      * Height
      *
-     * @var integer
+     * @var int
      */
     public $height;
 
@@ -30,9 +30,9 @@ class Size
     /**
      * Creates a new Size instance
      *
-     * @param integer $width
-     * @param integer $height
-     * @param Point   $pivot
+     * @param int   $width
+     * @param int   $height
+     * @param Point $pivot
      */
     public function __construct($width = null, $height = null, Point $pivot = null)
     {
@@ -44,8 +44,8 @@ class Size
     /**
      * Set the width and height absolutely
      *
-     * @param integer $width
-     * @param integer $height
+     * @param int $width
+     * @param int $height
      */
     public function set($width, $height)
     {
@@ -66,7 +66,7 @@ class Size
     /**
      * Get the current width
      *
-     * @return integer
+     * @return int
      */
     public function getWidth()
     {
@@ -76,7 +76,7 @@ class Size
     /**
      * Get the current height
      *
-     * @return integer
+     * @return int
      */
     public function getHeight()
     {
@@ -96,8 +96,8 @@ class Size
     /**
      * Resize to desired width and/or height
      *
-     * @param  integer $width
-     * @param  integer $height
+     * @param  int     $width
+     * @param  int     $height
      * @param  Closure $callback
      * @return Size
      */
@@ -132,7 +132,7 @@ class Size
     /**
      * Scale size according to given constraints
      *
-     * @param  integer $width
+     * @param  int     $width
      * @param  Closure $callback
      * @return Size
      */
@@ -168,7 +168,7 @@ class Size
     /**
      * Scale size according to given constraints
      *
-     * @param  integer $height
+     * @param  int     $height
      * @param  Closure $callback
      * @return Size
      */
@@ -271,8 +271,8 @@ class Size
      * and moves point automatically by offset.
      *
      * @param  string  $position
-     * @param  integer $offset_x
-     * @param  integer $offset_y
+     * @param  int     $offset_x
+     * @param  int     $offset_y
      * @return \Intervention\Image\Size
      */
     public function align($position, $offset_x = 0, $offset_y = 0)


### PR DESCRIPTION
IDEs like PhpStorm emit warnings in some methods:

![2018-04-08 20 47 47](https://user-images.githubusercontent.com/9006227/38466953-894a18ac-3b74-11e8-87ec-80577a2a4606.png)

It happens because there is no type `integer` in PHP, you can't set the `integer` type to a function argument:

![2018-04-08 20 49 12](https://user-images.githubusercontent.com/9006227/38466960-a43e498a-3b74-11e8-8c7c-5ee3235e34c2.png)
 
I replaced all the `integer` types with `int` so IDEs don't produce produce such warnings anymore.
