### PR TITLE
Better support for Lumen: Return Illuminate\Http\Response instance

### DIFF
--- a/src/Intervention/Image/Response.php
+++ b/src/Intervention/Image/Response.php
@@ -3,6 +3,7 @@
 namespace Intervention\Image;
 
 use Illuminate\Http\Response as IlluminateResponse;
+use Illuminate\Support\Facades\Response as IlluminateResponseFacade;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 class Response
@@ -54,9 +55,11 @@ class Response
         $mime = finfo_buffer(finfo_open(FILEINFO_MIME_TYPE), $data);
         $length = strlen($data);
 
-        if (function_exists('app') && is_a($app = app(), 'Illuminate\Container\Container')) {
+        if (function_exists('app') && app() instanceof \Illuminate\Container\Container) {
 
-            $response = new IlluminateResponse($data);
+            $response = IlluminateResponseFacade::getFacadeApplication()
+                ? IlluminateResponseFacade::make($data)
+                : new IlluminateResponse($data);
             $response->header('Content-Type', $mime);
             $response->header('Content-Length', $length);
 

--- a/src/Intervention/Image/Response.php
+++ b/src/Intervention/Image/Response.php
@@ -2,7 +2,7 @@
 
 namespace Intervention\Image;
 
-use Illuminate\Support\Facades\Response as IlluminateResponse;
+use Illuminate\Http\Response as IlluminateResponse;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 class Response
@@ -54,9 +54,9 @@ class Response
         $mime = finfo_buffer(finfo_open(FILEINFO_MIME_TYPE), $data);
         $length = strlen($data);
 
-        if (function_exists('app') && is_a($app = app(), 'Illuminate\Foundation\Application')) {
+        if (function_exists('app') && is_a($app = app(), 'Illuminate\Container\Container')) {
 
-            $response = IlluminateResponse::make($data);
+            $response = new IlluminateResponse($data);
             $response->header('Content-Type', $mime);
             $response->header('Content-Length', $length);
 


### PR DESCRIPTION
Currently, with a Lumen application, `$image->response()` returns `Symfony\Component\HttpFoundation\Response`. This change compares the `app()` container with `Illuminate\Container\Container` and correctly returns an Illuminate Response without the use of a facade.

Removing the facade use is key as Lumen applications have facades disabled by default.