### PR TITLE
Since symfony/http-foundation 5.1: The "Symfony\Component\HttpFoundation\Response::create()" method is deprecated, use "new Symfony\Component\HttpFoundation\Response()" instead

### DIFF
--- a/src/Intervention/Image/Response.php
+++ b/src/Intervention/Image/Response.php
@@ -62,7 +62,7 @@ class Response
 
         } elseif (class_exists('\Symfony\Component\HttpFoundation\Response')) {
 
-            $response = SymfonyResponse::create($data);
+            $response = new SymfonyResponse($data);
             $response->headers->set('Content-Type', $mime);
             $response->headers->set('Content-Length', $length);
 


### PR DESCRIPTION
This PR makes the Response Object compatible with Symfony 6.0, since Response::create() has been removed in Symfony 6.0.