### PR TITLE
Bugfix for decodeDataUrl when data contains newlines

### DIFF
--- a/src/Intervention/Image/AbstractDecoder.php
+++ b/src/Intervention/Image/AbstractDecoder.php
@@ -290,7 +290,7 @@ abstract class AbstractDecoder
         }
 
         $pattern = "/^data:(?:image\/[a-zA-Z\-\.]+)(?:charset=\".+\")?;base64,(?P<data>.+)$/";
-        preg_match($pattern, $data_url, $matches);
+        preg_match($pattern, str_replace(["\n", "\r"], '', $data_url), $matches);
 
         if (is_array($matches) && array_key_exists('data', $matches)) {
             return base64_decode($matches['data']);


### PR DESCRIPTION
Remove the newlines before doing a Regex check inside the `decodeDataUrl` method in the same way that is the `isBase64` method doing.

Some base64 encoded images contains newlines, passing them directly to the `Image::make` method can result in a `NotReadableException`.

Here are the tests I did before this commit :
- data part only  =>  OK 
- data:[..] header  +  data part  =>  OK
- data part only with newlines  =>  OK
- data:[..] header  +  data part with newlines  =>  Failure
