### PR TITLE
Php unit dedicate assert internal type

### DIFF
--- a/tests/DriverTest.php
+++ b/tests/DriverTest.php
@@ -21,7 +21,7 @@ class DriverTest extends TestCase
         $image = $driver->newImage(300, 200, '00ff00');
         $this->assertInstanceOf('\Intervention\Image\Image', $image);
         $this->assertInstanceOf('\Intervention\Image\Gd\Driver', $image->getDriver());
-        $this->assertInternalType('resource', $image->getCore());
+        $this->assertIsResource($image->getCore());
     }
 
     public function testNewImageImagick()

--- a/tests/ExifCommandTest.php
+++ b/tests/ExifCommandTest.php
@@ -20,7 +20,7 @@ class ExifCommandTest extends TestCase
         $result = $command->execute($image);
         $this->assertTrue($result);
         $this->assertTrue($command->hasOutput());
-        $this->assertInternalType('array', $command->getOutput());
+        $this->assertIsArray($command->getOutput());
     }
 
     public function testFetchDefined()
@@ -67,7 +67,7 @@ class ExifCommandTest extends TestCase
         $result = $command->execute($image);
         $this->assertTrue($result);
         $this->assertTrue($command->hasOutput());
-        $this->assertInternalType('array', $command->getOutput());
+        $this->assertIsArray($command->getOutput());
         $this->assertEquals('Oliver Vogel', $command->getOutput()['Artist']);
     }
 

--- a/tests/GdColorTest.php
+++ b/tests/GdColorTest.php
@@ -152,32 +152,32 @@ class GdColorTest extends TestCase
     {
         $c = new Color;
         $i = $c->getInt();
-        $this->assertInternalType('int', $i);
+        $this->assertIsInt($i);
         $this->assertEquals(2147483647, $i);
 
         $c = new Color([255, 255, 255]);
         $i = $c->getInt();
-        $this->assertInternalType('int', $i);
+        $this->assertIsInt($i);
         $this->assertEquals($i, 16777215);
 
         $c = new Color([255, 255, 255, 1]);
         $i = $c->getInt();
-        $this->assertInternalType('int', $i);
+        $this->assertIsInt($i);
         $this->assertEquals($i, 16777215);
 
         $c = new Color([181, 55, 23, 0.5]);
         $i = $c->getInt();
-        $this->assertInternalType('int', $i);
+        $this->assertIsInt($i);
         $this->assertEquals($i, 1085617943);
 
         $c = new Color([181, 55, 23, 1]);
         $i = $c->getInt();
-        $this->assertInternalType('int', $i);
+        $this->assertIsInt($i);
         $this->assertEquals($i, 11876119);
 
         $c = new Color([0, 0, 0, 0]);
         $i = $c->getInt();
-        $this->assertInternalType('int', $i);
+        $this->assertIsInt($i);
         $this->assertEquals($i, 2130706432);
     }
 
@@ -185,22 +185,22 @@ class GdColorTest extends TestCase
     {
         $c = new Color;
         $i = $c->getHex();
-        $this->assertInternalType('string', $i);
+        $this->assertIsString($i);
         $this->assertEquals($i, 'ffffff');
 
         $c = new Color([255, 255, 255, 1]);
         $i = $c->getHex();
-        $this->assertInternalType('string', $i);
+        $this->assertIsString($i);
         $this->assertEquals($i, 'ffffff');
 
         $c = new Color([181, 55, 23, 0.5]);
         $i = $c->getHex();
-        $this->assertInternalType('string', $i);
+        $this->assertIsString($i);
         $this->assertEquals($i, 'b53717');
 
         $c = new Color([0, 0, 0, 0]);
         $i = $c->getHex('#');
-        $this->assertInternalType('string', $i);
+        $this->assertIsString($i);
         $this->assertEquals($i, '#000000');
     }
 
@@ -208,22 +208,22 @@ class GdColorTest extends TestCase
     {
         $c = new Color;
         $i = $c->getArray();
-        $this->assertInternalType('array', $i);
+        $this->assertIsArray($i);
         $this->assertEquals($i, [255, 255, 255, 0]);
 
         $c = new Color([255, 255, 255, 1]);
         $i = $c->getArray();
-        $this->assertInternalType('array', $i);
+        $this->assertIsArray($i);
         $this->assertEquals($i, [255, 255, 255, 1]);
 
         $c = new Color([181, 55, 23, 0.5]);
         $i = $c->getArray();
-        $this->assertInternalType('array', $i);
+        $this->assertIsArray($i);
         $this->assertEquals($i, [181, 55, 23, 0.5]);
 
         $c = new Color([0, 0, 0, 1]);
         $i = $c->getArray();
-        $this->assertInternalType('array', $i);
+        $this->assertIsArray($i);
         $this->assertEquals($i, [0, 0, 0, 1]);
     }
 
