### PR TITLE
Add support to equal sign - '=' - on URL

### DIFF
--- a/src/Intervention/Image/ImageServiceProviderLaravelRecent.php
+++ b/src/Intervention/Image/ImageServiceProviderLaravelRecent.php
@@ -77,7 +77,7 @@ class ImageServiceProviderLaravelRecent extends ServiceProvider
         // imagecache route
         if (is_string(config('imagecache.route'))) {
 
-            $filename_pattern = '[ \w\\.\\/\\-\\@\(\)]+';
+            $filename_pattern = '[ \w\\.\\/\\-\\@\(\)\=]+';
 
             // route to access template applied image file
             $app['router']->get(config('imagecache.route').'/{template}/{filename}', [


### PR DESCRIPTION
Updated filename regex pattern to allow the equal sign as being part of the filename portion of the route, otherwise it would fall on 404 error.