### PR TITLE
initFromUrl Use Curl to download pictures first

### DIFF
--- a/src/Intervention/Image/AbstractDecoder.php
+++ b/src/Intervention/Image/AbstractDecoder.php
@@ -64,25 +64,41 @@ abstract class AbstractDecoder
      */
     public function initFromUrl($url)
     {
-        
-        $options = [
-            'http' => [
-                'method'=>"GET",
-                'header'=>"Accept-language: en\r\n".
-                "User-Agent: Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.2 (KHTML, like Gecko) Chrome/22.0.1216.0 Safari/537.2\r\n"
-          ]
-        ];
-        
-        $context  = stream_context_create($options);
-        
+        // Use Curl to download pictures first
+        if (function_exists('curl_init')) {
+            $ch = curl_init();
+            curl_setopt($ch, CURLOPT_URL, $url);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+            curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+            $data = curl_exec($ch);
+            curl_close($ch);
 
-        if ($data = @file_get_contents($url, false, $context)) {
-            return $this->initFromBinary($data);
+            if ($data) {
+                return $this->initFromBinary($data);
+            }
+
+            throw new \Intervention\Image\Exception\NotReadableException(
+                "Curl unable to init from given url (".$url.")"
+            );
+        } else {
+            $options = [
+                'http' => [
+                    'method'=>"GET",
+                    'header'=>"Accept-language: en\r\n".
+                        "User-Agent: Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.2 (KHTML, like Gecko) Chrome/22.0.1216.0 Safari/537.2\r\n"
+                ]
+            ];
+
+            $context  = stream_context_create($options);
+
+            if ($data = @file_get_contents($url, false, $context)) {
+                return $this->initFromBinary($data);
+            }
+
+            throw new \Intervention\Image\Exception\NotReadableException(
+                "Unable to init from given url (".$url.")."
+            );
         }
-
-        throw new \Intervention\Image\Exception\NotReadableException(
-            "Unable to init from given url (".$url.")."
-        );
     }
 
     /**


### PR DESCRIPTION
file_get_contents get an individual url request, the request takes too long. The CURL method is a good way.
show demo:
`ImageManager::make('http://thirdwx.qlogo.cn/mmopen/jJvKZ28qzw0GdxdicI2PTcp46DgfCtdhZEnMWJHJ2KmibCEKwBWkFuY1XwElNwxXQqSZu6sELdv32cKyQVeZHWKlGZX6QSZcHB/46')->resize(50, 50);`
It takes 10 seconds...

other information:
https://stackoverflow.com/questions/3629504/php-file-get-contents-very-slow-when-using-full-url