### PR TITLE
AVIF Support

### DIFF
--- a/src/Intervention/Image/AbstractEncoder.php
+++ b/src/Intervention/Image/AbstractEncoder.php
@@ -85,6 +85,13 @@ abstract class AbstractEncoder
     abstract protected function processWebp();
 
     /**
+     * Processes and returns image as Avif encoded string
+     *
+     * @return string
+     */
+    abstract protected function processAvif();
+
+    /**
      * Process a given image
      *
      * @param  Image   $image
@@ -167,6 +174,11 @@ abstract class AbstractEncoder
             case 'image/webp':
             case 'image/x-webp':
                 $this->result = $this->processWebp();
+                break;
+
+            case 'avif':
+            case 'image/avif':
+                $this->result = $this->processAvif();
                 break;
                 
             default:

--- a/src/Intervention/Image/Gd/Encoder.php
+++ b/src/Intervention/Image/Gd/Encoder.php
@@ -121,4 +121,16 @@ class Encoder extends \Intervention\Image\AbstractEncoder
             "PSD format is not supported by Gd Driver."
         );
     }
+
+    /**
+     * Processes and returns encoded image as AVIF string
+     *
+     * @return string
+     */
+    protected function processAvif()
+    {
+        throw new NotSupportedException(
+            "AVIF format is not supported by Gd Driver."
+        );
+    }
 }

--- a/src/Intervention/Image/Imagick/Encoder.php
+++ b/src/Intervention/Image/Imagick/Encoder.php
@@ -170,4 +170,26 @@ class Encoder extends AbstractEncoder
 
         return $imagick->getImagesBlob();
     }
+
+    protected function processAvif()
+    {
+        if ( ! \Imagick::queryFormats('AVIF')) {
+            throw new NotSupportedException(
+                "AVIF format is not supported by Imagick installation."
+            );
+        }
+
+        $format = 'avif';
+        $compression = \Imagick::COMPRESSION_UNDEFINED;
+
+        $imagick = $this->image->getCore();
+        $imagick->setFormat($format);
+        $imagick->setImageFormat($format);
+        $imagick->setCompression($compression);
+        $imagick->setImageCompression($compression);
+        $imagick->setCompressionQuality($this->quality);
+        $imagick->setImageCompressionQuality($this->quality);
+
+        return $imagick->getImagesBlob();
+    }
 }

--- a/tests/EncoderTest.php
+++ b/tests/EncoderTest.php
@@ -64,6 +64,18 @@ class EncoderTest extends TestCase
     /**
      * @expectedException \Intervention\Image\Exception\NotSupportedException
      */
+    public function testProcessAvifGd()
+    {
+        $core = imagecreatefromjpeg(__DIR__.'/images/test.jpg');
+        $encoder = new GdEncoder;
+        $image = Mockery::mock('\Intervention\Image\Image');
+        $img = $encoder->process($image, 'avif', 90);
+        $this->assertInstanceOf('Intervention\Image\Image', $img);
+    }
+
+    /**
+     * @expectedException \Intervention\Image\Exception\NotSupportedException
+     */
     public function testProcessTiffGd()
     {
         $core = imagecreatefromjpeg(__DIR__.'/images/test.jpg');
@@ -178,6 +190,16 @@ class EncoderTest extends TestCase
         $encoder = new ImagickEncoder;
         $image = Mockery::mock('\Intervention\Image\Image');
         $img = $encoder->process($image, 'webp', 90);
+    }
+
+    /**
+     * @expectedException \Intervention\Image\Exception\NotSupportedException
+     */
+    public function testProcessAvifImagick()
+    {
+        $encoder = new ImagickEncoder;
+        $image = Mockery::mock('\Intervention\Image\Image');
+        $img = $encoder->process($image, 'avif', 90);
     }
 
     public function testProcessTiffImagick()


### PR DESCRIPTION
This PR adds support for the AVIF encoding.

The AVIF format has been supported in ImageMagick since [at least 7.0.10-21](https://github.com/ImageMagick/ImageMagick/commit/9f4c23df9e6a462dcef91f98aecce64d78552a5d). I personally have tested it on 7.0.10-25 along with [this](https://github.com/ImageMagick/ImageMagick/issues/1432#issuecomment-671036653) person.

This closes #891