### PR TITLE
- make private method protected

### DIFF
--- a/src/Intervention/Image/ImageServiceProviderLaravel5.php
+++ b/src/Intervention/Image/ImageServiceProviderLaravel5.php
@@ -59,7 +59,7 @@ class ImageServiceProviderLaravel5 extends ServiceProvider
      *
      * @return void
      */
-    private function bootstrapImageCache()
+    protected function bootstrapImageCache()
     {
         $app = $this->app;
         $config = __DIR__.'/../../../../imagecache/src/config/config.php';


### PR DESCRIPTION
This is useful when you want to override this method, for example when used with imagecache to set it to look for images in AWS S3 as well. 