### PR TITLE
Fix incorrect docblock in AbstractFont (Strinf -> String)

### DIFF
--- a/src/Intervention/Image/AbstractFont.php
+++ b/src/Intervention/Image/AbstractFont.php
@@ -73,7 +73,7 @@ abstract class AbstractFont
     /**
      * Create a new instance of Font
      *
-     * @param Strinf $text Text to be written
+     * @param String $text Text to be written
      */
     public function __construct($text = null)
     {


### PR DESCRIPTION
Fixes an incorrect docblock. Sadly triggered PHPstan:

```Parameter #1 $text of class Intervention\Image\Gd\Font constructor expects Intervention\Image\Strinf|null, string given. ```