### PR TITLE
Image resolution support (ppi).

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=7.0.0",
         "ext-fileinfo": "*",
         "guzzlehttp/psr7": "~1.1"
     },

--- a/src/Intervention/Image/Gd/Commands/GetResolutionCommand.php
+++ b/src/Intervention/Image/Gd/Commands/GetResolutionCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Intervention\Image\Gd\Commands;
+
+use Intervention\Image\Commands\AbstractCommand;
+use Intervention\Image\Exception\NotSupportedException;
+use Intervention\Image\Resolution;
+
+class GetResolutionCommand extends AbstractCommand
+{
+    /**
+     * Reads resolution of given image instance.
+     *
+     * @param \Intervention\Image\Image $image
+     *
+     * @return boolean
+     * @throws \Intervention\Image\Exception\NotSupportedException
+     */
+    public function execute($image)
+    {
+        if (!$this->isSupported()) {
+            throw new NotSupportedException(
+                "Reading image resolution is not supported by this PHP installation."
+            );
+        }
+
+        $resolution = imageresolution($image->getCore());
+        $resolution = $resolution
+            ? new Resolution($resolution[0], $resolution[1], Resolution::UNITS_PPI)
+            : false;
+
+        $this->setOutput($resolution);
+
+        return true;
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isSupported()
+    {
+        return function_exists('imageresolution');
+    }
+}

--- a/src/Intervention/Image/Gd/Commands/SetResolutionCommand.php
+++ b/src/Intervention/Image/Gd/Commands/SetResolutionCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Intervention\Image\Gd\Commands;
+
+use Intervention\Image\Exception\NotSupportedException;
+use Intervention\Image\Imagick\Commands\SetResolutionArguments;
+use Intervention\Image\Resolution;
+
+class SetResolutionCommand extends GetResolutionCommand
+{
+    use SetResolutionArguments;
+
+    /**
+     * Updates resolution of given image instance.
+     *
+     * @param \Intervention\Image\Image $image
+     *
+     * @return boolean
+     * @throws \Intervention\Image\Exception\NotSupportedException
+     * @throws \Intervention\Image\Exception\InvalidArgumentException
+     */
+    public function execute($image)
+    {
+        // Supported?
+        if (!$this->isSupported()) {
+            throw new NotSupportedException(
+                "Updating image resolution is not supported by this PHP installation."
+            );
+        }
+
+        // GD Supports only PPI
+        $resolution = $this->getInputResolution($image);
+
+        return imageresolution(
+            $image->getCore(),
+            $resolution->getX(Resolution::UNITS_PPI),
+            $resolution->getY(Resolution::UNITS_PPI));
+    }
+}

--- a/src/Intervention/Image/Image.php
+++ b/src/Intervention/Image/Image.php
@@ -52,6 +52,8 @@ use Psr\Http\Message\StreamInterface;
  * @method \Intervention\Image\Image widen(int $width, \Closure $callback = null)                                                                                     Resizes the current image to new width, constraining aspect ratio. Pass an optional Closure callback as third parameter, to apply additional constraints like preventing possible upsizing.
  * @method StreamInterface           stream(string $format = null, int $quality = 90)                                                                                 Build PSR-7 compatible StreamInterface with current image in given format and quality.
  * @method ResponseInterface         psrResponse(string $format = null, int $quality = 90)                                                                            Build PSR-7 compatible ResponseInterface with current image in given format and quality.
+ * @method \Intervention\Image\Resolution getResolution()                                                                                                           Get resolution of an image.
+ * @method \Intervention\Image\Image setResolution(\Intervention\Image\Resolution|int $x, string|int $y = null, string $units = null)                               Set resolution of an image.
  */
 class Image extends File
 {

--- a/src/Intervention/Image/Imagick/Commands/GetResolutionCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/GetResolutionCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Intervention\Image\Imagick\Commands;
+
+use Imagick;
+use Intervention\Image\Commands\AbstractCommand;
+use Intervention\Image\Resolution;
+
+class GetResolutionCommand extends AbstractCommand
+{
+    protected static $unitsMap = [
+        Imagick::RESOLUTION_UNDEFINED           => Resolution::UNITS_UNKNOWN,
+        Imagick::RESOLUTION_PIXELSPERINCH       => Resolution::UNITS_PPI,
+        Imagick::RESOLUTION_PIXELSPERCENTIMETER => Resolution::UNITS_PPCM,
+    ];
+
+    /**
+     * Reads resolution of given image instance.
+     *
+     * @param \Intervention\Image\Image $image
+     *
+     * @return boolean
+     */
+    public function execute($image)
+    {
+        /** @var \Imagick $core */
+        $core       = $image->getCore();
+        $units      = $core->getImageUnits();
+        $resolution = $core->getImageResolution();
+        $resolution = new Resolution($resolution['x'], $resolution['y'], $this->getResolutionUnits($units));
+
+        $this->setOutput($resolution);
+
+        return true;
+    }
+
+    protected function getResolutionUnits(int $units): string
+    {
+        return static::$unitsMap[$units] ?? Resolution::UNITS_UNKNOWN;
+    }
+
+    protected function getImagickUnits(string $units): int
+    {
+        return array_search($units, static::$unitsMap, true) ?: Imagick::RESOLUTION_UNDEFINED;
+    }
+}

--- a/src/Intervention/Image/Imagick/Commands/SetResolutionArguments.php
+++ b/src/Intervention/Image/Imagick/Commands/SetResolutionArguments.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Intervention\Image\Imagick\Commands;
+
+use Intervention\Image\Exception\InvalidArgumentException;
+use Intervention\Image\Image;
+use Intervention\Image\Resolution;
+
+/**
+ * @mixin \Intervention\Image\Commands\AbstractCommand
+ */
+trait SetResolutionArguments
+{
+    /**
+     * Parses incoming arguments and returns {@see \Intervention\Image\Resolution} object.
+     *
+     * @param \Intervention\Image\Image $image
+     *
+     * @return \Intervention\Image\Resolution
+     * @throws \Intervention\Image\Exception\InvalidArgumentException
+     */
+    protected function getInputResolution(Image $image): Resolution
+    {
+        $resolution = null;
+
+        switch (count($this->arguments)) {
+            case 0:
+                throw new InvalidArgumentException("setResolution() expects at least 1 parameters, 0 given");
+                break;
+            case 1:
+                if ($this->argument(0)->value() instanceof Resolution) {
+                    // setResolution(new Resolution(...))
+                    $resolution = $this->argument(0)->required()->value();
+                } else {
+                    // setResolution(<XY>)
+                    $x          = $this->argument(0)->required()->type('int')->min(0)->value();
+                    $y          = $x;
+                    $units      = $image->getResolution()->getUnits();
+                    $resolution = new Resolution($x, $y, $units);
+                }
+                break;
+            case 2:
+                if (is_string($this->argument(1)->value())) {
+                    // setResolution(<XY>, 'units')
+                    $x          = $this->argument(0)->required()->type('int')->min(0)->value();
+                    $y          = $x;
+                    $units      = $this->argument(1)->required()->type('string')->value();
+                    $resolution = new Resolution($x, $y, $units);
+                } else {
+                    // setResolution(<X>, <Y>)
+                    $x          = $this->argument(0)->required()->type('int')->min(0)->value();
+                    $y          = $this->argument(1)->required()->type('int')->min(0)->value();
+                    $units      = $image->getResolution()->getUnits();
+                    $resolution = new Resolution($x, $y, $units);
+                }
+                break;
+            case 3:
+                // setResolution(<X>, <Y>, 'units')
+                $x          = $this->argument(0)->required()->type('int')->min(0)->value();
+                $y          = $this->argument(1)->required()->type('int')->min(0)->value();
+                $units      = $this->argument(2)->required()->type('string')->value();
+                $resolution = new Resolution($x, $y, $units);
+                break;
+            default:
+                throw new InvalidArgumentException(sprintf("setResolution() expects at most %s parameters, %s given", 3, count($this->arguments)));
+                break;
+        }
+
+        if (is_null($resolution)) {
+            throw new InvalidArgumentException("setResolution() called with wrong arguments");
+        }
+
+        return $resolution;
+    }
+}

--- a/src/Intervention/Image/Imagick/Commands/SetResolutionCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/SetResolutionCommand.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Intervention\Image\Imagick\Commands;
+
+class SetResolutionCommand extends GetResolutionCommand
+{
+    use SetResolutionArguments;
+
+    /**
+     * Updates resolution of given image instance.
+     *
+     * @param \Intervention\Image\Image $image
+     *
+     * @return boolean
+     */
+    public function execute($image)
+    {
+        /** @var \Imagick $core */
+        $core       = $image->getCore();
+        $resolution = $this->getInputResolution($image);
+
+        return $core->setImageUnits($this->getImagickUnits($resolution->getUnits()))
+               && $core->setImageResolution($resolution->getX(), $resolution->getY());
+    }
+}

--- a/src/Intervention/Image/Resolution.php
+++ b/src/Intervention/Image/Resolution.php
@@ -86,7 +86,7 @@ class Resolution implements JsonSerializable
 
     // <editor-fold desc="Functions">
     // =========================================================================
-    protected function convert(int $value, ?string $units, ?string $target): int
+    protected function convert(int $value, string $units = null, string $target = null): int
     {
         // Default
         $units  = $this->units($units ?: $this->getUnits());

--- a/src/Intervention/Image/Resolution.php
+++ b/src/Intervention/Image/Resolution.php
@@ -12,9 +12,9 @@ use JsonSerializable;
  */
 class Resolution implements JsonSerializable
 {
-    public const UNITS_PPI     = 'ppi';
-    public const UNITS_PPCM    = 'ppcm';
-    public const UNITS_UNKNOWN = 'unknown';
+    const UNITS_PPI     = 'ppi';
+    const UNITS_PPCM    = 'ppcm';
+    const UNITS_UNKNOWN = 'unknown';
 
     /**
      * @var int

--- a/src/Intervention/Image/Resolution.php
+++ b/src/Intervention/Image/Resolution.php
@@ -3,7 +3,6 @@
 
 namespace Intervention\Image;
 
-use Illuminate\Contracts\Support\Arrayable;
 use Intervention\Image\Exception\InvalidArgumentException;
 use Intervention\Image\Exception\RuntimeException;
 use JsonSerializable;
@@ -11,7 +10,7 @@ use JsonSerializable;
 /**
  * Resolution of an image.
  */
-class Resolution implements JsonSerializable, Arrayable
+class Resolution implements JsonSerializable
 {
     public const UNITS_PPI     = 'ppi';
     public const UNITS_PPCM    = 'ppcm';

--- a/src/Intervention/Image/Resolution.php
+++ b/src/Intervention/Image/Resolution.php
@@ -1,0 +1,186 @@
+<?php
+
+
+namespace Intervention\Image;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Intervention\Image\Exception\InvalidArgumentException;
+use Intervention\Image\Exception\RuntimeException;
+use JsonSerializable;
+
+/**
+ * Resolution of an image.
+ */
+class Resolution implements JsonSerializable, Arrayable
+{
+    public const UNITS_PPI     = 'ppi';
+    public const UNITS_PPCM    = 'ppcm';
+    public const UNITS_UNKNOWN = 'unknown';
+
+    /**
+     * @var int
+     */
+    protected $x;
+
+    /**
+     * @var int
+     */
+    protected $y;
+
+    /**
+     * @var string
+     */
+    protected $units;
+
+    public function __construct(int $x, int $y, string $units = self::UNITS_PPI)
+    {
+        $this->x     = $x;
+        $this->y     = $y;
+        $this->units = $this->units($units);
+    }
+
+    // <editor-fold desc="API">
+    // =========================================================================
+    public function getX(string $units = null): int
+    {
+        return $this->convert($this->x, $this->getUnits(), $units);
+    }
+
+    public function setX(int $x, string $units = null): self
+    {
+        $this->x = $this->convert($x, $units, $this->getUnits());
+
+        return $this;
+    }
+
+    public function getY(string $units = null): int
+    {
+        return $this->convert($this->y, $this->getUnits(), $units);
+    }
+
+    public function setY(int $y, string $units = null): self
+    {
+        $this->y = $this->convert($y, $units, $this->getUnits());
+
+        return $this;
+    }
+
+    public function getUnits(): string
+    {
+        return $this->units;
+    }
+
+    public function hasUnits(string $units): bool
+    {
+        return $this->units === $units;
+    }
+
+    public function setUnits(string $units): self
+    {
+        $this->x     = $this->getX($units);
+        $this->y     = $this->getY($units);
+        $this->units = $units;
+
+        return $this;
+    }
+    // </editor-fold>
+
+    // <editor-fold desc="Functions">
+    // =========================================================================
+    protected function convert(int $value, ?string $units, ?string $target): int
+    {
+        // Default
+        $units  = $this->units($units ?: $this->getUnits());
+        $target = $this->units($target ?: $this->getUnits());
+
+        // Same?
+        if ($units === $target) {
+            return $value;
+        }
+
+        // Convert
+        $converted = null;
+
+        switch ($units) {
+            case self::UNITS_PPI:
+                switch ($target) {
+                    case self::UNITS_PPCM:
+                        $converted = self::ppi2ppcm($value);
+                        break;
+                    default:
+                        // impossible to convert
+                        break;
+                }
+                break;
+            case self::UNITS_PPCM:
+                switch ($target) {
+                    case self::UNITS_PPI:
+                        $converted = self::ppcm2ppi($value);
+                        break;
+                    default:
+                        // impossible to convert
+                        break;
+                }
+                break;
+            default:
+                // impossible to convert
+                break;
+        }
+
+        if (is_null($converted)) {
+            throw new RuntimeException("Impossible convert value from '{$units}' to '{$target}'.");
+        }
+
+        // Return
+        return $converted;
+    }
+
+    protected function units(string $units): string
+    {
+        if (!in_array($units, [self::UNITS_PPI, self::UNITS_PPCM, self::UNITS_UNKNOWN], true)) {
+            throw new InvalidArgumentException("Units '{$units}' is not supported.");
+        }
+
+        return $units;
+    }
+    // </editor-fold>
+
+    // <editor-fold desc="Arrayable">
+    // =========================================================================
+    /**
+     * @inheritDoc
+     */
+    public function toArray()
+    {
+        return [
+            'x'     => $this->getX(),
+            'y'     => $this->getY(),
+            'units' => $this->getUnits(),
+        ];
+    }
+    // </editor-fold>
+
+    // <editor-fold desc="JsonSerializable">
+    // =========================================================================
+    /**
+     * @inheritDoc
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+    //</editor-fold>
+
+    // <editor-fold desc="Helpers">
+    // =========================================================================
+    public static function ppcm2ppi(int $dpcm): int
+    {
+        return (int)round($dpcm * 2.54);
+    }
+
+    public static function ppi2ppcm(int $dpi): int
+    {
+        return (int)round($dpi / 2.54);
+    }
+    // </editor-fold>
+}

--- a/tests/Gd/Commands/GetResolutionCommandTest.php
+++ b/tests/Gd/Commands/GetResolutionCommandTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Intervention\Image\Gd\Commands;
+
+use Intervention\Image\ImageManager;
+use Intervention\Image\Resolution;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Intervention\Image\Gd\Commands\GetResolutionCommand
+ */
+class GetResolutionCommandTest extends TestCase
+{
+    /**
+     * @covers ::execute
+     */
+    public function testExecute()
+    {
+        // Supported?
+        if (!function_exists('imageresolution')) {
+            $this->markTestSkipped('Function `imageresolution()` is not defined.');
+        }
+
+        // Test (96 is the default GD resolution)
+        $image    = (new ImageManager(['driver' => 'gd']))->canvas(32, 32);
+        $expected = new Resolution(96, 96, Resolution::UNITS_PPI);
+
+        $this->assertEquals($expected, $image->getResolution());
+    }
+}

--- a/tests/Gd/Commands/SetResolutionCommandTest.php
+++ b/tests/Gd/Commands/SetResolutionCommandTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Intervention\Image\Gd\Commands;
+
+use Intervention\Image\ImageManager;
+use Intervention\Image\Resolution;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Intervention\Image\Gd\Commands\SetResolutionCommand
+ */
+class SetResolutionCommandTest extends TestCase
+{
+    /**
+     * @covers ::execute
+     */
+    public function testExecute()
+    {
+        // Supported?
+        if (!function_exists('imageresolution')) {
+            $this->markTestSkipped('Function `imageresolution()` is not defined.');
+        }
+
+        // Test
+        $image    = (new ImageManager(['driver' => 'gd']))->canvas(32, 32);
+        $expected = new Resolution(128, 128, Resolution::UNITS_PPI);
+
+        $image->setResolution($expected);
+
+        $this->assertEquals($expected, $image->getResolution());
+
+        // GD always uses PPI
+        $ppcm     = new Resolution(128, 128, Resolution::UNITS_PPCM);
+        $expected = (clone $ppcm)->setUnits(Resolution::UNITS_PPI);
+
+        $image->setResolution($ppcm);
+
+        $this->assertEquals($expected, $image->getResolution());
+    }
+}

--- a/tests/Imagick/Commands/GetResolutionCommandTest.php
+++ b/tests/Imagick/Commands/GetResolutionCommandTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Intervention\Image\Imagick\Commands;
+
+use Imagick;
+use Intervention\Image\ImageManager;
+use Intervention\Image\Resolution;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Intervention\Image\Imagick\Commands\GetResolutionCommand
+ */
+class GetResolutionCommandTest extends TestCase
+{
+    /**
+     * @covers ::execute
+     */
+    public function testExecute()
+    {
+        /** @var \Imagick $imagick */
+        $map      = [
+            Imagick::RESOLUTION_UNDEFINED           => Resolution::UNITS_UNKNOWN,
+            Imagick::RESOLUTION_PIXELSPERINCH       => Resolution::UNITS_PPI,
+            Imagick::RESOLUTION_PIXELSPERCENTIMETER => Resolution::UNITS_PPCM,
+        ];
+        $image    = (new ImageManager(['driver' => 'imagick']))->canvas(32, 32);
+        $imagick  = $image->getCore();
+        $x        = $imagick->getImageResolution()['x'];
+        $y        = $imagick->getImageResolution()['y'];
+        $units    = $map[$imagick->getImageUnits()];
+        $expected = new Resolution($x, $y, $units);
+
+        $this->assertEquals($expected, $image->getResolution());
+    }
+}

--- a/tests/Imagick/Commands/SetResolutionArgumentsTest.php
+++ b/tests/Imagick/Commands/SetResolutionArgumentsTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Intervention\Image\Imagick\Commands;
+
+use Intervention\Image\Commands\AbstractCommand;
+use Intervention\Image\Exception\InvalidArgumentException;
+use Intervention\Image\Image;
+use Intervention\Image\Resolution;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Intervention\Image\Imagick\Commands\SetResolutionArguments
+ */
+class SetResolutionArgumentsTest extends TestCase
+{
+    // <editor-fold desc="Tests">
+    // =========================================================================
+    /**
+     * @covers ::getInputResolution()
+     *
+     * @dataProvider dataProviderGetInputResolution
+     *
+     * @param array|string $expected
+     * @param array $args
+     *
+     * @return void
+     */
+    public function testGetInputResolution($expected, array $args): void
+    {
+        /** @var \Intervention\Image\Image|\Mockery\MockInterface $image */
+        $resolution = new Resolution(100, 200, Resolution::UNITS_PPI);
+        $image      = Mockery::mock(Image::class)->shouldAllowMockingProtectedMethods();
+        $image->shouldReceive('getResolution')->andReturn($resolution);
+
+        $trait = new class($args) extends AbstractCommand {
+            use SetResolutionArguments;
+
+            public function execute($image) {
+                return $this->getInputResolution($image);
+            }
+        };
+
+        if (is_string($expected)) {
+            $this->expectException(InvalidArgumentException::class);
+            $this->expectExceptionMessage($expected);
+
+            $trait->execute($image);
+        } else {
+            $this->assertEquals(new Resolution(...$expected), $trait->execute($image));
+        }
+    }
+    // </editor-fold>
+
+    // <editor-fold desc="Providers">
+    // =========================================================================
+    public function dataProviderGetInputResolution(): array
+    {
+        // @formatter:off
+        return [
+            //                              expected                                                        args
+            'setResolution()'            => ['setResolution() expects at least 1 parameters, 0 given', []],
+            'setResolution(5+)'          => ['setResolution() expects at most 3 parameters, 5 given', [1, 2, 3, 4, 5]],
+            'setResolution(Resolution)'  => [[5, 10, Resolution::UNITS_PPI], [new Resolution(5, 10, Resolution::UNITS_PPI)]],
+            'setResolution(xy)'          => [[10, 10, Resolution::UNITS_PPI], [10]],
+            'setResolution(x, y)'        => [[15, 10, Resolution::UNITS_PPI], [15, 10]],
+            'setResolution(xy, units)'   => [[15, 15, Resolution::UNITS_PPCM], [15, Resolution::UNITS_PPCM]],
+            'setResolution(x, y, units)' => [[25, 15, Resolution::UNITS_PPCM], [25, 15, Resolution::UNITS_PPCM]],
+        ];
+        // @formatter:on
+    }
+    //</editor-fold>
+}

--- a/tests/Imagick/Commands/SetResolutionArgumentsTest.php
+++ b/tests/Imagick/Commands/SetResolutionArgumentsTest.php
@@ -26,7 +26,7 @@ class SetResolutionArgumentsTest extends TestCase
      *
      * @return void
      */
-    public function testGetInputResolution($expected, array $args): void
+    public function testGetInputResolution($expected, array $args)
     {
         /** @var \Intervention\Image\Image|\Mockery\MockInterface $image */
         $resolution = new Resolution(100, 200, Resolution::UNITS_PPI);

--- a/tests/Imagick/Commands/SetResolutionCommandTest.php
+++ b/tests/Imagick/Commands/SetResolutionCommandTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Intervention\Image\Imagick\Commands;
+
+use Intervention\Image\ImageManager;
+use Intervention\Image\Resolution;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Intervention\Image\Imagick\Commands\SetResolutionCommand
+ */
+class SetResolutionCommandTest extends TestCase
+{
+    /**
+     * @covers ::execute
+     */
+    public function testExecute()
+    {
+        // PPI
+        $image    = (new ImageManager(['driver' => 'imagick']))->canvas(32, 32);
+        $expected = new Resolution(128, 128, Resolution::UNITS_PPI);
+
+        $image->setResolution($expected);
+
+        $this->assertEquals($expected, $image->getResolution());
+
+        // PPCM
+        $ppcm     = new Resolution(128, 128, Resolution::UNITS_PPCM);
+        $expected = clone $ppcm;
+
+        $image->setResolution($ppcm);
+
+        $this->assertEquals($expected, $image->getResolution());
+    }
+}

--- a/tests/ResolutionTest.php
+++ b/tests/ResolutionTest.php
@@ -1,0 +1,146 @@
+<?php
+
+
+namespace Intervention\Image;
+
+use Intervention\Image\Exception\InvalidArgumentException;
+use Intervention\Image\Exception\RuntimeException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Intervention\Image\Resolution
+ */
+class ResolutionTest extends TestCase
+{
+    /**
+     * @covers ::__construct
+     */
+    public function testConstructWithInvalidUnits()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Units \'invalid\' is not supported.');
+
+        new Resolution(1, 2, 'invalid');
+    }
+
+    /**
+     * @covers ::getX
+     * @covers ::setX
+     * @covers ::getY
+     * @covers ::setY
+     * @covers ::getUnits
+     * @covers ::hasUnits
+     * @covers ::setUnits
+     * @covers ::convert
+     */
+    public function testGettersAndSetters()
+    {
+        // Defaults
+        $x = 300;
+        $y = 150;
+
+        // Getters
+        $resolution = new Resolution($x, $y, Resolution::UNITS_PPI);
+
+        $this->assertEquals($x, $resolution->getX());
+        $this->assertEquals($y, $resolution->getY());
+        $this->assertEquals(Resolution::UNITS_PPI, $resolution->getUnits());
+        $this->assertNotEquals(Resolution::UNITS_PPCM, $resolution->getUnits());
+        $this->assertTrue($resolution->hasUnits(Resolution::UNITS_PPI));
+        $this->assertFalse($resolution->hasUnits(Resolution::UNITS_PPCM));
+
+        // ... with conversion
+        $resolution = new Resolution($x, $y, Resolution::UNITS_PPI);
+
+        $this->assertEquals($x, $resolution->getX($resolution->getUnits()));
+        $this->assertEquals(Resolution::ppi2ppcm($x), $resolution->getX(Resolution::UNITS_PPCM));
+        $this->assertEquals($y, $resolution->getY($resolution->getUnits()));
+        $this->assertEquals(Resolution::ppi2ppcm($y), $resolution->getY(Resolution::UNITS_PPCM));
+
+        // Setters
+        $resolution = new Resolution($x, $y, Resolution::UNITS_PPI);
+        $resolution->setX($y);
+        $resolution->setY($x);
+
+        $this->assertEquals($y, $resolution->getX());
+        $this->assertEquals($x, $resolution->getY());
+
+        // ... with conversion
+        $resolution = new Resolution($x, $y, Resolution::UNITS_PPI);
+
+        $resolution->setX($x, Resolution::UNITS_PPCM);
+        $resolution->setY($y, Resolution::UNITS_PPCM);
+
+        $this->assertEquals(Resolution::ppcm2ppi($x), $resolution->getX($resolution->getUnits()));
+        $this->assertEquals($x, $resolution->getX(Resolution::UNITS_PPCM));
+        $this->assertEquals(Resolution::ppcm2ppi($y), $resolution->getY($resolution->getUnits()));
+        $this->assertEquals($y, $resolution->getY(Resolution::UNITS_PPCM));
+
+        // Units Conversion
+        $resolution = new Resolution($x, $y, Resolution::UNITS_PPCM);
+        $resolution->setUnits(Resolution::UNITS_PPI);
+
+        $this->assertEquals(Resolution::ppcm2ppi($x), $resolution->getX());
+        $this->assertEquals(Resolution::ppcm2ppi($y), $resolution->getY());
+        $this->assertEquals(Resolution::UNITS_PPI, $resolution->getUnits());
+    }
+
+    /**
+     * @covers ::convert
+     */
+    public function testConvertUnknownToUnits()
+    {
+        // Unknown/Invalid units cannot be converted
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("Impossible convert value from 'unknown' to 'ppi'.");
+
+        (new Resolution(150, 250, Resolution::UNITS_UNKNOWN))->setUnits(Resolution::UNITS_PPI);
+    }
+
+    /**
+     * @covers ::convert
+     */
+    public function testConvertUnitsToUnknown()
+    {
+        // Unknown/Invalid units cannot be converted
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("Impossible convert value from 'ppi' to 'unknown'.");
+
+        (new Resolution(150, 250, Resolution::UNITS_PPI))->setUnits(Resolution::UNITS_UNKNOWN);
+    }
+
+    /**
+     * @covers ::toArray
+     * @covers ::jsonSerialize
+     */
+    public function testToArrayJson()
+    {
+        $resolution = new Resolution(150, 250, Resolution::UNITS_PPI);
+        $expected   = [
+            'x'     => $resolution->getX(),
+            'y'     => $resolution->getY(),
+            'units' => $resolution->getUnits(),
+        ];
+
+        $this->assertEquals($expected, $resolution->toArray());
+        $this->assertEquals($expected, $resolution->jsonSerialize());
+    }
+
+    /**
+     * @covers ::ppcm2ppi
+     */
+    public function testPpcm2ppi()
+    {
+        $this->assertEquals((int)round(200 * 2.54), Resolution::ppcm2ppi(200));
+    }
+
+    /**
+     * @covers ::ppi2ppcm
+     */
+    public function testPpi2ppcm()
+    {
+        $this->assertEquals((int)round(200 / 2.54), Resolution::ppi2ppcm(200));
+    }
+}


### PR DESCRIPTION
This PR adds initial support to get and set the resolution of images for GD and Imagick, also it supports two resolutions units: ppi and ppcm (please see notes below).

### Methods

* `getResolution(): Resolution`
* `setResolution(\Intervention\Image\Resolution $resolution)`
* `setResolution(int $xy)`
* `setResolution(int $x, int $y)`
* `setResolution(int $xy, string $units)`
* `setResolution(int $x, int $y, string $units)`

### Notes

1. Tested on PHP 7.2, on 7.1 should work too, 7.0 (fixed and supported now) and below are officially dead and I don't see any reason to support them 😄 especially because the [`gd:imageresolution()`](https://www.php.net/imageresolution) was added in 7.2  
2. GD supports only ppi, so `setResolutions(ppcm)` will automatically convert ppcm into ppi (imagick will use original units)
2. While processing images (and even after `make()`) GD will lose original resolution 😞 technically this can be fixed too but requires a lot of work and will not be included in this PR.
