### PR TITLE
PHP 8: Add support for GdImage resource objects

### DIFF
--- a/src/Intervention/Image/AbstractDecoder.php
+++ b/src/Intervention/Image/AbstractDecoder.php
@@ -140,6 +140,10 @@ abstract class AbstractDecoder
             return (get_resource_type($this->data) == 'gd');
         }
 
+        if ($this->data instanceof \GdImage) {
+            return true;
+        }
+
         return false;
     }
 


### PR DESCRIPTION
In [PHP 8.0, `gd` resources are changed to `\GdImage` class objects](https://php.watch/versions/8.0/gdimage). This changes the `\Intervention\Image\AbstractDecoder::isGdResource` method to accept `\GdImage` objects as well as `gd` resources.