@@ -231,22 +231,22 @@ class GdColorTest extends TestCase
     {
         $c = new Color;
         $i = $c->getRgba();
-        $this->assertInternalType('string', $i);
+        $this->assertIsString($i);
         $this->assertEquals($i, 'rgba(255, 255, 255, 0.00)');
 
         $c = new Color([255, 255, 255, 1]);
         $i = $c->getRgba();
-        $this->assertInternalType('string', $i);
+        $this->assertIsString($i);
         $this->assertEquals($i, 'rgba(255, 255, 255, 1.00)');
 
         $c = new Color([181, 55, 23, 0.5]);
         $i = $c->getRgba();
-        $this->assertInternalType('string', $i);
+        $this->assertIsString($i);
         $this->assertEquals($i, 'rgba(181, 55, 23, 0.50)');
 
         $c = new Color([0, 0, 0, 1]);
         $i = $c->getRgba();
-        $this->assertInternalType('string', $i);
+        $this->assertIsString($i);
         $this->assertEquals($i, 'rgba(0, 0, 0, 1.00)');
     }
 
@@ -284,10 +284,10 @@ class GdColorTest extends TestCase
     private function validateColor($obj, $r, $g, $b, $a)
     {
         $this->assertInstanceOf('Intervention\Image\Gd\Color', $obj);
-        $this->assertInternalType('int', $r);
-        $this->assertInternalType('int', $g);
-        $this->assertInternalType('int', $b);
-        $this->assertInternalType('int', $a);
+        $this->assertIsInt($r);
+        $this->assertIsInt($g);
+        $this->assertIsInt($b);
+        $this->assertIsInt($a);
         $this->assertEquals($obj->r, $r);
         $this->assertEquals($obj->g, $g);
         $this->assertEquals($obj->b, $b);

--- a/tests/GdSystemTest.php
+++ b/tests/GdSystemTest.php
@@ -8,10 +8,10 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/circle.png');
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('resource', $img->getCore());
-        $this->assertInternalType('resource', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsResource($img->getCore());
+        $this->assertIsResource($img->getCore());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(50, $img->getWidth());
         $this->assertEquals(50, $img->getHeight());
         $this->assertEquals('image/png', $img->mime);
@@ -43,9 +43,9 @@ class GdSystemTest extends TestCase
         $str = file_get_contents('tests/images/circle.png');
         $img = $this->manager()->make($str);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('resource', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsResource($img->getCore());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(50, $img->getWidth());
         $this->assertEquals(50, $img->getHeight());
         $this->assertEquals('image/png', $img->mime);
@@ -56,9 +56,9 @@ class GdSystemTest extends TestCase
         $resource = imagecreatefrompng('tests/images/circle.png');
         $img = $this->manager()->make($resource);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('resource', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsResource($img->getCore());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(50, $img->getWidth());
         $this->assertEquals(50, $img->getHeight());
     }
@@ -67,9 +67,9 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAGElEQVQYlWM8c+bMfwYiABMxikYVUk8hAHWzA3cRvs4UAAAAAElFTkSuQmCC');
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('resource', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsResource($img->getCore());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
     }
@@ -78,9 +78,9 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAGElEQVQYlWM8c+bMfwYiABMxikYVUk8hAHWzA3cRvs4UAAAAAElFTkSuQmCC');
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('resource', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsResource($img->getCore());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
     }
@@ -94,9 +94,9 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->make($data);
 
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('resource', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsResource($img->getCore());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
     }
@@ -106,7 +106,7 @@ class GdSystemTest extends TestCase
         if (function_exists('imagecreatefromwebp')) {
             $img = $this->manager()->make('tests/images/test.webp');
             $this->assertInstanceOf('Intervention\Image\Image', $img);
-            $this->assertInternalType('resource', $img->getCore());
+            $this->assertIsResource($img->getCore());
             $this->assertEquals(16, $img->getWidth());
             $this->assertEquals(16, $img->getHeight());
             $this->assertEquals('image/webp', $img->mime);
@@ -121,9 +121,9 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->canvas(30, 20);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('resource', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsResource($img->getCore());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(30, $img->getWidth());
         $this->assertEquals(20, $img->getHeight());
         $this->assertTransparentPosition($img, 0, 0);
@@ -133,9 +133,9 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->canvas(30, 20, 'b53717');
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('resource', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsResource($img->getCore());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(30, $img->getWidth());
         $this->assertEquals(20, $img->getHeight());
         $this->assertEquals('#b53717', $img->pickColor(15, 15, 'hex'));
@@ -146,8 +146,8 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->make('tests/images/tile.png');
         $size = $img->getSize();
         $this->assertInstanceOf('Intervention\Image\Size', $size);
-        $this->assertInternalType('int', $size->width);
-        $this->assertInternalType('int', $size->height);
+        $this->assertIsInt($size->width);
+        $this->assertIsInt($size->height);
         $this->assertEquals(16, $size->width);
         $this->assertEquals(16, $size->height);
     }
@@ -157,9 +157,9 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->make('tests/images/circle.png');
         $img->resize(120, 150);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('resource', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsResource($img->getCore());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(120, $img->getWidth());
         $this->assertEquals(150, $img->getHeight());
         $this->assertTransparentPosition($img, 0, 0);
@@ -170,9 +170,9 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resize(120, null);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('resource', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsResource($img->getCore());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(120, $img->getWidth());
         $this->assertEquals(16, $img->getHeight());
         $this->assertTransparentPosition($img, 0, 15);
@@ -183,9 +183,9 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resize(null, 150);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('resource', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsResource($img->getCore());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(150, $img->getHeight());
         $this->assertTransparentPosition($img, 15, 0);
@@ -196,9 +196,9 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resize(50, null, function ($constraint) { $constraint->aspectRatio(); });
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('resource', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsResource($img->getCore());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(50, $img->getWidth());
         $this->assertEquals(50, $img->getHeight());
         $this->assertTransparentPosition($img, 30, 0);
@@ -209,9 +209,9 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resize(null, 50, function ($constraint) { $constraint->aspectRatio(); });
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('resource', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsResource($img->getCore());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(50, $img->getWidth());
         $this->assertEquals(50, $img->getHeight());
         $this->assertTransparentPosition($img, 30, 0);
@@ -222,9 +222,9 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resize(100, 120, function ($constraint) { $constraint->aspectRatio(); });
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('resource', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsResource($img->getCore());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(100, $img->getWidth());
         $this->assertEquals(100, $img->getHeight());
         $this->assertTransparentPosition($img, 60, 0);
@@ -235,9 +235,9 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resize(100, 100, function ($constraint) { $constraint->aspectRatio(); $constraint->upsize(); });
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('resource', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsResource($img->getCore());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(16, $img->getHeight());
         $this->assertTransparentPosition($img, 15, 0);
@@ -248,9 +248,9 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->make('tests/images/tile.png');
         $img->widen(100);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('resource', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsResource($img->getCore());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(100, $img->getWidth());
         $this->assertEquals(100, $img->getHeight());
         $this->assertTransparentPosition($img, 60, 0);
@@ -261,9 +261,9 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->make('tests/images/tile.png');
         $img->widen(100, function ($constraint) {$constraint->upsize();});
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('resource', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsResource($img->getCore());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(16, $img->getHeight());
         $this->assertTransparentPosition($img, 8, 0);
@@ -274,9 +274,9 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->make('tests/images/tile.png');
         $img->heighten(100);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('resource', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsResource($img->getCore());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(100, $img->getWidth());
         $this->assertEquals(100, $img->getHeight());
         $this->assertTransparentPosition($img, 60, 0);
@@ -287,9 +287,9 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->make('tests/images/tile.png');
         $img->heighten(100, function ($constraint) {$constraint->upsize();});
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('resource', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsResource($img->getCore());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(16, $img->getHeight());
         $this->assertTransparentPosition($img, 8, 0);
@@ -299,8 +299,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(10, 10);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 4);
@@ -313,8 +313,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(10, 10, 'top-left');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 7);
@@ -327,8 +327,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(10, 10, 'top');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 7);
@@ -341,8 +341,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(10, 10, 'top-right');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 7);
@@ -355,8 +355,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(10, 10, 'left');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 4);
@@ -369,8 +369,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(10, 10, 'right');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 4);
@@ -383,8 +383,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(10, 10, 'bottom-left');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 1);
@@ -397,8 +397,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(10, 10, 'bottom-right');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 1);
@@ -411,8 +411,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(10, 10, 'bottom');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 1);
@@ -425,8 +425,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(4, 4, 'center', true, '#ff00ff');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(20, $img->getWidth());
         $this->assertEquals(20, $img->getHeight());
         $this->assertColorAtPosition('#ff00ff', $img, 0, 0);
@@ -441,8 +441,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(10, null);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(16, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 7);
@@ -455,8 +455,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(null, 10);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 4);
@@ -469,8 +469,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(10, 20);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(20, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 9);
@@ -483,8 +483,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(20, 10);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(20, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 2, 4);
@@ -498,8 +498,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(-4, -4);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(12, $img->getWidth());
         $this->assertEquals(12, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 5);
@@ -512,8 +512,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(null, 20, 'bottom-left', false, '#ff00ff');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(20, $img->getHeight());
         $this->assertColorAtPosition('#ff00ff', $img, 0, 0);
@@ -528,8 +528,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->canvas(1, 1, 'ff0000');
         $img->resizeCanvas(17, 17, 'center', false, '333333');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(17, $img->getWidth());
         $this->assertEquals(17, $img->getHeight());
         $this->assertColorAtPosition('#333333', $img, 0, 0);
@@ -542,8 +542,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->crop(6, 6); // should be centered without pos.
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(6, $img->getWidth());
         $this->assertEquals(6, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 2);
@@ -556,8 +556,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->crop(4, 4, 7, 7); // should be centered without pos.
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(4, $img->getWidth());
         $this->assertEquals(4, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 0);
@@ -570,8 +570,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->fit(6);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(6, $img->getWidth());
         $this->assertEquals(6, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 2);
@@ -584,8 +584,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->fit(12, 6);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(12, $img->getWidth());
         $this->assertEquals(6, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 2);
@@ -598,8 +598,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/trim.png');
         $img->fit(300, 150, function ($constraint) {$constraint->upsize();});
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(50, $img->getWidth());
         $this->assertEquals(25, $img->getHeight());
         $this->assertColorAtPosition('#00aef0', $img, 0, 0);
@@ -611,8 +611,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->flip('h');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(16, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 8, 7);
@@ -625,8 +625,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->flip('v');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(16, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 8);
@@ -639,8 +639,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->rotate(90);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(16, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 8);
@@ -657,8 +657,8 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'top-left', 0, 0);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#0000ff', $img->pickColor(0, 0, 'hex'));
@@ -668,8 +668,8 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'top-left', 10, 10);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#ff0000', $img->pickColor(9, 9, 'hex'));
@@ -679,8 +679,8 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'top', 0, 0);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#ff0000', $img->pickColor(0, 0, 'hex'));
@@ -690,8 +690,8 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'top', 10, 10);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#0000ff', $img->pickColor(18, 10, 'hex'));
@@ -701,8 +701,8 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'top-right', 0, 0);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#ff0000', $img->pickColor(15, 0, 'hex'));
@@ -712,8 +712,8 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'top-right', 10, 10);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#ff0000', $img->pickColor(6, 9, 'hex'));
@@ -723,8 +723,8 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'left', 0, 0);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#0000ff', $img->pickColor(15, 23, 'hex'));
@@ -734,8 +734,8 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'left', 10, 10);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#ff0000', $img->pickColor(8, 23, 'hex'));
@@ -747,8 +747,8 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'right', 0, 0);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#0000ff', $img->pickColor(31, 23, 'hex'));
@@ -758,8 +758,8 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'right', 10, 10);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#ff0000', $img->pickColor(5, 8, 'hex'));
@@ -773,8 +773,8 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'bottom-left', 0, 0);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#0000ff', $img->pickColor(15, 31, 'hex'));
@@ -784,8 +784,8 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'bottom-left', 10, 10);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#0000ff', $img->pickColor(10, 21, 'hex'));
@@ -795,8 +795,8 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'bottom', 0, 0);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#0000ff', $img->pickColor(8, 16, 'hex'));
@@ -806,8 +806,8 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'bottom', 10, 10);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#ff0000', $img->pickColor(5, 8, 'hex'));
@@ -822,8 +822,8 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'bottom-right', 0, 0);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#0000ff', $img->pickColor(16, 16, 'hex'));
@@ -833,8 +833,8 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'bottom-right', 10, 10);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#0000ff', $img->pickColor(21, 21, 'hex'));
@@ -844,8 +844,8 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'center', 0, 0);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#0000ff', $img->pickColor(23, 23, 'hex'));
@@ -855,8 +855,8 @@ class GdSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'center', 10, 10);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#0000ff', $img->pickColor(23, 23, 'hex'));
@@ -875,8 +875,8 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/trim.png');
         $img->resize(16, 16)->insert('tests/images/tile.png');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(16, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 7);
