### PR TITLE
Increase accuracy for gd/imagick alpha channel

### DIFF
--- a/src/Intervention/Image/Gd/Color.php
+++ b/src/Intervention/Image/Gd/Color.php
@@ -168,7 +168,7 @@ class Color extends AbstractColor
      */
     public function getArray()
     {
-        return [$this->r, $this->g, $this->b, round(1 - $this->a / 127, 2)];
+        return [$this->r, $this->g, $this->b, round(1 - $this->a / 127, 3)];
     }
 
     /**
@@ -178,7 +178,7 @@ class Color extends AbstractColor
      */
     public function getRgba()
     {
-        return sprintf('rgba(%d, %d, %d, %.2F)', $this->r, $this->g, $this->b, round(1 - $this->a / 127, 2));
+        return sprintf('rgba(%d, %d, %d, %.3F)', $this->r, $this->g, $this->b, round(1 - $this->a / 127, 3));
     }
 
     /**

--- a/src/Intervention/Image/Imagick/Color.php
+++ b/src/Intervention/Image/Imagick/Color.php
@@ -165,7 +165,7 @@ class Color extends AbstractColor
      */
     public function getRgba()
     {
-        return sprintf('rgba(%d, %d, %d, %.2F)',
+        return sprintf('rgba(%d, %d, %d, %.3F)',
             $this->getRedValue(),
             $this->getGreenValue(),
             $this->getBlueValue(),
@@ -237,7 +237,7 @@ class Color extends AbstractColor
      */
     public function getAlphaValue()
     {
-        return round($this->pixel->getColorValue(\Imagick::COLOR_ALPHA), 2);
+        return round($this->pixel->getColorValue(\Imagick::COLOR_ALPHA), 3);
     }
 
     /**
@@ -250,7 +250,7 @@ class Color extends AbstractColor
         $a = is_null($a) ? 1 : $a;
 
         return $this->pixel = new \ImagickPixel(
-            sprintf('rgba(%d, %d, %d, %.2F)', $r, $g, $b, $a)
+            sprintf('rgba(%d, %d, %d, %.3F)', $r, $g, $b, $a)
         );
     }
 
@@ -273,7 +273,7 @@ class Color extends AbstractColor
     private function rgb2alpha($value)
     {
         // (255 -> 1.0) / (0 -> 0.0)
-        return (float) round($value/255, 2);
+        return (float) round($value/255, 3);
     }
 
 }

--- a/tests/GdColorTest.php
+++ b/tests/GdColorTest.php
@@ -232,22 +232,22 @@ class GdColorTest extends TestCase
         $c = new Color;
         $i = $c->getRgba();
         $this->assertInternalType('string', $i);
-        $this->assertEquals($i, 'rgba(255, 255, 255, 0.00)');
+        $this->assertEquals($i, 'rgba(255, 255, 255, 0.000)');
 
         $c = new Color([255, 255, 255, 1]);
         $i = $c->getRgba();
         $this->assertInternalType('string', $i);
-        $this->assertEquals($i, 'rgba(255, 255, 255, 1.00)');
+        $this->assertEquals($i, 'rgba(255, 255, 255, 1.000)');
 
         $c = new Color([181, 55, 23, 0.5]);
         $i = $c->getRgba();
         $this->assertInternalType('string', $i);
-        $this->assertEquals($i, 'rgba(181, 55, 23, 0.50)');
+        $this->assertEquals($i, 'rgba(181, 55, 23, 0.500)');
 
         $c = new Color([0, 0, 0, 1]);
         $i = $c->getRgba();
         $this->assertInternalType('string', $i);
-        $this->assertEquals($i, 'rgba(0, 0, 0, 1.00)');
+        $this->assertEquals($i, 'rgba(0, 0, 0, 1.000)');
     }
 
     public function testDiffers()

--- a/tests/GdColorTest.php
+++ b/tests/GdColorTest.php
@@ -248,6 +248,11 @@ class GdColorTest extends TestCase
         $i = $c->getRgba();
         $this->assertInternalType('string', $i);
         $this->assertEquals($i, 'rgba(0, 0, 0, 1.000)');
+        
+        $c = new Color([255, 255, 255, 0.5]);
+        $i = $c->getRgba();
+        $this->assertInternalType('string', $i);
+        $this->assertEquals($i, 'rgba(255, 255, 255, 0.500)');
     }
 
     public function testDiffers()

--- a/tests/GdSystemTest.php
+++ b/tests/GdSystemTest.php
@@ -1240,7 +1240,7 @@ class GdSystemTest extends TestCase
         $this->assertEquals(34, $c[0]);
         $this->assertEquals(0, $c[1]);
         $this->assertEquals(160, $c[2]);
-        $this->assertEquals(0.476, $c[3]);
+        $this->assertEquals(0.467, $c[3]);
 
         $c = $img->pickColor(16, 16);
         $this->assertEquals(231, $c[0]);

--- a/tests/GdSystemTest.php
+++ b/tests/GdSystemTest.php
@@ -1240,7 +1240,7 @@ class GdSystemTest extends TestCase
         $this->assertEquals(34, $c[0]);
         $this->assertEquals(0, $c[1]);
         $this->assertEquals(160, $c[2]);
-        $this->assertEquals(0.46, $c[3]);
+        $this->assertEquals(0.476, $c[3]);
 
         $c = $img->pickColor(16, 16);
         $this->assertEquals(231, $c[0]);

--- a/tests/ImagickColorTest.php
+++ b/tests/ImagickColorTest.php
@@ -277,22 +277,22 @@ class ImagickColorTest extends TestCase
         $c = new Color([255, 255, 255, 1]);
         $i = $c->getRgba();
         $this->assertInternalType('string', $i);
-        $this->assertEquals($i, 'rgba(255, 255, 255, 1.00)');
+        $this->assertEquals($i, 'rgba(255, 255, 255, 1.000)');
 
         $c = new Color([181, 55, 23, 0.5]);
         $i = $c->getRgba();
         $this->assertInternalType('string', $i);
-        $this->assertEquals($i, 'rgba(181, 55, 23, 0.50)');
+        $this->assertEquals($i, 'rgba(181, 55, 23, 0.500)');
 
         $c = new Color([0, 0, 0, 1]);
         $i = $c->getRgba();
         $this->assertInternalType('string', $i);
-        $this->assertEquals($i, 'rgba(0, 0, 0, 1.00)');
+        $this->assertEquals($i, 'rgba(0, 0, 0, 1.000)');
 
         $c = new Color([255, 255, 255, 0.5]);
         $i = $c->getRgba();
         $this->assertInternalType('string', $i);
-        $this->assertEquals($i, 'rgba(255, 255, 255, 0.50)');
+        $this->assertEquals($i, 'rgba(255, 255, 255, 0.500)');
     }
 
     public function testDiffers()

--- a/tests/ImagickColorTest.php
+++ b/tests/ImagickColorTest.php
@@ -272,7 +272,7 @@ class ImagickColorTest extends TestCase
         $c = new Color;
         $i = $c->getRgba();
         $this->assertInternalType('string', $i);
-        $this->assertEquals($i, 'rgba(255, 255, 255, 0.00)');
+        $this->assertEquals($i, 'rgba(255, 255, 255, 0.000)');
 
         $c = new Color([255, 255, 255, 1]);
         $i = $c->getRgba();

--- a/tests/ImagickSystemTest.php
+++ b/tests/ImagickSystemTest.php
@@ -1187,7 +1187,7 @@ class ImagickSystemTest extends TestCase
         $this->assertEquals(34, $c[0]);
         $this->assertEquals(0, $c[1]);
         $this->assertEquals(160, $c[2]);
-        $this->assertEquals(0.47, $c[3]);
+        $this->assertEquals(0.467, $c[3]);
 
         $c = $img->pickColor(16, 16);
         $this->assertEquals(231, $c[0]);


### PR DESCRIPTION
2 decimal digits accuracy for alpha channel do not cover the entire space of 256(imagick)/128(gd) values (101 values possible  only)
fix for that
tests need be changed too (accuracy has been increased)