### PR TITLE
added the $format parameter to the save method

### DIFF
--- a/src/Intervention/Image/Image.php
+++ b/src/Intervention/Image/Image.php
@@ -126,9 +126,10 @@ class Image extends File
      *
      * @param  string  $path
      * @param  int     $quality
+     * @param  string  $format
      * @return \Intervention\Image\Image
      */
-    public function save($path = null, $quality = null)
+    public function save($path = null, $quality = null, $format = null)
     {
         $path = is_null($path) ? $this->basePath() : $path;
 
@@ -138,7 +139,11 @@ class Image extends File
             );
         }
 
-        $data = $this->encode(pathinfo($path, PATHINFO_EXTENSION), $quality);
+        if ($format === null) {
+            $format = pathinfo($path, PATHINFO_EXTENSION);
+        }
+
+        $data = $this->encode($format, $quality);
         $saved = @file_put_contents($path, $data);
 
         if ($saved === false) {

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Intervention\Image\Image;
+use Intervention\Image\ImageManager;
 use PHPUnit\Framework\TestCase;
 
 class ImageTest extends TestCase
@@ -41,6 +42,25 @@ class ImageTest extends TestCase
         $this->assertEquals($image->basename, 'test.jpg');
         $this->assertEquals($image->extension, 'jpg');
         $this->assertEquals($image->filename, 'test');
+        @unlink($save_as);
+    }
+
+    public function testFormatSave()
+    {
+        $save_as = __DIR__.'/tmp/test';
+
+        $config = ['driver' => new Intervention\Image\Imagick\Driver()];
+        $manager = new ImageManager($config);
+
+        $image = $manager->make('data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7');
+        $this->assertInstanceOf('Intervention\Image\Image', $image);
+        $this->assertInstanceOf('Imagick', $image->getCore());
+
+        $gifCore = $image->getCore();
+        $this->assertEquals($gifCore->getImageMimeType(), 'image/gif');
+        $image->save($save_as, null, 'jpg');
+
+        $this->assertEquals(\mime_content_type($save_as), 'image/jpeg');
         @unlink($save_as);
     }
 


### PR DESCRIPTION
Hello.
I have a problem to save the image in the format I need I have to add EXT to it and then move it.

```php
$filepath = $path . '.jpg';
$image->save($filepath);
copy($filepath, $path);
unlink($filepath);
```

This PR fix this issue.