### PR TITLE
Missing 'jfif' format encoder. Only have 'image/jfif' format.

### DIFF
--- a/src/Intervention/Image/AbstractEncoder.php
+++ b/src/Intervention/Image/AbstractEncoder.php
@@ -131,6 +131,7 @@ abstract class AbstractEncoder
 
             case 'jpg':
             case 'jpeg':
+            case 'jfif':
             case 'image/jp2':
             case 'image/jpg':
             case 'image/jpeg':


### PR DESCRIPTION
I have an issue with JFIF format. The problem is some of the JFIF the format only return as `jfif` not `image/jfif`. Right now the code only check for `image/jfif`. I just added `jfif` in the `AbstractEncoder.php` file.