@@ -1139,8 +1139,8 @@ class GdSystemTest extends TestCase
         $img->backup();
         $img->resize(30, 20);
         $img->reset();
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(16, $img->getHeight());
     }
@@ -1152,8 +1152,8 @@ class GdSystemTest extends TestCase
         $img->resize(30, 20);
         $img->fill('#ff0000');
         $img->reset();
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(16, $img->getHeight());
         $this->assertColorAtPosition('#0000ff', $img, 0, 0);
@@ -1499,21 +1499,21 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/trim.png');
         $img->encode();
-        $this->assertInternalType('resource', imagecreatefromstring($img->encoded));
+        $this->assertIsResource(imagecreatefromstring($img->encoded));
     }
 
     public function testEncodeJpeg()
     {
         $img = $this->manager()->make('tests/images/trim.png');
         $img->encode('jpg');
-        $this->assertInternalType('resource', imagecreatefromstring($img->encoded));
+        $this->assertIsResource(imagecreatefromstring($img->encoded));
     }
 
     public function testEncodeGif()
     {
         $img = $this->manager()->make('tests/images/trim.png');
         $img->encode('gif');
-        $this->assertInternalType('resource', imagecreatefromstring($img->encoded));
+        $this->assertIsResource(imagecreatefromstring($img->encoded));
     }
 
     public function testEncodeWebp()
