### PR TITLE
Php unit no expectation annotation

### DIFF
--- a/tests/AbstractColorTest.php
+++ b/tests/AbstractColorTest.php
@@ -10,10 +10,11 @@ class AbstractColorTest extends TestCase
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\NotSupportedException
      */
     public function testFormatUnknown()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\NotSupportedException::class);
+
         $color = $this->getMockForAbstractClass('\Intervention\Image\AbstractColor');
         $color->format('xxxxxxxxxxxxxxxxxxxxxxx');
     }

--- a/tests/AbstractDriverTest.php
+++ b/tests/AbstractDriverTest.php
@@ -10,10 +10,11 @@ class AbstractDriverTest extends TestCase
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\NotSupportedException
      */
     public function testExecuteCommand()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\NotSupportedException::class);
+
         $image = Mockery::mock('Intervention\Image\Image');
         $driver = $this->getMockForAbstractClass('\Intervention\Image\AbstractDriver');
         $command = $driver->executeCommand($image, 'xxxxxxxxxxxxxxxxxxxxxxx', []);

--- a/tests/ArgumentTest.php
+++ b/tests/ArgumentTest.php
@@ -33,19 +33,21 @@ class ArgumentTest extends TestCase
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\InvalidArgumentException
      */
     public function testRequiredFail()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\InvalidArgumentException::class);
+
         $arg = new Argument($this->getMockedCommand([]));
         $arg->required();
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\InvalidArgumentException
      */
     public function testRequiredFailSecondParameter()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\InvalidArgumentException::class);
+
         $arg = new Argument($this->getMockedCommand(['foo']), 1);
         $arg->required();
     }
@@ -62,10 +64,11 @@ class ArgumentTest extends TestCase
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\InvalidArgumentException
      */
     public function testTypeIntegerFail()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\InvalidArgumentException::class);
+
         $arg = new Argument($this->getMockedCommand(['foo']));
         $arg->type('integer');
     }
@@ -82,10 +85,11 @@ class ArgumentTest extends TestCase
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\InvalidArgumentException
      */
     public function testTypeArrayFail()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\InvalidArgumentException::class);
+
         $arg = new Argument($this->getMockedCommand(['foo']));
         $arg->type('array');
     }
@@ -126,28 +130,31 @@ class ArgumentTest extends TestCase
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\InvalidArgumentException
      */
     public function testTypeDigitFailString()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\InvalidArgumentException::class);
+
         $arg = new Argument($this->getMockedCommand(['foo']));
         $arg->type('digit');
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\InvalidArgumentException
      */
     public function testTypeDigitFailFloat()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\InvalidArgumentException::class);
+
         $arg = new Argument($this->getMockedCommand([12.5]));
         $arg->type('digit');
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\InvalidArgumentException
      */
     public function testTypeDigitFailBool()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\InvalidArgumentException::class);
+
         $arg = new Argument($this->getMockedCommand([true]));
         $arg->type('digit');
     }
@@ -164,10 +171,11 @@ class ArgumentTest extends TestCase
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\InvalidArgumentException
      */
     public function testTypeNumericFail()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\InvalidArgumentException::class);
+
         $arg = new Argument($this->getMockedCommand(['foo']));
         $arg->type('numeric');
     }
@@ -188,10 +196,11 @@ class ArgumentTest extends TestCase
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\InvalidArgumentException
      */
     public function testTypeBooleanFail()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\InvalidArgumentException::class);
+
         $arg = new Argument($this->getMockedCommand(['foo']));
         $arg->type('boolean');
     }
@@ -208,10 +217,11 @@ class ArgumentTest extends TestCase
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\InvalidArgumentException
      */
     public function testTypeStringFail()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\InvalidArgumentException::class);
+
         $arg = new Argument($this->getMockedCommand([12]));
         $arg->type('string');
     }
@@ -229,10 +239,11 @@ class ArgumentTest extends TestCase
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\InvalidArgumentException
      */
     public function testTypeClosureFail()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\InvalidArgumentException::class);
+
         $arg = new Argument($this->getMockedCommand(['foo']));
         $arg->type('closure');
     }
@@ -273,37 +284,41 @@ class ArgumentTest extends TestCase
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\InvalidArgumentException
      */
     public function testBetweenFailString()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\InvalidArgumentException::class);
+
         $arg = new Argument($this->getMockedCommand(['foo']));
         $arg->between(1, 10);
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\InvalidArgumentException
      */
     public function testBetweenFailAbove()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\InvalidArgumentException::class);
+
         $arg = new Argument($this->getMockedCommand([10.9]));
         $arg->between(0, 10);
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\InvalidArgumentException
      */
     public function testBetweenFailBelow()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\InvalidArgumentException::class);
+
         $arg = new Argument($this->getMockedCommand([-1]));
         $arg->between(0, 10);
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\InvalidArgumentException
      */
     public function testBetweenFail()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\InvalidArgumentException::class);
+
         $arg = new Argument($this->getMockedCommand([-1000]));
         $arg->between(-100, 100);
     }
@@ -336,19 +351,21 @@ class ArgumentTest extends TestCase
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\InvalidArgumentException
      */
     public function testMinFailString()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\InvalidArgumentException::class);
+
         $arg = new Argument($this->getMockedCommand(['foo']));
         $arg->min(10);
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\InvalidArgumentException
      */
     public function testMinFail()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\InvalidArgumentException::class);
+
         $arg = new Argument($this->getMockedCommand([10.9]));
         $arg->min(11);
     }
@@ -381,19 +398,21 @@ class ArgumentTest extends TestCase
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\InvalidArgumentException
      */
     public function testMaxFailString()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\InvalidArgumentException::class);
