### PR TITLE
Fix: ::class is only available since PHP 5.5

### DIFF
--- a/src/Intervention/Image/Commands/StreamCommand.php
+++ b/src/Intervention/Image/Commands/StreamCommand.php
@@ -30,7 +30,7 @@ class StreamCommand extends AbstractCommand
      */
     protected function getStream($data)
     {
-        if (class_exists(\GuzzleHttp\Psr7\Utils::class)) {
+        if (class_exists('\\GuzzleHttp\\Psr7\\Utils')) {
             return \GuzzleHttp\Psr7\Utils::streamFor($data); // guzzlehttp/psr7 >= 2.0
         }
 


### PR DESCRIPTION
The `::class` constant is only available since PHP 5.5

`composer.json` says we support PHP 5.4 and higher