### PR TITLE
Final public method for abstract class

### DIFF
--- a/src/Intervention/Image/AbstractColor.php
+++ b/src/Intervention/Image/AbstractColor.php
@@ -114,7 +114,7 @@ abstract class AbstractColor
      * @param  mixed $value
      * @return \Intervention\Image\AbstractColor
      */
-    public function parse($value)
+    final public function parse($value)
     {
         switch (true) {
 
@@ -153,7 +153,7 @@ abstract class AbstractColor
      * @param  string $type
      * @return mixed
      */
-    public function format($type)
+    final public function format($type)
     {
         switch (strtolower($type)) {
 

--- a/src/Intervention/Image/AbstractDecoder.php
+++ b/src/Intervention/Image/AbstractDecoder.php
@@ -63,7 +63,7 @@ abstract class AbstractDecoder
      * @param  string $url
      * @return \Intervention\Image\Image
      */
-    public function initFromUrl($url)
+    final public function initFromUrl($url)
     {
         
         $options = [
@@ -93,7 +93,7 @@ abstract class AbstractDecoder
      * @param StreamInterface|resource $stream
      * @return \Intervention\Image\Image
      */
-    public function initFromStream($stream)
+    final public function initFromStream($stream)
     {
         if (!$stream instanceof StreamInterface) {
             $stream = new Stream($stream);
@@ -135,7 +135,7 @@ abstract class AbstractDecoder
      *
      * @return boolean
      */
-    public function isGdResource()
+    final public function isGdResource()
     {
         if (is_resource($this->data)) {
             return (get_resource_type($this->data) == 'gd');
@@ -153,7 +153,7 @@ abstract class AbstractDecoder
      *
      * @return boolean
      */
-    public function isImagick()
+    final public function isImagick()
     {
         return is_a($this->data, 'Imagick');
     }
@@ -163,7 +163,7 @@ abstract class AbstractDecoder
      *
      * @return boolean
      */
-    public function isInterventionImage()
+    final public function isInterventionImage()
     {
         return is_a($this->data, '\Intervention\Image\Image');
     }
@@ -173,7 +173,7 @@ abstract class AbstractDecoder
      *
      * @return boolean
      */
-    public function isSplFileInfo()
+    final public function isSplFileInfo()
     {
         return is_a($this->data, 'SplFileInfo');
     }
@@ -183,7 +183,7 @@ abstract class AbstractDecoder
      *
      * @return boolean
      */
-    public function isSymfonyUpload()
+    final public function isSymfonyUpload()
     {
         return is_a($this->data, 'Symfony\Component\HttpFoundation\File\UploadedFile');
     }
@@ -193,7 +193,7 @@ abstract class AbstractDecoder
      *
      * @return boolean
      */
-    public function isFilePath()
+    final public function isFilePath()
     {
         if (is_string($this->data)) {
             try {
@@ -211,7 +211,7 @@ abstract class AbstractDecoder
      *
      * @return boolean
      */
-    public function isUrl()
+    final public function isUrl()
     {
         return (bool) filter_var($this->data, FILTER_VALIDATE_URL);
     }
@@ -221,7 +221,7 @@ abstract class AbstractDecoder
      *
      * @return boolean
      */
-    public function isStream()
+    final public function isStream()
     {
         if ($this->data instanceof StreamInterface) return true;
         if (!is_resource($this->data)) return false;
@@ -235,7 +235,7 @@ abstract class AbstractDecoder
      *
      * @return boolean
      */
-    public function isBinary()
+    final public function isBinary()
     {
         if (is_string($this->data)) {
             $mime = finfo_buffer(finfo_open(FILEINFO_MIME_TYPE), $this->data);
@@ -250,7 +250,7 @@ abstract class AbstractDecoder
      *
      * @return boolean
      */
-    public function isDataUrl()
+    final public function isDataUrl()
     {
         $data = $this->decodeDataUrl($this->data);
 
@@ -262,7 +262,7 @@ abstract class AbstractDecoder
      *
      * @return boolean
      */
-    public function isBase64()
+    final public function isBase64()
     {
         if (!is_string($this->data)) {
             return false;
@@ -277,7 +277,7 @@ abstract class AbstractDecoder
      * @param  Image $object
      * @return \Intervention\Image\Image
      */
-    public function initFromInterventionImage($object)
+    final public function initFromInterventionImage($object)
     {
         return $object;
     }
@@ -310,7 +310,7 @@ abstract class AbstractDecoder
      * @param  mixed $data
      * @return \Intervention\Image\Image
      */
-    public function init($data)
+    final public function init($data)
     {
         $this->data = $data;
 

--- a/src/Intervention/Image/AbstractDriver.php
+++ b/src/Intervention/Image/AbstractDriver.php
@@ -50,7 +50,7 @@ abstract class AbstractDriver
      *
      * @return mixed
      */
-    public function cloneCore($core)
+    final public function cloneCore($core)
     {
         return clone $core;
     }
@@ -61,7 +61,7 @@ abstract class AbstractDriver
      * @param  mixed $data
      * @return \Intervention\Image\Image
      */
-    public function init($data)
+    final public function init($data)
     {
         return $this->decoder->init($data);
     }
@@ -74,7 +74,7 @@ abstract class AbstractDriver
      * @param  int     $quality
      * @return \Intervention\Image\Image
      */
-    public function encode($image, $format, $quality)
+    final public function encode($image, $format, $quality)
     {
         return $this->encoder->process($image, $format, $quality);
     }
@@ -87,7 +87,7 @@ abstract class AbstractDriver
      * @param  array $arguments
      * @return \Intervention\Image\Commands\AbstractCommand
      */
-    public function executeCommand($image, $name, $arguments)
+    final public function executeCommand($image, $name, $arguments)
     {
         $commandName = $this->getCommandClassName($name);
         $command = new $commandName($arguments);
@@ -130,7 +130,7 @@ abstract class AbstractDriver
      *
      * @return string
      */
-    public function getDriverName()
+    final public function getDriverName()
     {
         $reflect = new \ReflectionClass($this);
         $namespace = $reflect->getNamespaceName();

--- a/src/Intervention/Image/AbstractEncoder.php
+++ b/src/Intervention/Image/AbstractEncoder.php
@@ -106,7 +106,7 @@ abstract class AbstractEncoder
      * @param  int     $quality
      * @return Image
      */
-    public function process(Image $image, $format = null, $quality = null)
+    final public function process(Image $image, $format = null, $quality = null)
     {
         $this->setImage($image);
         $this->setFormat($format);

--- a/src/Intervention/Image/AbstractFont.php
+++ b/src/Intervention/Image/AbstractFont.php
@@ -93,7 +93,7 @@ abstract class AbstractFont
      * @param  String $text
      * @return self
      */
-    public function text($text)
+    final public function text($text)
     {
         $this->text = $text;
 
@@ -105,7 +105,7 @@ abstract class AbstractFont
      *
      * @return String
      */
-    public function getText()
+    final public function getText()
     {
         return $this->text;
     }
@@ -116,7 +116,7 @@ abstract class AbstractFont
      * @param  int $size
      * @return self
      */
-    public function size($size)
+    final public function size($size)
     {
         $this->size = $size;
 
@@ -128,7 +128,7 @@ abstract class AbstractFont
      *
      * @return int
      */
-    public function getSize()
+    final public function getSize()
     {
         return $this->size;
     }
@@ -139,7 +139,7 @@ abstract class AbstractFont
      * @param  mixed $color
      * @return self
      */
-    public function color($color)
+    final public function color($color)
     {
         $this->color = $color;
 
@@ -151,7 +151,7 @@ abstract class AbstractFont
      *
      * @return mixed
      */
-    public function getColor()
+    final public function getColor()
     {
         return $this->color;
     }
@@ -162,7 +162,7 @@ abstract class AbstractFont
      * @param  int $angle
      * @return self
      */
-    public function angle($angle)
+    final public function angle($angle)
     {
         $this->angle = $angle;
 
@@ -174,7 +174,7 @@ abstract class AbstractFont
      *
      * @return int
      */
-    public function getAngle()
+    final public function getAngle()
     {
         return $this->angle;
     }
@@ -185,7 +185,7 @@ abstract class AbstractFont
      * @param  string $align
      * @return self
      */
-    public function align($align)
+    final public function align($align)
     {
         $this->align = $align;
 
@@ -197,7 +197,7 @@ abstract class AbstractFont
      *
      * @return string
      */
-    public function getAlign()
+    final public function getAlign()
     {
         return $this->align;
     }
@@ -208,7 +208,7 @@ abstract class AbstractFont
      * @param  string $valign
      * @return self
      */
-    public function valign($valign)
+    final public function valign($valign)
     {
         $this->valign = $valign;
 
@@ -220,7 +220,7 @@ abstract class AbstractFont
      *
      * @return string
      */
-    public function getValign()
+    final public function getValign()
     {
         return $this->valign;
     }
@@ -231,7 +231,7 @@ abstract class AbstractFont
      * @param  string $kerning
      * @return void
      */
-    public function kerning($kerning)
+    final public function kerning($kerning)
     {
         $this->kerning = $kerning;
     }
@@ -241,7 +241,7 @@ abstract class AbstractFont
      *
      * @return float
      */
-    public function getKerning()
+    final public function getKerning()
     {
         return $this->kerning;
     }
@@ -252,7 +252,7 @@ abstract class AbstractFont
      * @param  string $file
      * @return self
      */
-    public function file($file)
+    final public function file($file)
     {
         $this->file = $file;
 
@@ -264,7 +264,7 @@ abstract class AbstractFont
      *
      * @return string
      */
-    public function getFile()
+    final public function getFile()
     {
         return $this->file;
     }
@@ -288,7 +288,7 @@ abstract class AbstractFont
      *
      * @return int
      */
-    public function countLines()
+    final public function countLines()
     {
         return count(explode(PHP_EOL, $this->text));
     }

--- a/src/Intervention/Image/AbstractShape.php
+++ b/src/Intervention/Image/AbstractShape.php
@@ -41,7 +41,7 @@ abstract class AbstractShape
      * @param  string $text
      * @return void
      */
-    public function background($color)
+    final public function background($color)
     {
         $this->background = $color;
     }
@@ -53,7 +53,7 @@ abstract class AbstractShape
      * @param  string  $color
      * @return void
      */
-    public function border($width, $color = null)
+    final public function border($width, $color = null)
     {
         $this->border_width = is_numeric($width) ? intval($width) : 0;
         $this->border_color = is_null($color) ? '#000000' : $color;
@@ -64,7 +64,7 @@ abstract class AbstractShape
      *
      * @return boolean
      */
-    public function hasBorder()
+    final public function hasBorder()
     {
         return ($this->border_width >= 1);
     }

--- a/src/Intervention/Image/Commands/AbstractCommand.php
+++ b/src/Intervention/Image/Commands/AbstractCommand.php
@@ -44,7 +44,7 @@ abstract class AbstractCommand
      * @param  int $key
      * @return \Intervention\Image\Commands\Argument
      */
-    public function argument($key)
+    final public function argument($key)
     {
         return new Argument($this, $key);
     }
@@ -54,7 +54,7 @@ abstract class AbstractCommand
      *
      * @return mixed
      */
-    public function getOutput()
+    final public function getOutput()
     {
         return $this->output ? $this->output : null;
     }
@@ -64,7 +64,7 @@ abstract class AbstractCommand
      *
      * @return boolean
      */
-    public function hasOutput()
+    final public function hasOutput()
     {
         return ! is_null($this->output);
     }
@@ -74,7 +74,7 @@ abstract class AbstractCommand
      *
      * @param mixed $value
      */
-    public function setOutput($value)
+    final public function setOutput($value)
     {
         $this->output = $value;
     }


### PR DESCRIPTION
All public methods of abstract classes should be final. Enforce API encapsulation in an inheritance architecture. If you want to override a method, use the Template method pattern.