### PR TITLE
Allow rotation angle with decimals

### DIFF
--- a/src/Intervention/Image/Gd/Commands/RotateCommand.php
+++ b/src/Intervention/Image/Gd/Commands/RotateCommand.php
@@ -20,7 +20,7 @@ class RotateCommand extends AbstractCommand
         $color = new Color($color);
 
         // restrict rotations beyond 360 degrees, since the end result is the same
-        $angle %= 360;
+        $angle = fmod($angle, 360);
 
         // rotate image
         $image->setCore(imagerotate($image->getCore(), $angle, $color->getInt()));

--- a/src/Intervention/Image/Imagick/Commands/RotateCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/RotateCommand.php
@@ -20,7 +20,7 @@ class RotateCommand extends AbstractCommand
         $color = new Color($color);
 
         // restrict rotations beyond 360 degrees, since the end result is the same
-        $angle %= 360;
+        $angle = fmod($angle, 360);
 
         // rotate image
         $image->getCore()->rotateImage($color->getPixel(), ($angle * -1));


### PR DESCRIPTION
Hi, this is my first pull request on GitHub. I hope I don't mess anything up.

It turns out that the restriction on rotations beyond 360 degrees prevents decimal accuracy. Using fmod instead of the % operator preserves the constraint and allows the use of angles with decimals.