### PR TITLE
Fallback to Utils::streamFor for guzzlehttp/psr7 ^2.0

### DIFF
--- a/src/Intervention/Image/Commands/StreamCommand.php
+++ b/src/Intervention/Image/Commands/StreamCommand.php
@@ -2,6 +2,9 @@
 
 namespace Intervention\Image\Commands;
 
+use GuzzleHttp\Psr7\Utils;
+use function GuzzleHttp\Psr7\stream_for;
+
 class StreamCommand extends AbstractCommand
 {
     /**
@@ -16,9 +19,10 @@ class StreamCommand extends AbstractCommand
         $format = $this->argument(0)->value();
         $quality = $this->argument(1)->between(0, 100)->value();
 
-        $this->setOutput(\GuzzleHttp\Psr7\stream_for(
-            $image->encode($format, $quality)->getEncoded()
-        ));
+        $encoded_image = $image->encode($format, $quality)->getEncoded();
+        $output = function_exists('stream_for') ? stream_for($encoded_image) : Utils::streamFor($encoded_image);
+
+        $this->setOutput($output);
 
         return true;
     }

--- a/src/Intervention/Image/Commands/StreamCommand.php
+++ b/src/Intervention/Image/Commands/StreamCommand.php
@@ -3,7 +3,6 @@
 namespace Intervention\Image\Commands;
 
 use GuzzleHttp\Psr7\Utils;
-use function GuzzleHttp\Psr7\stream_for;
 
 class StreamCommand extends AbstractCommand
 {
@@ -20,7 +19,9 @@ class StreamCommand extends AbstractCommand
         $quality = $this->argument(1)->between(0, 100)->value();
 
         $encoded_image = $image->encode($format, $quality)->getEncoded();
-        $output = function_exists('stream_for') ? stream_for($encoded_image) : Utils::streamFor($encoded_image);
+        
+        // For backwards compatibility with guzzlehttp/psr7 ~1.1
+        $output = function_exists('\GuzzleHttp\Psr7\stream_for') ? \GuzzleHttp\Psr7\stream_for($encoded_image) : Utils::streamFor($encoded_image);
 
         $this->setOutput($output);
 


### PR DESCRIPTION
**Fixes #1095**
**Fixes flarum/core#2966**

`guzzlehttp/psr7` changed the function API to a utility class `Utils`, I checked and this should be the only function from that API used in this package.

https://github.com/guzzle/psr7/blob/c0dcda9f54d145bd4d062a6d15f54931a67732f9/README.md#upgrading-from-function-api 