### PR TITLE
Prevent passing of null to strtolower() : Size.php

### DIFF
--- a/src/Intervention/Image/Size.php
+++ b/src/Intervention/Image/Size.php
@@ -278,7 +278,7 @@ class Size
      */
     public function align($position, $offset_x = 0, $offset_y = 0)
     {
-        switch (strtolower($position)) {
+        switch (strtolower($position ?: '')) {
 
             case 'top':
             case 'top-center':


### PR DESCRIPTION
Fix deprecation error when running under php8.1
```strtolower(): Passing null to parameter #1 ($string) of type string is deprecated
vendor/intervention/image/src/Intervention/Image/Size.php, line 281```