### PR TITLE
[Next][Test] GD & ImageMagick tests require extension to run

### DIFF
--- a/tests/Drivers/Gd/ColorTest.php
+++ b/tests/Drivers/Gd/ColorTest.php
@@ -5,6 +5,9 @@ namespace Intervention\Image\Tests\Drivers\Gd;
 use Intervention\Image\Drivers\Gd\Color;
 use Intervention\Image\Tests\TestCase;
 
+/**
+ * @requires extension gd
+ */
 class ColorTest extends TestCase
 {
     protected function getTestColor($r = 0, $g = 0, $b = 0, $a = 0): Color

--- a/tests/Drivers/Gd/Decoders/ArrayColorDecoderTest.php
+++ b/tests/Drivers/Gd/Decoders/ArrayColorDecoderTest.php
@@ -6,6 +6,9 @@ use Intervention\Image\Drivers\Gd\Color;
 use Intervention\Image\Drivers\Gd\Decoders\ArrayColorDecoder;
 use Intervention\Image\Tests\TestCase;
 
+/**
+ * @requires extension gd
+ */
 class ArrayColorDecoderTest extends TestCase
 {
     public function testDecode(): void

--- a/tests/Drivers/Gd/Decoders/Base64ImageDecoderTest.php
+++ b/tests/Drivers/Gd/Decoders/Base64ImageDecoderTest.php
@@ -7,6 +7,9 @@ use Intervention\Image\Drivers\Gd\Image;
 use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateGdTestImage;
 
+/**
+ * @requires extension gd
+ */
 class Base64ImageDecoderTest extends TestCase
 {
     use CanCreateGdTestImage;

--- a/tests/Drivers/Gd/Decoders/BinaryImageDecoderTest.php
+++ b/tests/Drivers/Gd/Decoders/BinaryImageDecoderTest.php
@@ -6,6 +6,9 @@ use Intervention\Image\Drivers\Gd\Decoders\BinaryImageDecoder;
 use Intervention\Image\Drivers\Gd\Image;
 use Intervention\Image\Tests\TestCase;
 
+/**
+ * @requires extension gd
+ */
 class BinaryImageDecoderTest extends TestCase
 {
     public function testDecodePng(): void

--- a/tests/Drivers/Gd/Decoders/DataUriImageDecoderTest.php
+++ b/tests/Drivers/Gd/Decoders/DataUriImageDecoderTest.php
@@ -7,6 +7,9 @@ use Intervention\Image\Drivers\Gd\Image;
 use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateGdTestImage;
 
+/**
+ * @requires extension gd
+ */
 class DataUriImageDecoderTest extends TestCase
 {
     use CanCreateGdTestImage;

--- a/tests/Drivers/Gd/Decoders/FilePathImageDecoderTest.php
+++ b/tests/Drivers/Gd/Decoders/FilePathImageDecoderTest.php
@@ -7,6 +7,9 @@ use Intervention\Image\Drivers\Gd\Image;
 use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateGdTestImage;
 
+/**
+ * @requires extension gd
+ */
 class FilePathImageDecoderTest extends TestCase
 {
     use CanCreateGdTestImage;

--- a/tests/Drivers/Gd/Decoders/HexColorDecoderTest.php
+++ b/tests/Drivers/Gd/Decoders/HexColorDecoderTest.php
@@ -2,10 +2,13 @@
 
 namespace Intervention\Image\Tests\Drivers\Gd\Decoders;
 
-use Intervention\Image\Drivers\Gd\Decoders\HexColorDecoder;
 use Intervention\Image\Drivers\Gd\Color;
+use Intervention\Image\Drivers\Gd\Decoders\HexColorDecoder;
 use Intervention\Image\Tests\TestCase;
 
+/**
+ * @requires extension gd
+ */
 class HexColorDecoderTest extends TestCase
 {
     public function testDecode(): void

--- a/tests/Drivers/Gd/Decoders/ImageObjectDecoderTest.php
+++ b/tests/Drivers/Gd/Decoders/ImageObjectDecoderTest.php
@@ -7,6 +7,9 @@ use Intervention\Image\Drivers\Gd\Image;
 use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateGdTestImage;
 
+/**
+ * @requires extension gd
+ */
 class ImageObjectDecoderTest extends TestCase
 {
     use CanCreateGdTestImage;

--- a/tests/Drivers/Gd/Decoders/RgbStringColorDecoderTest.php
+++ b/tests/Drivers/Gd/Decoders/RgbStringColorDecoderTest.php
@@ -6,6 +6,9 @@ use Intervention\Image\Drivers\Gd\Color;
 use Intervention\Image\Drivers\Gd\Decoders\RgbStringColorDecoder;
 use Intervention\Image\Tests\TestCase;
 
+/**
+ * @requires extension gd
+ */
 class RgbStringColorDecoderTest extends TestCase
 {
     public function testDecodeRgb(): void

--- a/tests/Drivers/Gd/Decoders/TransparentColorDecoderTest.php
+++ b/tests/Drivers/Gd/Decoders/TransparentColorDecoderTest.php
@@ -6,6 +6,9 @@ use Intervention\Image\Drivers\Gd\Color;
 use Intervention\Image\Drivers\Gd\Decoders\TransparentColorDecoder;
 use Intervention\Image\Tests\TestCase;
 
+/**
+ * @requires extension gd
+ */
 class TransparentColorDecoderTest extends TestCase
 {
     public function testDecode(): void

--- a/tests/Drivers/Gd/Encoders/GifEncoderTest.php
+++ b/tests/Drivers/Gd/Encoders/GifEncoderTest.php
@@ -10,6 +10,9 @@ use Intervention\Image\Tests\TestCase;
 use Intervention\MimeSniffer\MimeSniffer;
 use Intervention\MimeSniffer\Types\ImageGif;
 
+/**
+ * @requires extension gd
+ */
 class GifEncoderTest extends TestCase
 {
     protected function getTestImage(): Image

--- a/tests/Drivers/Gd/Encoders/JpegEncoderTest.php
+++ b/tests/Drivers/Gd/Encoders/JpegEncoderTest.php
@@ -10,6 +10,9 @@ use Intervention\Image\Tests\TestCase;
 use Intervention\MimeSniffer\MimeSniffer;
 use Intervention\MimeSniffer\Types\ImageJpeg;
 
+/**
+ * @requires extension gd
+ */
 class JpegEncoderTest extends TestCase
 {
     protected function getTestImage(): Image

--- a/tests/Drivers/Gd/Encoders/PngEncoderTest.php
+++ b/tests/Drivers/Gd/Encoders/PngEncoderTest.php
@@ -10,6 +10,9 @@ use Intervention\Image\Tests\TestCase;
 use Intervention\MimeSniffer\MimeSniffer;
 use Intervention\MimeSniffer\Types\ImagePng;
 
+/**
+ * @requires extension gd
+ */
 class PngEncoderTest extends TestCase
 {
     protected function getTestImage(): Image

--- a/tests/Drivers/Gd/FrameTest.php
+++ b/tests/Drivers/Gd/FrameTest.php
@@ -8,6 +8,9 @@ use Intervention\Image\Drivers\Gd\Image;
 use Intervention\Image\Geometry\Size;
 use Intervention\Image\Tests\TestCase;
 
+/**
+ * @requires extension gd
+ */
 class FrameTest extends TestCase
 {
     protected function getTestFrame(): Frame

--- a/tests/Drivers/Gd/ImageFactoryTest.php
+++ b/tests/Drivers/Gd/ImageFactoryTest.php
@@ -7,6 +7,9 @@ use Intervention\Image\Drivers\Gd\Image;
 use Intervention\Image\Drivers\Gd\ImageFactory;
 use Intervention\Image\Tests\TestCase;
 
+/**
+ * @requires extension gd
+ */
 class ImageFactoryTest extends TestCase
 {
     public function testNewImage(): void

--- a/tests/Drivers/Gd/ImageTest.php
+++ b/tests/Drivers/Gd/ImageTest.php
@@ -9,6 +9,9 @@ use Intervention\Image\Drivers\Gd\Image;
 use Intervention\Image\Geometry\Size;
 use Intervention\Image\Tests\TestCase;
 
+/**
+ * @requires extension gd
+ */
 class ImageTest extends TestCase
 {
     protected Image $image;

--- a/tests/Drivers/Gd/InputHandlerTest.php
+++ b/tests/Drivers/Gd/InputHandlerTest.php
@@ -2,15 +2,15 @@
 
 namespace Intervention\Image\Tests\Drivers\Gd;
 
-use Intervention\Image\Collection;
 use Intervention\Image\Drivers\Gd\Color;
-use Intervention\Image\Drivers\Gd\Frame;
 use Intervention\Image\Drivers\Gd\Image;
 use Intervention\Image\Drivers\Gd\InputHandler;
 use Intervention\Image\Exceptions\DecoderException;
-use Intervention\Image\Geometry\Size;
 use Intervention\Image\Tests\TestCase;
 
+/**
+ * @requires extension gd
+ */
 class InputHandlerTest extends TestCase
 {
     public function testHandleEmptyString(): void

--- a/tests/Drivers/Gd/Modifiers/BlurModifierTest.php
+++ b/tests/Drivers/Gd/Modifiers/BlurModifierTest.php
@@ -2,11 +2,13 @@
 
 namespace Intervention\Image\Tests\Drivers\Gd\Modifiers;
 
-use Intervention\Image\Drivers\Gd\Image;
 use Intervention\Image\Drivers\Gd\Modifiers\BlurModifier;
 use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateGdTestImage;
 
+/**
+ * @requires extension gd
+ */
 class BlurModifierTest extends TestCase
 {
     use CanCreateGdTestImage;

--- a/tests/Drivers/Gd/Modifiers/BrightnessModifierTest.php
+++ b/tests/Drivers/Gd/Modifiers/BrightnessModifierTest.php
@@ -2,11 +2,13 @@
 
 namespace Intervention\Image\Tests\Drivers\Gd\Modifiers;
 
-use Intervention\Image\Drivers\Gd\Image;
 use Intervention\Image\Drivers\Gd\Modifiers\BrightnessModifier;
 use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateGdTestImage;
 
+/**
+ * @requires extension gd
+ */
 class BrightnessModifierTest extends TestCase
 {
     use CanCreateGdTestImage;

--- a/tests/Drivers/Gd/Modifiers/ContrastModifierTest.php
+++ b/tests/Drivers/Gd/Modifiers/ContrastModifierTest.php
@@ -2,11 +2,13 @@
 
 namespace Intervention\Image\Tests\Drivers\Gd\Modifiers;
 
-use Intervention\Image\Drivers\Gd\Image;
 use Intervention\Image\Drivers\Gd\Modifiers\ContrastModifier;
 use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateGdTestImage;
 
+/**
+ * @requires extension gd
+ */
 class ContrastModifierTest extends TestCase
 {
     use CanCreateGdTestImage;

--- a/tests/Drivers/Gd/Modifiers/DestroyModifierTest.php
+++ b/tests/Drivers/Gd/Modifiers/DestroyModifierTest.php
@@ -3,11 +3,13 @@
 namespace Intervention\Image\Tests\Drivers\Gd\Modifiers;
 
 use GdImage;
-use Intervention\Image\Drivers\Gd\Image;
 use Intervention\Image\Drivers\Gd\Modifiers\DestroyModifier;
 use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateGdTestImage;
 
+/**
+ * @requires extension gd
+ */
 class DestroyModifierTest extends TestCase
 {
     use CanCreateGdTestImage;

--- a/tests/Drivers/Gd/Modifiers/FillModifierTest.php
+++ b/tests/Drivers/Gd/Modifiers/FillModifierTest.php
@@ -8,6 +8,9 @@ use Intervention\Image\Geometry\Point;
 use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateGdTestImage;
 
+/**
+ * @requires extension gd
+ */
 class FillModifierTest extends TestCase
 {
     use CanCreateGdTestImage;

--- a/tests/Drivers/Gd/Modifiers/FitModifierTest.php
+++ b/tests/Drivers/Gd/Modifiers/FitModifierTest.php
@@ -2,13 +2,13 @@
 
 namespace Intervention\Image\Tests\Drivers\Gd\Modifiers;
 
-use Intervention\Image\Drivers\Gd\Image;
 use Intervention\Image\Drivers\Gd\Modifiers\FitModifier;
-use Intervention\Image\Geometry\Point;
-use Intervention\Image\Geometry\Size;
 use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateGdTestImage;
 
+/**
+ * @requires extension gd
+ */
 class FitModifierTest extends TestCase
 {
     use CanCreateGdTestImage;

--- a/tests/Drivers/Gd/Modifiers/GreyscaleModifierTest.php
+++ b/tests/Drivers/Gd/Modifiers/GreyscaleModifierTest.php
@@ -2,11 +2,13 @@
 
 namespace Intervention\Image\Tests\Drivers\Gd\Modifiers;
 
-use Intervention\Image\Tests\TestCase;
-use Intervention\Image\Drivers\Gd\Image;
 use Intervention\Image\Drivers\Gd\Modifiers\GreyscaleModifier;
+use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateGdTestImage;
 
+/**
+ * @requires extension gd
+ */
 class GreyscaleModifierTest extends TestCase
 {
     use CanCreateGdTestImage;

--- a/tests/Drivers/Gd/Modifiers/InvertModifierTest.php
+++ b/tests/Drivers/Gd/Modifiers/InvertModifierTest.php
@@ -2,11 +2,13 @@
 
 namespace Intervention\Image\Tests\Drivers\Gd\Modifiers;
 
-use Intervention\Image\Tests\TestCase;
-use Intervention\Image\Drivers\Gd\Image;
 use Intervention\Image\Drivers\Gd\Modifiers\InvertModifier;
+use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateGdTestImage;
 
+/**
+ * @requires extension gd
+ */
 class InvertModifierTest extends TestCase
 {
     use CanCreateGdTestImage;

--- a/tests/Drivers/Gd/Modifiers/PixelateModifierTest.php
+++ b/tests/Drivers/Gd/Modifiers/PixelateModifierTest.php
@@ -2,11 +2,13 @@
 
 namespace Intervention\Image\Tests\Drivers\Gd\Modifiers;
 
-use Intervention\Image\Drivers\Gd\Image;
 use Intervention\Image\Drivers\Gd\Modifiers\PixelateModifier;
 use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateGdTestImage;
 
+/**
+ * @requires extension gd
+ */
 class PixelateModifierTest extends TestCase
 {
     use CanCreateGdTestImage;

--- a/tests/Drivers/Gd/Modifiers/PlaceModifierTest.php
+++ b/tests/Drivers/Gd/Modifiers/PlaceModifierTest.php
@@ -2,12 +2,13 @@
 
 namespace Intervention\Image\Tests\Drivers\Gd\Modifiers;
 
-use Intervention\Image\Drivers\Gd\Image;
 use Intervention\Image\Drivers\Gd\Modifiers\PlaceModifier;
-use Intervention\Image\Geometry\Size;
 use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateGdTestImage;
 
+/**
+ * @requires extension gd
+ */
 class PlaceModifierTest extends TestCase
 {
     use CanCreateGdTestImage;

--- a/tests/Drivers/Gd/Modifiers/ResizeModifierTest.php
+++ b/tests/Drivers/Gd/Modifiers/ResizeModifierTest.php
@@ -2,12 +2,13 @@
 
 namespace Intervention\Image\Tests\Drivers\Gd\Modifiers;
 
-use Intervention\Image\Drivers\Gd\Image;
 use Intervention\Image\Drivers\Gd\Modifiers\ResizeModifier;
-use Intervention\Image\Geometry\Size;
 use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateGdTestImage;
 
+/**
+ * @requires extension gd
+ */
 class ResizeModifierTest extends TestCase
 {
     use CanCreateGdTestImage;

--- a/tests/Drivers/Gd/Modifiers/SharpenModifierTest.php
+++ b/tests/Drivers/Gd/Modifiers/SharpenModifierTest.php
@@ -2,11 +2,13 @@
 
 namespace Intervention\Image\Tests\Drivers\Gd\Modifiers;
 
-use Intervention\Image\Tests\TestCase;
-use Intervention\Image\Drivers\Gd\Image;
 use Intervention\Image\Drivers\Gd\Modifiers\SharpenModifier;
+use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateGdTestImage;
 
+/**
+ * @requires extension gd
+ */
 class SharpenModifierTest extends TestCase
 {
     use CanCreateGdTestImage;

--- a/tests/Drivers/Imagick/ColorTest.php
+++ b/tests/Drivers/Imagick/ColorTest.php
@@ -6,6 +6,9 @@ use ImagickPixel;
 use Intervention\Image\Drivers\Imagick\Color;
 use Intervention\Image\Tests\TestCase;
 
+/**
+ * @requires extension imagick
+ */
 class ColorTest extends TestCase
 {
     protected function getTestColor(int $r = 0, int $g = 0, int $b = 0, float $a = 1): Color

--- a/tests/Drivers/Imagick/Decoders/ArrayColorDecoderTest.php
+++ b/tests/Drivers/Imagick/Decoders/ArrayColorDecoderTest.php
@@ -6,6 +6,9 @@ use Intervention\Image\Drivers\Imagick\Color;
 use Intervention\Image\Drivers\Imagick\Decoders\ArrayColorDecoder;
 use Intervention\Image\Tests\TestCase;
 
+/**
+ * @requires extension imagick
+ */
 class ArrayColorDecoderTest extends TestCase
 {
     public function testDecode(): void

--- a/tests/Drivers/Imagick/Decoders/ImageObjectDecoderTest.php
+++ b/tests/Drivers/Imagick/Decoders/ImageObjectDecoderTest.php
@@ -7,6 +7,9 @@ use Intervention\Image\Drivers\Imagick\Image;
 use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateImagickTestImage;
 
+/**
+ * @requires extension imagick
+ */
 class ImageObjectDecoderTest extends TestCase
 {
     use CanCreateImagickTestImage;

--- a/tests/Drivers/Imagick/Decoders/RgbStringColorDecoderTest.php
+++ b/tests/Drivers/Imagick/Decoders/RgbStringColorDecoderTest.php
@@ -6,6 +6,9 @@ use Intervention\Image\Drivers\Imagick\Color;
 use Intervention\Image\Drivers\Imagick\Decoders\RgbStringColorDecoder;
 use Intervention\Image\Tests\TestCase;
 
+/**
+ * @requires extension imagick
+ */
 class RgbStringColorDecoderTest extends TestCase
 {
     public function testDecodeRgb(): void

--- a/tests/Drivers/Imagick/Decoders/TransparentColorDecoderTest.php
+++ b/tests/Drivers/Imagick/Decoders/TransparentColorDecoderTest.php
@@ -6,6 +6,9 @@ use Intervention\Image\Drivers\Imagick\Color;
 use Intervention\Image\Drivers\Imagick\Decoders\TransparentColorDecoder;
 use Intervention\Image\Tests\TestCase;
 
+/**
+ * @requires extension imagick
+ */
 class TransparentColorDecoderTest extends TestCase
 {
     public function testDecode(): void

--- a/tests/Drivers/Imagick/Encoders/GifEncoderTest.php
+++ b/tests/Drivers/Imagick/Encoders/GifEncoderTest.php
@@ -12,6 +12,9 @@ use Intervention\Image\Tests\TestCase;
 use Intervention\MimeSniffer\MimeSniffer;
 use Intervention\MimeSniffer\Types\ImageGif;
 
+/**
+ * @requires extension imagick
+ */
 class GifEncoderTest extends TestCase
 {
     protected function getTestImage(): Image

--- a/tests/Drivers/Imagick/Encoders/JpegEncoderTest.php
+++ b/tests/Drivers/Imagick/Encoders/JpegEncoderTest.php
@@ -12,6 +12,9 @@ use Intervention\Image\Tests\TestCase;
 use Intervention\MimeSniffer\MimeSniffer;
 use Intervention\MimeSniffer\Types\ImageJpeg;
 
+/**
+ * @requires extension imagick
+ */
 class JpegEncoderTest extends TestCase
 {
     protected function getTestImage(): Image

--- a/tests/Drivers/Imagick/FrameTest.php
+++ b/tests/Drivers/Imagick/FrameTest.php
@@ -9,6 +9,9 @@ use Intervention\Image\Drivers\Imagick\Image;
 use Intervention\Image\Geometry\Size;
 use Intervention\Image\Tests\TestCase;
 
+/**
+ * @requires extension imagick
+ */
 class FrameTest extends TestCase
 {
     protected function getTestFrame(): Frame

--- a/tests/Drivers/Imagick/ImageFactoryTest.php
+++ b/tests/Drivers/Imagick/ImageFactoryTest.php
@@ -7,6 +7,9 @@ use Intervention\Image\Drivers\Imagick\Image;
 use Intervention\Image\Drivers\Imagick\ImageFactory;
 use Intervention\Image\Tests\TestCase;
 
+/**
+ * @requires extension imagick
+ */
 class ImageFactoryTest extends TestCase
 {
     public function testNewImage(): void

--- a/tests/Drivers/Imagick/ImageTest.php
+++ b/tests/Drivers/Imagick/ImageTest.php
@@ -10,6 +10,9 @@ use Intervention\Image\Drivers\Imagick\Image;
 use Intervention\Image\Geometry\Size;
 use Intervention\Image\Tests\TestCase;
 
+/**
+ * @requires extension imagick
+ */
 class ImageTest extends TestCase
 {
     protected Image $image;

--- a/tests/Drivers/Imagick/InputHandlerTest.php
+++ b/tests/Drivers/Imagick/InputHandlerTest.php
@@ -2,15 +2,15 @@
 
 namespace Intervention\Image\Tests\Drivers\Imagick;
 
-use Intervention\Image\Collection;
 use Intervention\Image\Drivers\Imagick\Color;
-use Intervention\Image\Drivers\Imagick\Frame;
 use Intervention\Image\Drivers\Imagick\Image;
 use Intervention\Image\Drivers\Imagick\InputHandler;
 use Intervention\Image\Exceptions\DecoderException;
-use Intervention\Image\Geometry\Size;
 use Intervention\Image\Tests\TestCase;
 
+/**
+ * @requires extension imagick
+ */
 class InputHandlerTest extends TestCase
 {
     public function testHandleEmptyString(): void

--- a/tests/Drivers/Imagick/Modifiers/BlurModifierTest.php
+++ b/tests/Drivers/Imagick/Modifiers/BlurModifierTest.php
@@ -2,11 +2,13 @@
 
 namespace Intervention\Image\Tests\Drivers\Imagick\Modifiers;
 
-use Intervention\Image\Tests\TestCase;
-use Intervention\Image\Drivers\Imagick\Image;
 use Intervention\Image\Drivers\Imagick\Modifiers\BlurModifier;
+use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateImagickTestImage;
 
+/**
+ * @requires extension imagick
+ */
 class BlurModifierTest extends TestCase
 {
     use CanCreateImagickTestImage;

--- a/tests/Drivers/Imagick/Modifiers/BrightnessModifierTest.php
+++ b/tests/Drivers/Imagick/Modifiers/BrightnessModifierTest.php
@@ -2,11 +2,13 @@
 
 namespace Intervention\Image\Tests\Drivers\Imagick\Modifiers;
 
-use Intervention\Image\Tests\TestCase;
-use Intervention\Image\Drivers\Imagick\Image;
 use Intervention\Image\Drivers\Imagick\Modifiers\BrightnessModifier;
+use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateImagickTestImage;
 
+/**
+ * @requires extension imagick
+ */
 class BrightnessModifierTest extends TestCase
 {
     use CanCreateImagickTestImage;

--- a/tests/Drivers/Imagick/Modifiers/ContrastModifierTest.php
+++ b/tests/Drivers/Imagick/Modifiers/ContrastModifierTest.php
@@ -2,11 +2,13 @@
 
 namespace Intervention\Image\Tests\Drivers\Imagick\Modifiers;
 
-use Intervention\Image\Tests\TestCase;
-use Intervention\Image\Drivers\Imagick\Image;
 use Intervention\Image\Drivers\Imagick\Modifiers\ContrastModifier;
+use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateImagickTestImage;
 
+/**
+ * @requires extension imagick
+ */
 class ContrastModifierTest extends TestCase
 {
     use CanCreateImagickTestImage;

--- a/tests/Drivers/Imagick/Modifiers/DestroyModifierTest.php
+++ b/tests/Drivers/Imagick/Modifiers/DestroyModifierTest.php
@@ -3,11 +3,13 @@
 namespace Intervention\Image\Tests\Drivers\Imagick\Modifiers;
 
 use Imagick;
-use Intervention\Image\Tests\TestCase;
-use Intervention\Image\Drivers\Imagick\Image;
 use Intervention\Image\Drivers\Imagick\Modifiers\DestroyModifier;
+use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateImagickTestImage;
 
+/**
+ * @requires extension imagick
+ */
 class DestroyModifierTest extends TestCase
 {
     use CanCreateImagickTestImage;

--- a/tests/Drivers/Imagick/Modifiers/FillModifierTest.php
+++ b/tests/Drivers/Imagick/Modifiers/FillModifierTest.php
@@ -4,12 +4,14 @@ namespace Intervention\Image\Tests\Drivers\Imagick\Modifiers;
 
 use ImagickPixel;
 use Intervention\Image\Drivers\Imagick\Color;
-use Intervention\Image\Drivers\Imagick\Image;
 use Intervention\Image\Drivers\Imagick\Modifiers\FillModifier;
 use Intervention\Image\Geometry\Point;
 use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateImagickTestImage;
 
+/**
+ * @requires extension imagick
+ */
 class FillModifierTest extends TestCase
 {
     use CanCreateImagickTestImage;

--- a/tests/Drivers/Imagick/Modifiers/FitModifierTest.php
+++ b/tests/Drivers/Imagick/Modifiers/FitModifierTest.php
@@ -2,13 +2,13 @@
 
 namespace Intervention\Image\Tests\Drivers\Imagick\Modifiers;
 
-use Intervention\Image\Drivers\Imagick\Image;
 use Intervention\Image\Drivers\Imagick\Modifiers\FitModifier;
-use Intervention\Image\Geometry\Point;
-use Intervention\Image\Geometry\Size;
 use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateImagickTestImage;
 
+/**
+ * @requires extension imagick
+ */
 class FitModifierTest extends TestCase
 {
     use CanCreateImagickTestImage;

--- a/tests/Drivers/Imagick/Modifiers/GreyscaleModifierTest.php
+++ b/tests/Drivers/Imagick/Modifiers/GreyscaleModifierTest.php
@@ -2,11 +2,13 @@
 
 namespace Intervention\Image\Tests\Drivers\Imagick\Modifiers;
 
-use Intervention\Image\Tests\TestCase;
-use Intervention\Image\Drivers\Imagick\Image;
 use Intervention\Image\Drivers\Imagick\Modifiers\GreyscaleModifier;
+use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateImagickTestImage;
 
+/**
+ * @requires extension imagick
+ */
 class GreyscaleModifierTest extends TestCase
 {
     use CanCreateImagickTestImage;

--- a/tests/Drivers/Imagick/Modifiers/InvertModifierTest.php
+++ b/tests/Drivers/Imagick/Modifiers/InvertModifierTest.php
@@ -2,11 +2,13 @@
 
 namespace Intervention\Image\Tests\Drivers\Imagick\Modifiers;
 
-use Intervention\Image\Tests\TestCase;
-use Intervention\Image\Drivers\Imagick\Image;
 use Intervention\Image\Drivers\Imagick\Modifiers\InvertModifier;
+use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateImagickTestImage;
 
+/**
+ * @requires extension imagick
+ */
 class InvertModifierTest extends TestCase
 {
     use CanCreateImagickTestImage;

--- a/tests/Drivers/Imagick/Modifiers/PixelateModifierTest.php
+++ b/tests/Drivers/Imagick/Modifiers/PixelateModifierTest.php
@@ -2,11 +2,13 @@
 
 namespace Intervention\Image\Tests\Drivers\Imagick\Modifiers;
 
-use Intervention\Image\Drivers\Imagick\Image;
 use Intervention\Image\Drivers\Imagick\Modifiers\PixelateModifier;
 use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateImagickTestImage;
 
+/**
+ * @requires extension imagick
+ */
 class PixelateModifierTest extends TestCase
 {
     use CanCreateImagickTestImage;

--- a/tests/Drivers/Imagick/Modifiers/PlaceModifierTest.php
+++ b/tests/Drivers/Imagick/Modifiers/PlaceModifierTest.php
@@ -2,12 +2,13 @@
 
 namespace Intervention\Image\Tests\Drivers\Imagick\Modifiers;
 
-use Intervention\Image\Drivers\Imagick\Image;
 use Intervention\Image\Drivers\Imagick\Modifiers\PlaceModifier;
-use Intervention\Image\Geometry\Size;
 use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateImagickTestImage;
 
+/**
+ * @requires extension imagick
+ */
 class PlaceModifierTest extends TestCase
 {
     use CanCreateImagickTestImage;

--- a/tests/Drivers/Imagick/Modifiers/ResizeModifierTest.php
+++ b/tests/Drivers/Imagick/Modifiers/ResizeModifierTest.php
@@ -2,13 +2,14 @@
 
 namespace Intervention\Image\Tests\Drivers\Imagick\Modifiers;
 
-use Intervention\Image\Drivers\Imagick\Image;
 use Intervention\Image\Drivers\Imagick\Modifiers\ResizeModifier;
-use Intervention\Image\Geometry\Size;
 use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateImagickTestImage;
 
-class CropResizeModifierTest extends TestCase
+/**
+ * @requires extension imagick
+ */
+class ResizeModifierTest extends TestCase
 {
     use CanCreateImagickTestImage;
 

--- a/tests/Drivers/Imagick/Modifiers/SharpenModifierTest.php
+++ b/tests/Drivers/Imagick/Modifiers/SharpenModifierTest.php
@@ -2,11 +2,13 @@
 
 namespace Intervention\Image\Tests\Drivers\Imagick\Modifiers;
 
-use Intervention\Image\Tests\TestCase;
-use Intervention\Image\Drivers\Imagick\Image;
 use Intervention\Image\Drivers\Imagick\Modifiers\SharpenModifier;
+use Intervention\Image\Tests\TestCase;
 use Intervention\Image\Tests\Traits\CanCreateImagickTestImage;
 
+/**
+ * @requires extension imagick
+ */
 class SharpenModifierTest extends TestCase
 {
     use CanCreateImagickTestImage;

--- a/tests/ImageManagerTest.php
+++ b/tests/ImageManagerTest.php
@@ -13,6 +13,7 @@ class ImageManagerTest extends TestCase
         $this->assertInstanceOf(ImageManager::class, $manager);
     }
 
+    /** @requires extension gd */
     public function testCreateGd()
     {
         $manager = new ImageManager('gd');
@@ -20,6 +21,7 @@ class ImageManagerTest extends TestCase
         $this->assertInstanceOf(ImageInterface::class, $image);
     }
 
+    /** @requires extension gd */
     public function testMakeGd()
     {
         $manager = new ImageManager('gd');
@@ -27,6 +29,7 @@ class ImageManagerTest extends TestCase
         $this->assertInstanceOf(ImageInterface::class, $image);
     }
 
+    /** @requires extension imagick */
     public function testCreateImagick()
     {
         $manager = new ImageManager('imagick');
@@ -34,6 +37,7 @@ class ImageManagerTest extends TestCase
         $this->assertInstanceOf(ImageInterface::class, $image);
     }
 
+    /** @requires extension imagick */
     public function testMakeImagick()
     {
         $manager = new ImageManager('imagick');


### PR DESCRIPTION
This updates the test in `next` to skip tests that require a specific extension module to be loaded, and it isn't.

Makes development easier when only one driver is loaded locally :smiley_cat: 