@@ -1536,7 +1536,7 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/exif.jpg');
         $data = $img->exif();
-        $this->assertInternalType('array', $data);
+        $this->assertIsArray($data);
         $this->assertEquals(19, count($data));
     }
 
@@ -1544,7 +1544,7 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/exif.jpg');
         $data = $img->exif('Artist');
-        $this->assertInternalType('string', $data);
+        $this->assertIsString($data);
         $this->assertEquals('Oliver Vogel', $data);
     }
 
@@ -1632,7 +1632,7 @@ class GdSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/trim.png');
         $value = strval($img);
-        $this->assertInternalType('string', $value);
+        $this->assertIsString($value);
     }
 
     public function testFilter()
@@ -1657,7 +1657,7 @@ class GdSystemTest extends TestCase
 
         // clone should be still intact
         $this->assertInstanceOf('Intervention\Image\Image', $cln);
-        $this->assertInternalType('resource', $cln->getCore());
+        $this->assertIsResource($cln->getCore());
     }
 
     public function testGifConversionKeepsTransparency()

--- a/tests/ImagickColorTest.php
+++ b/tests/ImagickColorTest.php
@@ -187,37 +187,37 @@ class ImagickColorTest extends TestCase
     {
         $c = new Color;
         $i = $c->getInt();
-        $this->assertInternalType('int', $i);
+        $this->assertIsInt($i);
         $this->assertEquals($i, 16777215);
 
         $c = new Color([255, 255, 255]);
         $i = $c->getInt();
-        $this->assertInternalType('int', $i);
+        $this->assertIsInt($i);
         $this->assertEquals($i, 4294967295);
 
         $c = new Color([255, 255, 255, 1]);
         $i = $c->getInt();
-        $this->assertInternalType('int', $i);
+        $this->assertIsInt($i);
         $this->assertEquals($i, 4294967295);
 
         $c = new Color([181, 55, 23, 0.2]);
         $i = $c->getInt();
-        $this->assertInternalType('int', $i);
+        $this->assertIsInt($i);
         $this->assertEquals($i, 867514135);
 
         $c = new Color([255, 255, 255, 0.5]);
         $i = $c->getInt();
-        $this->assertInternalType('int', $i);
+        $this->assertIsInt($i);
         $this->assertEquals($i, 2164260863);
 
         $c = new Color([181, 55, 23, 1]);
         $i = $c->getInt();
-        $this->assertInternalType('int', $i);
+        $this->assertIsInt($i);
         $this->assertEquals($i, 4290066199);
 
         $c = new Color([0, 0, 0, 0]);
         $i = $c->getInt();
-        $this->assertInternalType('int', $i);
+        $this->assertIsInt($i);
         $this->assertEquals($i, 0);
     }
 
