### PR TITLE
Support JP2 images

### DIFF
--- a/src/Intervention/Image/AbstractEncoder.php
+++ b/src/Intervention/Image/AbstractEncoder.php
@@ -171,7 +171,7 @@ abstract class AbstractEncoder
                 
             default:
                 throw new NotSupportedException(
-                    "Encoding format ({$format}) is not supported."
+                    "Encoding format ({$this->format}) is not supported."
                 );
         }
 

--- a/src/Intervention/Image/AbstractEncoder.php
+++ b/src/Intervention/Image/AbstractEncoder.php
@@ -117,6 +117,7 @@ abstract class AbstractEncoder
 
             case 'jpg':
             case 'jpeg':
+            case 'image/jp2':
             case 'image/jpg':
             case 'image/jpeg':
             case 'image/pjpeg':


### PR DESCRIPTION
Sometimes JPEG images carry the image/jp2 MIME type (JPEG2000 encoding). ImageMagick supports this if it has the correct delegates compiled.