### PR TITLE
fix resize image bug on windows os

### DIFF
--- a/src/Intervention/Image/AbstractEncoder.php
+++ b/src/Intervention/Image/AbstractEncoder.php
@@ -117,6 +117,7 @@ abstract class AbstractEncoder
             case 'image/jpg':
             case 'image/jpeg':
             case 'image/pjpeg':
+            case 'tmp':
                 $this->result = $this->processJpeg();
                 break;
 


### PR DESCRIPTION
```
NotSupportedException in AbstractEncoder.php line 151: Encodingformat (tmp) is not supported.
```
The reason for this bug is that during the upload process, the image extension identified by the system is named tmp, so it is not possible to find a suitable method to store the image. But it is said that this phenomenon only appears in the windows system, it does not exist in linux.