### PR TITLE
Fixed deprecation warnings with PHP 8.1

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -31,9 +31,9 @@ class Collection implements CollectionInterface, IteratorAggregate, Countable
     /**
      * Returns Iterator
      *
-     * @return array
+     * @return \Traversable
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new ArrayIterator($this->items);
     }

--- a/src/Drivers/Gd/Modifiers/BrightnessModifier.php
+++ b/src/Drivers/Gd/Modifiers/BrightnessModifier.php
@@ -15,7 +15,7 @@ class BrightnessModifier implements ModifierInterface
     public function apply(ImageInterface $image): ImageInterface
     {
         foreach ($image as $frame) {
-            imagefilter($frame->getCore(), IMG_FILTER_BRIGHTNESS, ($this->level * 2.55));
+            imagefilter($frame->getCore(), IMG_FILTER_BRIGHTNESS, intval($this->level * 2.55));
         }
 
         return $image;


### PR DESCRIPTION
Fixed a couple of warnings with PHP 8.1:
```
PHP Deprecated:  Implicit conversion from float 76.5 to int loses precision in /Users/deluxetom/Dev/dlxmedia/intervention-image/src/Drivers/Gd/Modifiers/BrightnessModifier.php on line 18
```

```
PHP Deprecated:  Return type of Intervention\Image\Collection::getIterator(): iterable should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/deluxetom/Dev/dlxmedia/intervention-image/src/Collection.php on line 36
```