### PR TITLE
Php unit dedicate assert

### DIFF
--- a/tests/GdSystemTest.php
+++ b/tests/GdSystemTest.php
@@ -1537,7 +1537,7 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->make('tests/images/exif.jpg');
         $data = $img->exif();
         $this->assertInternalType('array', $data);
-        $this->assertEquals(19, count($data));
+        $this->assertCount(19, $data);
     }
 
     public function testExifReadKey()

--- a/tests/PickColorCommandTest.php
+++ b/tests/PickColorCommandTest.php
@@ -21,7 +21,7 @@ class PickColorCommandTest extends TestCase
         $this->assertTrue($result);
         $this->assertTrue($command->hasOutput());
         $this->assertInternalType('array', $command->getOutput());
-        $this->assertEquals(4, count($command->getOutput()));
+        $this->assertCount(4, $command->getOutput());
     }
 
     public function testGdWithFormat()
@@ -48,7 +48,7 @@ class PickColorCommandTest extends TestCase
         $this->assertTrue($result);
         $this->assertTrue($command->hasOutput());
         $this->assertInternalType('array', $command->getOutput());
-        $this->assertEquals(4, count($command->getOutput()));
+        $this->assertCount(4, $command->getOutput());
     }
 
     public function testImagickWithFormat()


### PR DESCRIPTION
PHPUnit assertions like assertInternalType, assertFileExists, should be used over assertTrue.