@@ -225,22 +225,22 @@ class ImagickColorTest extends TestCase
     {
         $c = new Color;
         $i = $c->getHex();
-        $this->assertInternalType('string', $i);
+        $this->assertIsString($i);
         $this->assertEquals($i, 'ffffff');
 
         $c = new Color([255, 255, 255, 1]);
         $i = $c->getHex();
-        $this->assertInternalType('string', $i);
+        $this->assertIsString($i);
         $this->assertEquals($i, 'ffffff');
 
         $c = new Color([181, 55, 23, 0.5]);
         $i = $c->getHex();
-        $this->assertInternalType('string', $i);
+        $this->assertIsString($i);
         $this->assertEquals($i, 'b53717');
 
         $c = new Color([0, 0, 0, 0]);
         $i = $c->getHex('#');
-        $this->assertInternalType('string', $i);
+        $this->assertIsString($i);
         $this->assertEquals($i, '#000000');
     }
 
@@ -248,22 +248,22 @@ class ImagickColorTest extends TestCase
     {
         $c = new Color;
         $i = $c->getArray();
-        $this->assertInternalType('array', $i);
+        $this->assertIsArray($i);
         $this->assertEquals($i, [255, 255, 255, 0]);
 
         $c = new Color([255, 255, 255, 1]);
         $i = $c->getArray();
-        $this->assertInternalType('array', $i);
+        $this->assertIsArray($i);
         $this->assertEquals($i, [255, 255, 255, 1]);
 
         $c = new Color([181, 55, 23, 0.5]);
         $i = $c->getArray();
-        $this->assertInternalType('array', $i);
+        $this->assertIsArray($i);
         $this->assertEquals($i, [181, 55, 23, 0.5]);
 
         $c = new Color([0, 0, 0, 1]);
         $i = $c->getArray();
-        $this->assertInternalType('array', $i);
+        $this->assertIsArray($i);
         $this->assertEquals($i, [0, 0, 0, 1]);
     }
 
@@ -271,27 +271,27 @@ class ImagickColorTest extends TestCase
     {
         $c = new Color;
         $i = $c->getRgba();
-        $this->assertInternalType('string', $i);
+        $this->assertIsString($i);
         $this->assertEquals($i, 'rgba(255, 255, 255, 0.00)');
 
         $c = new Color([255, 255, 255, 1]);
         $i = $c->getRgba();
-        $this->assertInternalType('string', $i);
+        $this->assertIsString($i);
         $this->assertEquals($i, 'rgba(255, 255, 255, 1.00)');
 
         $c = new Color([181, 55, 23, 0.5]);
         $i = $c->getRgba();
-        $this->assertInternalType('string', $i);
+        $this->assertIsString($i);
         $this->assertEquals($i, 'rgba(181, 55, 23, 0.50)');
 
         $c = new Color([0, 0, 0, 1]);
         $i = $c->getRgba();
-        $this->assertInternalType('string', $i);
+        $this->assertIsString($i);
         $this->assertEquals($i, 'rgba(0, 0, 0, 1.00)');
 
         $c = new Color([255, 255, 255, 0.5]);
         $i = $c->getRgba();
-        $this->assertInternalType('string', $i);
+        $this->assertIsString($i);
         $this->assertEquals($i, 'rgba(255, 255, 255, 0.50)');
     }
 

