### PR TITLE
Update User-Agent to latest Chrome

### DIFF
--- a/src/Intervention/Image/AbstractDecoder.php
+++ b/src/Intervention/Image/AbstractDecoder.php
@@ -71,7 +71,7 @@ abstract class AbstractDecoder
                 'method'=>"GET",
                 'protocol_version'=>1.1, // force use HTTP 1.1 for service mesh environment with envoy
                 'header'=>"Accept-language: en\r\n".
-                "User-Agent: Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.2 (KHTML, like Gecko) Chrome/22.0.1216.0 Safari/537.2\r\n"
+                "User-Agent: Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.71 Safari/537.36\r\n"
           ]
         ];
         


### PR DESCRIPTION
Some services, like https://lucid.app/documents/image/882959d4-782d-44f7-8e13-ca4f338e0876/2/2000 recognizes Intervention/image user agent as an old browser and serve redirect, instead of image content. This PR updates `user-agent` to latest stable chrome version.

Before:
```
curl -H "User-Agent: Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.2 (KHTML, like Gecko) Chrome/22.0.1216.0 Safari/537.2" https://lucid.app/documents/image/882959d4-782d-44f7-8e13-ca4f338e0876/2/2000 -I
HTTP/1.1 302 Found
content-length: 0
location: https://www.lucidchart.com/pages/old_browser
[...]
```

After:
```
curl -H "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.71 Safari/537.36" https://lucid.app/documents/image/882959d4-782d-44f7-8e13-ca4f338e0876/2/2000 -I
HTTP/1.1 200 OK
vary: Origin
x-lucid-flow-id: 67de87de675af82
content-length: 1797
content-type: image/png
[...]
```
