### PR TITLE
GD AVIF support

### DIFF
--- a/src/Intervention/Image/Gd/Encoder.php
+++ b/src/Intervention/Image/Gd/Encoder.php
@@ -147,9 +147,23 @@ class Encoder extends \Intervention\Image\AbstractEncoder
      */
     protected function processAvif()
     {
-        throw new NotSupportedException(
-            "AVIF format is not supported by Gd Driver."
-        );
+	    if ( ! function_exists('imageavif')) {
+		    throw new NotSupportedException(
+		      "AVIF format is not supported by PHP installation."
+		    );
+	    }
+
+	    ob_start();
+        $resource = $this->image->getCore();
+	    imagepalettetotruecolor($resource);
+	    imagealphablending($resource, true);
+	    imagesavealpha($resource, true);
+	    imageavif($resource, null, $this->quality);
+	    $this->image->mime = defined('IMAGETYPE_AVIF') ? image_type_to_mime_type(IMAGETYPE_AVIF) : 'image/avif';
+	    $buffer = ob_get_contents();
+	    ob_end_clean();
+
+	    return $buffer;
     }
 
     /**

--- a/tests/EncoderTest.php
+++ b/tests/EncoderTest.php
@@ -60,7 +60,7 @@ class EncoderTest extends TestCase
             $this->assertEquals('image/webp; charset=binary', $this->getMime($encoder->result));
         }
     }
-    
+
     public function testProcessWebpGdWithUnSupportedPalette()
     {
         if (function_exists('imagewebp')) {
@@ -75,17 +75,18 @@ class EncoderTest extends TestCase
         }
     }
 
-
-    /**
-     * @expectedException \Intervention\Image\Exception\NotSupportedException
-     */
     public function testProcessAvifGd()
     {
-        $core = imagecreatefromjpeg(__DIR__.'/images/test.jpg');
-        $encoder = new GdEncoder;
-        $image = Mockery::mock('\Intervention\Image\Image');
-        $img = $encoder->process($image, 'avif', 90);
-        $this->assertInstanceOf('Intervention\Image\Image', $img);
+        if (function_exists('imageavif')) {
+            $core = imagecreatefromjpeg(__DIR__.'/images/test.jpg');
+            $encoder = new GdEncoder;
+            $image = Mockery::mock('\Intervention\Image\Image');
+            $image->shouldReceive('getCore')->once()->andReturn($core);
+            $image->shouldReceive('setEncoded')->once()->andReturn($image);
+            $img = $encoder->process($image, 'avif', 90);
+            $this->assertInstanceOf('Intervention\Image\Image', $img);
+            $this->assertEquals('image/avif; charset=binary', $this->getMime($encoder->result));
+        }
     }
 
     /**


### PR DESCRIPTION
This PR adds support for the AVIF imagetype in the GD driver.

GD AVIF support will be available in PHP 8.1: https://github.com/php/php-src/pull/7026

I've tested this on PHP 8.1beta3