### PR TITLE
BUGFIX: Circle x & y arguments should be optional

### DIFF
--- a/src/Intervention/Image/Commands/CircleCommand.php
+++ b/src/Intervention/Image/Commands/CircleCommand.php
@@ -15,8 +15,8 @@ class CircleCommand extends AbstractCommand
     public function execute($image)
     {
         $diameter = $this->argument(0)->type('numeric')->required()->value();
-        $x = $this->argument(1)->type('numeric')->required()->value();
-        $y = $this->argument(2)->type('numeric')->required()->value();
+        $x = $this->argument(1)->type('numeric')->value();
+        $y = $this->argument(2)->type('numeric')->value();
         $callback = $this->argument(3)->type('closure')->value();
 
         $circle_classname = sprintf('\Intervention\Image\%s\Shapes\CircleShape',


### PR DESCRIPTION
It appears that the arguments for $x & $y should be set to be optional as they're not required (and set to '0' by default) for both supported image libraries.

Any feedback welcome.

Ref;
- https://github.com/Intervention/image/blob/master/src/Intervention/Image/Gd/Shapes/CircleShape.php#L36
- https://github.com/Intervention/image/blob/master/src/Intervention/Image/Imagick/Shapes/CircleShape.php#L36