--- a/tests/ImagickSystemTest.php
+++ b/tests/ImagickSystemTest.php
@@ -9,8 +9,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->make('tests/images/circle.png');
         $this->assertInstanceOf('Intervention\Image\Image', $img);
         $this->assertInstanceOf('Imagick', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(50, $img->getWidth());
         $this->assertEquals(50, $img->getHeight());
         $this->assertEquals('image/png', $img->mime);
@@ -27,8 +27,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->make($str);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
         $this->assertInstanceOf('Imagick', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(50, $img->getWidth());
         $this->assertEquals(50, $img->getHeight());
         $this->assertEquals('image/png', $img->mime);
@@ -41,8 +41,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->make($imagick);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
         $this->assertInstanceOf('Imagick', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(50, $img->getWidth());
         $this->assertEquals(50, $img->getHeight());
     }
@@ -53,8 +53,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->make($str);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
         $this->assertInstanceOf('Imagick', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertEquals('image/png', $img->mime);
@@ -66,8 +66,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->make($str);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
         $this->assertInstanceOf('Imagick', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertEquals('image/png', $img->mime);
@@ -82,8 +82,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->make($data);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
         $this->assertInstanceOf('Imagick', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertEquals('image/png', $img->mime);
@@ -95,8 +95,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->canvas(30, 20);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
         $this->assertInstanceOf('Imagick', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(30, $img->getWidth());
         $this->assertEquals(20, $img->getHeight());
         $this->assertTransparentPosition($img, 0, 0);
@@ -107,8 +107,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->canvas(30, 20, 'b53717');
         $this->assertInstanceOf('Intervention\Image\Image', $img);
         $this->assertInstanceOf('Imagick', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(30, $img->getWidth());
         $this->assertEquals(20, $img->getHeight());
         $this->assertEquals('#b53717', $img->pickColor(15, 15, 'hex'));
@@ -119,8 +119,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->make('tests/images/tile.png');
         $size = $img->getSize();
         $this->assertInstanceOf('Intervention\Image\Size', $size);
-        $this->assertInternalType('int', $size->width);
-        $this->assertInternalType('int', $size->height);
+        $this->assertIsInt($size->width);
+        $this->assertIsInt($size->height);
         $this->assertEquals(16, $size->width);
         $this->assertEquals(16, $size->height);
     }
@@ -131,8 +131,8 @@ class ImagickSystemTest extends TestCase
         $img->resize(120, 150);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
         $this->assertInstanceOf('Imagick', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(120, $img->getWidth());
         $this->assertEquals(150, $img->getHeight());
         $this->assertTransparentPosition($img, 0, 0);
@@ -144,8 +144,8 @@ class ImagickSystemTest extends TestCase
         $img->resize(120, null);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
         $this->assertInstanceOf('Imagick', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(120, $img->getWidth());
         $this->assertEquals(16, $img->getHeight());
         $this->assertTransparentPosition($img, 0, 15);
@@ -157,8 +157,8 @@ class ImagickSystemTest extends TestCase
         $img->resize(null, 150);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
         $this->assertInstanceOf('Imagick', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(150, $img->getHeight());
         $this->assertTransparentPosition($img, 15, 0);
@@ -170,8 +170,8 @@ class ImagickSystemTest extends TestCase
         $img->resize(50, null, function ($constraint) { $constraint->aspectRatio(); });
         $this->assertInstanceOf('Intervention\Image\Image', $img);
         $this->assertInstanceOf('Imagick', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(50, $img->getWidth());
         $this->assertEquals(50, $img->getHeight());
         $this->assertTransparentPosition($img, 30, 0);
@@ -183,8 +183,8 @@ class ImagickSystemTest extends TestCase
         $img->resize(null, 50, function ($constraint) { $constraint->aspectRatio(); });
         $this->assertInstanceOf('Intervention\Image\Image', $img);
         $this->assertInstanceOf('Imagick', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(50, $img->getWidth());
         $this->assertEquals(50, $img->getHeight());
         $this->assertTransparentPosition($img, 30, 0);
@@ -196,8 +196,8 @@ class ImagickSystemTest extends TestCase
         $img->resize(100, 120, function ($constraint) { $constraint->aspectRatio(); });
         $this->assertInstanceOf('Intervention\Image\Image', $img);
         $this->assertInstanceOf('Imagick', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(100, $img->getWidth());
         $this->assertEquals(100, $img->getHeight());
         $this->assertTransparentPosition($img, 60, 0);
@@ -209,8 +209,8 @@ class ImagickSystemTest extends TestCase
         $img->resize(100, 100, function ($constraint) { $constraint->aspectRatio(); $constraint->upsize(); });
         $this->assertInstanceOf('Intervention\Image\Image', $img);
         $this->assertInstanceOf('Imagick', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(16, $img->getHeight());
         $this->assertTransparentPosition($img, 15, 0);
@@ -222,8 +222,8 @@ class ImagickSystemTest extends TestCase
         $img->widen(100);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
         $this->assertInstanceOf('Imagick', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(100, $img->getWidth());
         $this->assertEquals(100, $img->getHeight());
         $this->assertTransparentPosition($img, 60, 0);
@@ -235,8 +235,8 @@ class ImagickSystemTest extends TestCase
         $img->widen(100, function ($constraint) {$constraint->upsize();});
         $this->assertInstanceOf('Intervention\Image\Image', $img);
         $this->assertInstanceOf('Imagick', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(16, $img->getHeight());
         $this->assertTransparentPosition($img, 8, 0);
@@ -248,8 +248,8 @@ class ImagickSystemTest extends TestCase
         $img->heighten(100);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
         $this->assertInstanceOf('Imagick', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(100, $img->getWidth());
         $this->assertEquals(100, $img->getHeight());
         $this->assertTransparentPosition($img, 60, 0);
@@ -261,8 +261,8 @@ class ImagickSystemTest extends TestCase
         $img->heighten(100, function ($constraint) {$constraint->upsize();});
         $this->assertInstanceOf('Intervention\Image\Image', $img);
         $this->assertInstanceOf('Imagick', $img->getCore());
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(16, $img->getHeight());
         $this->assertTransparentPosition($img, 8, 0);
@@ -272,8 +272,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(10, 10);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 4);
@@ -286,8 +286,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(10, 10, 'top-left');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 7);
@@ -300,8 +300,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(10, 10, 'top');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 7);
@@ -314,8 +314,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(10, 10, 'top-right');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 7);
@@ -328,8 +328,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(10, 10, 'left');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 4);
@@ -342,8 +342,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(10, 10, 'right');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 4);
@@ -356,8 +356,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(10, 10, 'bottom-left');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 1);
@@ -370,8 +370,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(10, 10, 'bottom-right');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 1);
@@ -384,8 +384,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(10, 10, 'bottom');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 1);
@@ -398,8 +398,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(4, 4, 'center', true, '#ff00ff');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(20, $img->getWidth());
         $this->assertEquals(20, $img->getHeight());
         $this->assertColorAtPosition('#ff00ff', $img, 0, 0);
@@ -414,8 +414,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(10, null);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(16, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 7);
@@ -428,8 +428,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(null, 10);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 4);
@@ -442,8 +442,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(10, 20);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(10, $img->getWidth());
         $this->assertEquals(20, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 9);
@@ -456,8 +456,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(20, 10);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(20, $img->getWidth());
         $this->assertEquals(10, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 2, 4);
@@ -471,8 +471,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(-4, -4);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(12, $img->getWidth());
         $this->assertEquals(12, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 5);
@@ -485,8 +485,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->resizeCanvas(null, 20, 'bottom-left', false, '#ff00ff');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(20, $img->getHeight());
         $this->assertColorAtPosition('#ff00ff', $img, 0, 0);
@@ -501,8 +501,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->canvas(1, 1, 'ff0000');
         $img->resizeCanvas(17, 17, 'center', false, '333333');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(17, $img->getWidth());
         $this->assertEquals(17, $img->getHeight());
         $this->assertColorAtPosition('#333333', $img, 0, 0);
@@ -515,8 +515,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->crop(6, 6); // should be centered without pos.
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(6, $img->getWidth());
         $this->assertEquals(6, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 2);
@@ -529,8 +529,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->crop(4, 4, 7, 7); // should be centered without pos.
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(4, $img->getWidth());
         $this->assertEquals(4, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 0);
@@ -543,8 +543,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->fit(6);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(6, $img->getWidth());
         $this->assertEquals(6, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 2);
@@ -557,8 +557,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->fit(12, 6);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(12, $img->getWidth());
         $this->assertEquals(6, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 2);
@@ -571,8 +571,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/trim.png');
         $img->fit(300, 150, function ($constraint) {$constraint->upsize();});
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(50, $img->getWidth());
         $this->assertEquals(25, $img->getHeight());
         $this->assertColorAtPosition('#00aef0', $img, 0, 0);
@@ -584,8 +584,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->flip('h');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(16, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 8, 7);
@@ -598,8 +598,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->flip('v');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(16, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 8);
@@ -612,8 +612,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/tile.png');
         $img->rotate(90);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(16, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 8);
@@ -630,8 +630,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'top-left', 0, 0);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#0000ff', $img->pickColor(0, 0, 'hex'));
@@ -641,8 +641,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'top-left', 10, 10);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#ff0000', $img->pickColor(9, 9, 'hex'));
@@ -652,8 +652,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'top', 0, 0);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#ff0000', $img->pickColor(0, 0, 'hex'));
@@ -663,8 +663,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'top', 10, 10);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#0000ff', $img->pickColor(18, 10, 'hex'));
@@ -674,8 +674,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'top-right', 0, 0);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#ff0000', $img->pickColor(15, 0, 'hex'));
@@ -685,8 +685,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'top-right', 10, 10);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#ff0000', $img->pickColor(6, 9, 'hex'));
@@ -696,8 +696,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'left', 0, 0);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#0000ff', $img->pickColor(15, 23, 'hex'));
@@ -707,8 +707,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'left', 10, 10);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#ff0000', $img->pickColor(8, 23, 'hex'));
@@ -720,8 +720,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'right', 0, 0);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#0000ff', $img->pickColor(31, 23, 'hex'));
@@ -731,8 +731,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'right', 10, 10);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#ff0000', $img->pickColor(5, 8, 'hex'));
@@ -746,8 +746,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'bottom-left', 0, 0);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#0000ff', $img->pickColor(15, 31, 'hex'));
@@ -757,8 +757,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'bottom-left', 10, 10);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#0000ff', $img->pickColor(10, 21, 'hex'));
@@ -768,8 +768,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'bottom', 0, 0);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#0000ff', $img->pickColor(8, 16, 'hex'));
@@ -779,8 +779,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'bottom', 10, 10);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#ff0000', $img->pickColor(5, 8, 'hex'));
@@ -795,8 +795,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'bottom-right', 0, 0);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#0000ff', $img->pickColor(16, 16, 'hex'));
@@ -806,8 +806,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'bottom-right', 10, 10);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#0000ff', $img->pickColor(21, 21, 'hex'));
@@ -817,8 +817,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'center', 0, 0);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#0000ff', $img->pickColor(23, 23, 'hex'));
@@ -828,8 +828,8 @@ class ImagickSystemTest extends TestCase
         $img = $this->manager()->canvas(32, 32, '#ff0000'); // create canvas
         $img->insert($watermark, 'center', 10, 10);
         $this->assertInstanceOf('Intervention\Image\Image', $img);
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals($img->getWidth(), 32);
         $this->assertEquals($img->getHeight(), 32);
         $this->assertEquals('#0000ff', $img->pickColor(23, 23, 'hex'));
