### PR TITLE
Multibyte text is not rendered

### DIFF
--- a/src/Intervention/Image/Gd/Font.php
+++ b/src/Intervention/Image/Gd/Font.php
@@ -82,6 +82,11 @@ class Font extends \Intervention\Image\AbstractFont
 
         if ($this->hasApplicableFontFile()) {
 
+            // imagettfbbox() converts numeric entities to their respective
+            // character. Preserve any originally double encoded entities to be
+            // represented as is.
+            // eg: &amp;#160; will render &#160; rather than its character.
+            $this->text = preg_replace('/&(#(?:x[a-fA-F0-9]+|[0-9]+);)/', '&#38;\1', $this->text);
             $this->text = mb_encode_numericentity($this->text, array(0x0080, 0xffff, 0, 0xffff), 'UTF-8');
 
             // get bounding box with angle 0

--- a/src/Intervention/Image/Gd/Font.php
+++ b/src/Intervention/Image/Gd/Font.php
@@ -82,6 +82,8 @@ class Font extends \Intervention\Image\AbstractFont
 
         if ($this->hasApplicableFontFile()) {
 
+            $this->text = mb_encode_numericentity($this->text, array(0x0080, 0xffff, 0, 0xffff), 'UTF-8');
+
             // get bounding box with angle 0
             $box = imagettfbbox($this->getPointSize(), 0, $this->file, $this->text);
 


### PR DESCRIPTION
In some server configration, Multibyte text is not rendered ( is not encoded properly).

PDF Library DOMPDF  is doing like this way.

`$text = mb_encode_numericentity($text, array(0x0080, 0xffff, 0, 0xffff), 'UTF-8'); `

https://github.com/dompdf/dompdf/blob/313f466e77fe63df0c53c20b54540945a0b165cd/src/Adapter/GD.php#L866


This is error log.
```
imagettfbbox(): any2eucjp(): invalid code in input string {"exception":"[object] (ErrorException(code: 0): imagettfbbox(): any2eucjp(): invalid code in input string at /usr/home/webapp/vendor/intervention/image/src/Intervention/Image/Gd/Font.php:85)
[stacktrace]
#0 [internal function]: Illuminate\\Foundation\\Bootstrap\\HandleExceptions->handleError(2, 'imagettfbbox():...', '/usr/home/...', 85, Array)
#1 /usr/home/webapp/vendor/intervention/image/src/Intervention/Image/Gd/Font.php(85): imagettfbbox(38, 0, '/usr/home/...', '\\xE3\\x82\\x8A')
#2 /usr/home/webapp/vendor/intervention/image/src/Intervention/Image/Gd/Font.php(140): Intervention\\Image\\Gd\\Font->getBoxSize()
#3 /usr/home/webapp/vendor/intervention/image/src/Intervention/Image/Commands/TextCommand.php(30): Intervention\\Image\\Gd\\Font->applyToImage(Object(Intervention\\Image\\Image), 4, 15)
#4 /usr/home/webapp/vendor/intervention/image/src/Intervention/Image/AbstractDriver.php(92): Intervention\\Image\\Commands\\TextCommand->execute(Object(Intervention\\Image\\Image))
#5 /usr/home/webapp/vendor/intervention/image/src/Intervention/Image/Image.php(106): Intervention\\Image\\AbstractDriver->executeCommand(Object(Intervention\\Image\\Image), 'text', Array)
...
```