### PR TITLE
fix: gd memory issue when retrieving mime type

### DIFF
--- a/src/Intervention/Image/Gd/Decoder.php
+++ b/src/Intervention/Image/Gd/Decoder.php
@@ -118,7 +118,7 @@ class Decoder extends \Intervention\Image\AbstractDecoder
         }
 
         $image = $this->initFromGdResource($resource);
-        $image->mime = finfo_buffer(finfo_open(FILEINFO_MIME_TYPE), $binary);
+        $image->mime = getimagesizefromstring($binary)['mime'];
 
         return $image;
     }


### PR DESCRIPTION
I had some memory issues within the gd driver.

`Allowed memory size of 134217728 bytes exhausted (tried to allocate 10076428 bytes)`

With that little change, it works now, even with 64MB.