### PR TITLE
2.4.2 Fix exif errors on PNG / corrupted images

### DIFF
--- a/src/Intervention/Image/Commands/ExifCommand.php
+++ b/src/Intervention/Image/Commands/ExifCommand.php
@@ -2,6 +2,8 @@
 
 namespace Intervention\Image\Commands;
 
+use Intervention\Image\Exception\NotReadableException;
+
 class ExifCommand extends AbstractCommand
 {
     /**
@@ -15,7 +17,7 @@ class ExifCommand extends AbstractCommand
      */
     public function execute($image)
     {
-        if ( ! function_exists('exif_read_data')) {
+        if (!function_exists('exif_read_data')) {
             throw new \Intervention\Image\Exception\NotSupportedException(
                 "Reading Exif data is not supported by this PHP installation."
             );
@@ -24,14 +26,25 @@ class ExifCommand extends AbstractCommand
         $key = $this->argument(0)->value();
 
         // try to read exif data from image file
-        $data = @exif_read_data($image->dirname .'/'. $image->basename);
+        try {
+            $data = @exif_read_data($image->dirname . '/' . $image->basename);
 
-        if (! is_null($key) && is_array($data)) {
-            $data = array_key_exists($key, $data) ? $data[$key] : false;
+            if (!is_null($key) && is_array($data)) {
+                $data = array_key_exists($key, $data) ? $data[$key] : false;
+            }
+
+        } catch (\Exception $e) {
+            throw new NotReadableException(
+                sprintf(
+                    "Cannot read the Exif data from the filename (%s) provided ",
+                    $image->dirname . '/' . $image->basename
+                ),
+                $e->getCode(),
+                $e
+            );
         }
 
         $this->setOutput($data);
-
         return true;
     }
 }


### PR DESCRIPTION
PNGs sometimes don't have exif data, and corrupted images might have corrupted versions. This function raises exceptions in these cases are not handled. 

This PR changes that to throw a relevant exception, to be handled upstream. 

Related:
https://github.com/Intervention/image/issues/917