@@ -848,8 +848,8 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/trim.png');
         $img->resize(16, 16)->insert('tests/images/tile.png');
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(16, $img->getHeight());
         $this->assertColorAtPosition('#b4e000', $img, 0, 7);
@@ -1085,8 +1085,8 @@ class ImagickSystemTest extends TestCase
         $img->backup();
         $img->resize(30, 20);
         $img->reset();
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(16, $img->getHeight());
     }
@@ -1098,8 +1098,8 @@ class ImagickSystemTest extends TestCase
         $img->resize(30, 20);
         $img->fill('#ff0000');
         $img->reset();
-        $this->assertInternalType('int', $img->getWidth());
-        $this->assertInternalType('int', $img->getHeight());
+        $this->assertIsInt($img->getWidth());
+        $this->assertIsInt($img->getHeight());
         $this->assertEquals(16, $img->getWidth());
         $this->assertEquals(16, $img->getHeight());
         $this->assertColorAtPosition('#0000ff', $img, 0, 0);
@@ -1483,7 +1483,7 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/exif.jpg');
         $data = $img->exif();
-        $this->assertInternalType('array', $data);
+        $this->assertIsArray($data);
         $this->assertGreaterThanOrEqual(13, count($data));
     }
 
@@ -1491,7 +1491,7 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/exif.jpg');
         $data = $img->exif('Artist');
