### PR TITLE
[fix] Size.php php8.1 strtolower() Passing null to param

### DIFF
--- a/src/Intervention/Image/Gd/Font.php
+++ b/src/Intervention/Image/Gd/Font.php
@@ -229,7 +229,7 @@ class Font extends \Intervention\Image\AbstractFont
             }
 
             // x-position corrections for horizontal alignment
-            switch (strtolower($this->align)) {
+            switch (strtolower((string) $this->align)) {
                 case 'center':
                     $posx = ceil($posx - ($width / 2));
                     break;
@@ -240,7 +240,7 @@ class Font extends \Intervention\Image\AbstractFont
             }
 
             // y-position corrections for vertical alignment
-            switch (strtolower($this->valign)) {
+            switch (strtolower((string) $this->valign)) {
                 case 'center':
                 case 'middle':
                     $posy = ceil($posy - ($height / 2));

--- a/src/Intervention/Image/Size.php
+++ b/src/Intervention/Image/Size.php
@@ -278,7 +278,7 @@ class Size
      */
     public function align($position, $offset_x = 0, $offset_y = 0)
     {
-        switch (strtolower($position)) {
+        switch (strtolower((string) $position)) {
 
             case 'top':
             case 'top-center':


### PR DESCRIPTION
I'm getting ErrorException on PHP 8.1, PHP 8.2

`strtolower(): Passing null to parameter #1 ($string) of type string is deprecated`

Without this change, the defaults are never set

https://github.com/Intervention/image/blob/54934ae8ea3661fd189437df90fb09ec3b679c74/src/Intervention/Image/Size.php#L345-L351