+
         $arg = new Argument($this->getMockedCommand(['foo']));
         $arg->max(10);
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\InvalidArgumentException
      */
     public function testMaxFail()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\InvalidArgumentException::class);
+
         $arg = new Argument($this->getMockedCommand([25]));
         $arg->max(10);
     }

--- a/tests/EncoderTest.php
+++ b/tests/EncoderTest.php
@@ -90,10 +90,11 @@ class EncoderTest extends TestCase
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\NotSupportedException
      */
     public function testProcessHeicGd()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\NotSupportedException::class);
+
         $core = imagecreatefromjpeg(__DIR__.'/images/test.jpg');
         $encoder = new GdEncoder;
         $image = Mockery::mock('\Intervention\Image\Image');
@@ -102,10 +103,11 @@ class EncoderTest extends TestCase
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\NotSupportedException
      */
     public function testProcessTiffGd()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\NotSupportedException::class);
+
         $core = imagecreatefromjpeg(__DIR__.'/images/test.jpg');
         $encoder = new GdEncoder;
         $image = Mockery::mock('\Intervention\Image\Image');
@@ -128,10 +130,11 @@ class EncoderTest extends TestCase
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\NotSupportedException
      */
     public function testProcessIcoGd()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\NotSupportedException::class);
+
         $core = imagecreatefromjpeg(__DIR__.'/images/test.jpg');
         $encoder = new GdEncoder;
         $image = Mockery::mock('\Intervention\Image\Image');
@@ -140,10 +143,11 @@ class EncoderTest extends TestCase
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\NotSupportedException
      */
     public function testProcessPsdGd()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\NotSupportedException::class);
+
         $core = imagecreatefromjpeg(__DIR__.'/images/test.jpg');
         $encoder = new GdEncoder;
         $image = Mockery::mock('\Intervention\Image\Image');
@@ -213,30 +217,33 @@ class EncoderTest extends TestCase
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\NotSupportedException
      */
     public function testProcessWebpImagick()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\NotSupportedException::class);
+
         $encoder = new ImagickEncoder;
         $image = Mockery::mock('\Intervention\Image\Image');
         $img = $encoder->process($image, 'webp', 90);
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\NotSupportedException
      */
     public function testProcessAvifImagick()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\NotSupportedException::class);
+
         $encoder = new ImagickEncoder;
         $image = Mockery::mock('\Intervention\Image\Image');
         $img = $encoder->process($image, 'avif', 90);
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\NotSupportedException
      */
     public function testProcessHeicImagick()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\NotSupportedException::class);
+
         $encoder = new ImagickEncoder;
         $image = Mockery::mock('\Intervention\Image\Image');
         $img = $encoder->process($image, 'heic', 90);

--- a/tests/GdColorTest.php
+++ b/tests/GdColorTest.php
@@ -274,10 +274,11 @@ class GdColorTest extends TestCase
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\NotReadableException
      */
     public function testParseUnknown()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\NotReadableException::class);
+
         $c = new Color('xxxxxxxxxxxxxxxxxxxx');
     }
 

--- a/tests/GdSystemTest.php
+++ b/tests/GdSystemTest.php
@@ -23,18 +23,20 @@ class GdSystemTest extends TestCase
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\NotReadableException
      */
    public function testMakeFromPathBroken()
    {
+        $this->setExpectedException(\Intervention\Image\Exception\NotReadableException::class);
+
        $this->manager()->make('tests/images/broken.png');
    }
 
     /**
-     * @expectedException \Intervention\Image\Exception\NotReadableException
      */
     public function testMakeFromNotExisting()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\NotReadableException::class);
+
         $this->manager()->make('tests/images/not_existing.png');
     }
 

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -88,10 +88,11 @@ class ImageTest extends TestCase
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\RuntimeException
      */
     public function testGetBackupWithoutBackuo()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\RuntimeException::class);
+
         $image = $this->getTestImage();
         $image->getBackup();
     }

--- a/tests/ImagickColorTest.php
+++ b/tests/ImagickColorTest.php
@@ -319,10 +319,11 @@ class ImagickColorTest extends TestCase
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\NotReadableException
      */
     public function testParseUnknown()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\NotReadableException::class);
+
         $c = new Color('xxxxxxxxxxxxxxxxxxxx');
     }
 

--- a/tests/ImagickSystemTest.php
+++ b/tests/ImagickSystemTest.php
@@ -1565,20 +1565,22 @@ class ImagickSystemTest extends TestCase
     }
 
     /**
-     * @expectedException ImagickException
      */
     public function testDestroy()
     {
+        $this->setExpectedException(\ImagickException::class);
+
         $img = $this->manager()->make('tests/images/trim.png');
         $img->destroy();
         $img->getCore()->getImageWidth(); // try to get width (should throw exception)
     }
 
     /**
-     * @expectedException Exception
      */
     public function testDestroyWithBackup()
     {
+        $this->setExpectedException(\Exception::class);
+
         $img = $this->manager()->make('tests/images/trim.png');
         $img->backup();
         $img->destroy();

--- a/tests/SizeTest.php
+++ b/tests/SizeTest.php
@@ -426,10 +426,11 @@ class SizeTest extends TestCase
     }
 
     /**
-     * @expectedException \Intervention\Image\Exception\InvalidArgumentException
      */
     public function testInvalidResize()
     {
+        $this->setExpectedException(\Intervention\Image\Exception\InvalidArgumentException::class);
+
         $size = new Size(800, 600);
         $size->resize(null, null);
     }


### PR DESCRIPTION
Usages of @expectedException* annotations MUST be replaced by ->setExpectedException* methods.