-        $this->assertInternalType('string', $data);
+        $this->assertIsString($data);
         $this->assertEquals('Oliver Vogel', $data);
     }
 
@@ -1589,7 +1589,7 @@ class ImagickSystemTest extends TestCase
     {
         $img = $this->manager()->make('tests/images/trim.png');
         $value = strval($img);
-        $this->assertInternalType('string', $value);
+        $this->assertIsString($value);
     }
 
     public function testFilter()

--- a/tests/IptcCommandTest.php
+++ b/tests/IptcCommandTest.php
@@ -19,7 +19,7 @@ class IptcCommandTest extends TestCase
         $result = $command->execute($image);
         $this->assertTrue($result);
         $this->assertTrue($command->hasOutput());
-        $this->assertInternalType('array', $command->getOutput());
+        $this->assertIsArray($command->getOutput());
     }
 
     public function testFetchDefined()

--- a/tests/PickColorCommandTest.php
+++ b/tests/PickColorCommandTest.php
@@ -20,7 +20,7 @@ class PickColorCommandTest extends TestCase
         $result = $command->execute($image);
         $this->assertTrue($result);
         $this->assertTrue($command->hasOutput());
-        $this->assertInternalType('array', $command->getOutput());
+        $this->assertIsArray($command->getOutput());
         $this->assertEquals(4, count($command->getOutput()));
     }
 
@@ -33,7 +33,7 @@ class PickColorCommandTest extends TestCase
         $result = $command->execute($image);
         $this->assertTrue($result);
         $this->assertTrue($command->hasOutput());
-        $this->assertInternalType('string', $command->getOutput());
+        $this->assertIsString($command->getOutput());
         $this->assertEquals('#ffffff', $command->getOutput());
     }
 
@@ -47,7 +47,7 @@ class PickColorCommandTest extends TestCase
         $result = $command->execute($image);
         $this->assertTrue($result);
         $this->assertTrue($command->hasOutput());
-        $this->assertInternalType('array', $command->getOutput());
+        $this->assertIsArray($command->getOutput());
         $this->assertEquals(4, count($command->getOutput()));
     }
 
@@ -61,7 +61,7 @@ class PickColorCommandTest extends TestCase
         $result = $command->execute($image);
         $this->assertTrue($result);
         $this->assertTrue($command->hasOutput());
-        $this->assertInternalType('string', $command->getOutput());
+        $this->assertIsString($command->getOutput());
         $this->assertEquals('#ff0000', $command->getOutput());
     }
 }


### PR DESCRIPTION
PHPUnit assertions like assertIsArray should be used over assertInternalType.