### PR TITLE
laravel5 pass variable as array to ImageManager [support Laravel 6 upgrade]

### DIFF
--- a/src/Intervention/Image/ImageServiceProviderLaravel5.php
+++ b/src/Intervention/Image/ImageServiceProviderLaravel5.php
@@ -48,7 +48,7 @@ class ImageServiceProviderLaravel5 extends ServiceProvider
 
         // create image
         $app->singleton('image', function ($app) {
-            return new ImageManager($app['config']->get('image'));
+            return new ImageManager([$app['config']->get('image')]);
         });
 
         $app->alias('image', 'Intervention\Image\ImageManager');
@@ -76,7 +76,6 @@ class ImageServiceProviderLaravel5 extends ServiceProvider
 
         // imagecache route
         if (is_string(config('imagecache.route'))) {
-
             $filename_pattern = '[ \w\\.\\/\\-\\@\(\)]+';
 
             // route to access template applied image file


### PR DESCRIPTION
How to replay error
- Laravel 6
- PHP 7.3

Error

    "Argument 1 passed to Intervention\Image\ImageManager::__construct() must be of the type array, null given, called in vendor/intervention/image/src/Intervention/Image/ImageServiceProviderLaravel5.php on line 51"

ImageManager.php Construct

    /**
     * Creates new instance of Image Manager
     *
     * @param array $config
     */
    public function __construct(array $config = [])
    {
        $this->checkRequirements();
        $this->configure($config);
    }

ImageServiceProviderLaravel5.php

    // create image
    $app->singleton('image', function ($app) {
         return new ImageManager($app['config']->get('image'));  // variable being passed is not an array.
    });

- Laravel version 5.7 works with the current configuration but fails with Laravel 6 when using the same PHP version of 7.3. 

- Made changes so that the config being passed to the ImageManager passes an array and tested functionality with Laravel 5.7 and Laravel 6 with PHP versions 7.1, 7.2 and 7.3