### PR TITLE
Void return

### DIFF
--- a/src/Intervention/Image/AbstractEncoder.php
+++ b/src/Intervention/Image/AbstractEncoder.php
@@ -227,7 +227,7 @@ abstract class AbstractEncoder
      *
      * @param Image $image
      */
-    protected function setImage($image)
+    protected function setImage($image): void
     {
         $this->image = $image;
     }

--- a/src/Intervention/Image/AbstractFont.php
+++ b/src/Intervention/Image/AbstractFont.php
@@ -231,7 +231,7 @@ abstract class AbstractFont
      * @param  string $kerning
      * @return void
      */
-    public function kerning($kerning)
+    public function kerning($kerning): void
     {
         $this->kerning = $kerning;
     }

--- a/src/Intervention/Image/AbstractShape.php
+++ b/src/Intervention/Image/AbstractShape.php
@@ -41,7 +41,7 @@ abstract class AbstractShape
      * @param  string $text
      * @return void
      */
-    public function background($color)
+    public function background($color): void
     {
         $this->background = $color;
     }
@@ -53,7 +53,7 @@ abstract class AbstractShape
      * @param  string  $color
      * @return void
      */
-    public function border($width, $color = null)
+    public function border($width, $color = null): void
     {
         $this->border_width = is_numeric($width) ? intval($width) : 0;
         $this->border_color = is_null($color) ? '#000000' : $color;

--- a/src/Intervention/Image/Commands/AbstractCommand.php
+++ b/src/Intervention/Image/Commands/AbstractCommand.php
@@ -74,7 +74,7 @@ abstract class AbstractCommand
      *
      * @param mixed $value
      */
-    public function setOutput($value)
+    public function setOutput($value): void
     {
         $this->output = $value;
     }

--- a/src/Intervention/Image/Constraint.php
+++ b/src/Intervention/Image/Constraint.php
@@ -54,7 +54,7 @@ class Constraint
      * @param  int $type
      * @return void
      */
-    public function fix($type)
+    public function fix($type): void
     {
         $this->fixed = ($this->fixed & ~(1 << $type)) | (1 << $type);
     }
@@ -75,7 +75,7 @@ class Constraint
      *
      * @return void
      */
-    public function aspectRatio()
+    public function aspectRatio(): void
     {
         $this->fix(self::ASPECTRATIO);
     }
@@ -85,7 +85,7 @@ class Constraint
      *
      * @return void
      */
-    public function upsize()
+    public function upsize(): void
     {
         $this->fix(self::UPSIZE);
     }

--- a/src/Intervention/Image/Gd/Commands/HeightenCommand.php
+++ b/src/Intervention/Image/Gd/Commands/HeightenCommand.php
@@ -17,7 +17,7 @@ class HeightenCommand extends ResizeCommand
 
         $this->arguments[0] = null;
         $this->arguments[1] = $height;
-        $this->arguments[2] = function ($constraint) use ($additionalConstraints) {
+        $this->arguments[2] = function ($constraint) use ($additionalConstraints): void {
             $constraint->aspectRatio();
             if(is_callable($additionalConstraints))
                 $additionalConstraints($constraint);

--- a/src/Intervention/Image/Gd/Commands/WidenCommand.php
+++ b/src/Intervention/Image/Gd/Commands/WidenCommand.php
@@ -17,7 +17,7 @@ class WidenCommand extends ResizeCommand
 
         $this->arguments[0] = $width;
         $this->arguments[1] = null;
-        $this->arguments[2] = function ($constraint) use ($additionalConstraints) {
+        $this->arguments[2] = function ($constraint) use ($additionalConstraints): void {
             $constraint->aspectRatio();
             if(is_callable($additionalConstraints))
                 $additionalConstraints($constraint);

--- a/src/Intervention/Image/Gd/Font.php
+++ b/src/Intervention/Image/Gd/Font.php
@@ -136,7 +136,7 @@ class Font extends \Intervention\Image\AbstractFont
      * @param  int     $posy
      * @return void
      */
-    public function applyToImage(Image $image, $posx = 0, $posy = 0)
+    public function applyToImage(Image $image, $posx = 0, $posy = 0): void
     {
         // parse text color
         $color = new Color($this->color);
@@ -267,7 +267,7 @@ class Font extends \Intervention\Image\AbstractFont
      * @param  string $kerning
      * @return void
      */
-    public function kerning($kerning)
+    public function kerning($kerning): void
     {
         throw new \Intervention\Image\Exception\NotSupportedException(
             "Kerning is not supported by GD driver."

--- a/src/Intervention/Image/Gd/Shapes/LineShape.php
+++ b/src/Intervention/Image/Gd/Shapes/LineShape.php
@@ -54,7 +54,7 @@ class LineShape extends AbstractShape
      * @param  string $color
      * @return void
      */
-    public function color($color)
+    public function color($color): void
     {
         $this->color = $color;
     }
@@ -65,7 +65,7 @@ class LineShape extends AbstractShape
      * @param  int $width
      * @return void
      */
-    public function width($width)
+    public function width($width): void
     {
         throw new \Intervention\Image\Exception\NotSupportedException(
             "Line width is not supported by GD driver."

--- a/src/Intervention/Image/ImageManager.php
+++ b/src/Intervention/Image/ImageManager.php
@@ -131,7 +131,7 @@ class ImageManager
      *
      * @return void
      */
-    private function checkRequirements()
+    private function checkRequirements(): void
     {
         if ( ! function_exists('finfo_buffer')) {
             throw new MissingDependencyException(

--- a/src/Intervention/Image/ImageServiceProviderLaravel4.php
+++ b/src/Intervention/Image/ImageServiceProviderLaravel4.php
@@ -12,7 +12,7 @@ class ImageServiceProviderLaravel4 extends ServiceProvider
      *
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         $this->package('intervention/image');
 
@@ -99,7 +99,7 @@ class ImageServiceProviderLaravel4 extends ServiceProvider
      *
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         $app = $this->app;
 

--- a/src/Intervention/Image/ImageServiceProviderLaravelRecent.php
+++ b/src/Intervention/Image/ImageServiceProviderLaravelRecent.php
@@ -21,7 +21,7 @@ class ImageServiceProviderLaravelRecent extends ServiceProvider
      *
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         $this->publishes([
             __DIR__.'/../../config/config.php' => config_path('image.php')
@@ -36,7 +36,7 @@ class ImageServiceProviderLaravelRecent extends ServiceProvider
      *
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         $app = $this->app;
 
@@ -59,7 +59,7 @@ class ImageServiceProviderLaravelRecent extends ServiceProvider
      *
      * @return void
      */
-    protected function bootstrapImageCache()
+    protected function bootstrapImageCache(): void
     {
         $app = $this->app;
         $config = __DIR__.'/../../../../imagecache/src/config/config.php';

--- a/src/Intervention/Image/ImageServiceProviderLeague.php
+++ b/src/Intervention/Image/ImageServiceProviderLeague.php
@@ -33,7 +33,7 @@ class ImageServiceProviderLeague extends AbstractServiceProvider
      *
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         $this->getContainer()->share('Intervention\Image\ImageManager', function () {
             return new ImageManager($this->config);

--- a/src/Intervention/Image/ImageServiceProviderLumen.php
+++ b/src/Intervention/Image/ImageServiceProviderLumen.php
@@ -11,7 +11,7 @@ class ImageServiceProviderLumen extends ServiceProvider
      *
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         $app = $this->app;
 

--- a/src/Intervention/Image/Imagick/Commands/ExifCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/ExifCommand.php
@@ -17,7 +17,7 @@ class ExifCommand extends BaseCommand
     /**
      *
      */
-    public function dontPreferExtension() {
+    public function dontPreferExtension(): void {
         $this->preferExtension = false;
     }
 

--- a/src/Intervention/Image/Imagick/Commands/HeightenCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/HeightenCommand.php
@@ -17,7 +17,7 @@ class HeightenCommand extends ResizeCommand
 
         $this->arguments[0] = null;
         $this->arguments[1] = $height;
-        $this->arguments[2] = function ($constraint) use ($additionalConstraints) {
+        $this->arguments[2] = function ($constraint) use ($additionalConstraints): void {
             $constraint->aspectRatio();
             if(is_callable($additionalConstraints))
                 $additionalConstraints($constraint);

--- a/src/Intervention/Image/Imagick/Commands/WidenCommand.php
+++ b/src/Intervention/Image/Imagick/Commands/WidenCommand.php
@@ -17,7 +17,7 @@ class WidenCommand extends ResizeCommand
 
         $this->arguments[0] = $width;
         $this->arguments[1] = null;
-        $this->arguments[2] = function ($constraint) use ($additionalConstraints) {
+        $this->arguments[2] = function ($constraint) use ($additionalConstraints): void {
             $constraint->aspectRatio();
             if(is_callable($additionalConstraints))
                 $additionalConstraints($constraint);

--- a/src/Intervention/Image/Imagick/Font.php
+++ b/src/Intervention/Image/Imagick/Font.php
@@ -16,7 +16,7 @@ class Font extends AbstractFont
      * @param  int     $posy
      * @return void
      */
-    public function applyToImage(Image $image, $posx = 0, $posy = 0)
+    public function applyToImage(Image $image, $posx = 0, $posy = 0): void
     {
         // build draw object
         $draw = new \ImagickDraw();

--- a/src/Intervention/Image/Imagick/Shapes/LineShape.php
+++ b/src/Intervention/Image/Imagick/Shapes/LineShape.php
@@ -54,7 +54,7 @@ class LineShape extends AbstractShape
      * @param  string $color
      * @return void
      */
-    public function color($color)
+    public function color($color): void
     {
         $this->color = $color;
     }
@@ -65,7 +65,7 @@ class LineShape extends AbstractShape
      * @param  int $width
      * @return void
      */
-    public function width($width)
+    public function width($width): void
     {
         $this->width = $width;
     }

--- a/src/Intervention/Image/Point.php
+++ b/src/Intervention/Image/Point.php
@@ -35,7 +35,7 @@ class Point
      *
      * @param int $x
      */
-    public function setX($x)
+    public function setX($x): void
     {
         $this->x = intval($x);
     }
@@ -45,7 +45,7 @@ class Point
      *
      * @param int $y
      */
-    public function setY($y)
+    public function setY($y): void
     {
         $this->y = intval($y);
     }
@@ -56,7 +56,7 @@ class Point
      * @param int $x
      * @param int $y
      */
-    public function setPosition($x, $y)
+    public function setPosition($x, $y): void
     {
         $this->setX($x);
         $this->setY($y);

--- a/src/Intervention/Image/Size.php
+++ b/src/Intervention/Image/Size.php
@@ -48,7 +48,7 @@ class Size
      * @param int $width
      * @param int $height
      */
-    public function set($width, $height)
+    public function set($width, $height): void
     {
         $this->width = $width;
         $this->height = $height;
@@ -59,7 +59,7 @@ class Size
      *
      * @param Point $point
      */
-    public function setPivot(Point $point)
+    public function setPivot(Point $point): void
     {
         $this->pivot = $point;
     }
@@ -228,7 +228,7 @@ class Size
         // create size with auto height
         $auto_height = clone $size;
 
-        $auto_height->resize($this->width, null, function ($constraint) {
+        $auto_height->resize($this->width, null, function ($constraint): void {
             $constraint->aspectRatio();
         });
 
@@ -242,7 +242,7 @@ class Size
             // create size with auto width
             $auto_width = clone $size;
 
-            $auto_width->resize(null, $this->height, function ($constraint) {
+            $auto_width->resize(null, $this->height, function ($constraint): void {
                 $constraint->aspectRatio();
             });
 


### PR DESCRIPTION
Add void return type to functions with missing or empty return statements, but priority is given to @return annotations.