### PR TITLE
Fix issue where execute is failing due to is_resource no longer used …

### DIFF
--- a/src/Intervention/Image/Gd/Commands/ResetCommand.php
+++ b/src/Intervention/Image/Gd/Commands/ResetCommand.php
@@ -16,8 +16,8 @@ class ResetCommand extends AbstractCommand
     public function execute($image)
     {
         $backupName = $this->argument(0)->value();
-
-        if (is_resource($backup = $image->getBackup($backupName))) {
+	$backup = $backup = $image->getBackup($backupName);
+        if (is_resource($backup) || $image instanceof \GdImage) {
 
             // destroy current resource
             imagedestroy($image->getCore());


### PR DESCRIPTION
…in php 8

I was running into a problem were I could not backup and reset an image in php 8.