### PR TITLE
Explicitly convert to integer

### DIFF
--- a/src/Intervention/Image/Gd/Commands/ResizeCommand.php
+++ b/src/Intervention/Image/Gd/Commands/ResizeCommand.php
@@ -44,7 +44,7 @@ class ResizeCommand extends AbstractCommand
     protected function modify($image, $dst_x, $dst_y, $src_x, $src_y, $dst_w, $dst_h, $src_w, $src_h)
     {
         // create new image
-        $modified = imagecreatetruecolor($dst_w, $dst_h);
+        $modified = imagecreatetruecolor(intval($dst_w), intval($dst_h));
 
         // get current image
         $resource = $image->getCore();
@@ -70,8 +70,8 @@ class ResizeCommand extends AbstractCommand
             $dst_y,
             $src_x,
             $src_y,
-            $dst_w,
-            $dst_h,
+            intval($dst_w),
+            intval($dst_h),
             $src_w,
             $src_h
         );


### PR DESCRIPTION
This is intended to stop deprecation notices on PHP 8.1, e.g.:
```
Implicit conversion from float 256.8493150684931 to int loses precision in /.../vendor/intervention/image/src/Intervention/Image/Gd/Commands/ResizeCommand.php on line 67 [] []
```

The other usages of these functions don't look like they will cause this problem.