### PR TITLE
Logical operators

### DIFF
--- a/src/Intervention/Image/Gd/Color.php
+++ b/src/Intervention/Image/Gd/Color.php
@@ -201,9 +201,9 @@ class Color extends AbstractColor
         ];
 
         return (
-            $delta['r'] > $color_tolerance or
-            $delta['g'] > $color_tolerance or
-            $delta['b'] > $color_tolerance or
+            $delta['r'] > $color_tolerance ||
+            $delta['g'] > $color_tolerance ||
+            $delta['b'] > $color_tolerance ||
             $delta['a'] > $alpha_tolerance
         );
     }

--- a/src/Intervention/Image/Imagick/Color.php
+++ b/src/Intervention/Image/Imagick/Color.php
@@ -193,9 +193,9 @@ class Color extends AbstractColor
         ];
 
         return (
-            $delta['r'] > $color_tolerance or
-            $delta['g'] > $color_tolerance or
-            $delta['b'] > $color_tolerance or
+            $delta['r'] > $color_tolerance ||
+            $delta['g'] > $color_tolerance ||
+            $delta['b'] > $color_tolerance ||
             $delta['a'] > $alpha_tolerance
         );
     }


### PR DESCRIPTION
Use && and || logical operators instead of and and or.