### PR TITLE
Fix Decoder::initFromUrl under service mesh with envoy side raise a 426 http code

### DIFF
--- a/src/Intervention/Image/AbstractDecoder.php
+++ b/src/Intervention/Image/AbstractDecoder.php
@@ -69,6 +69,7 @@ abstract class AbstractDecoder
         $options = [
             'http' => [
                 'method'=>"GET",
+                'protocol_version'=>1.1, // force use HTTP 1.1 for service mesh environment with envoy
                 'header'=>"Accept-language: en\r\n".
                 "User-Agent: Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.2 (KHTML, like Gecko) Chrome/22.0.1216.0 Safari/537.2\r\n"
           ]


### PR DESCRIPTION
my company uses this package for fasting image processing, but when we deploy to k8s with istio, the envoy sidecar requires newer HTTP version, so i think we should improve http context from HTTP 1.0 (default to HTTP Context) to HTTP 1.1 with context options 'http.protocol_version'.

