### PR TITLE
Fix file_exists bug in PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "intervention/image",
+    "name": "bnd170/image",
     "description": "Image handling and manipulation library with support for Laravel integration",
     "homepage": "http://image.intervention.io/",
     "keywords": ["image", "gd", "imagick", "laravel", "watermark", "thumbnail"],

--- a/src/Intervention/Image/File.php
+++ b/src/Intervention/Image/File.php
@@ -52,7 +52,7 @@ class File
         $this->extension = array_key_exists('extension', $info) ? $info['extension'] : null;
         $this->filename = array_key_exists('filename', $info) ? $info['filename'] : null;
 
-        if (file_exists($path) && is_file($path)) {
+        if ($path !== null && file_exists($path) && is_file($path)) {
             $this->mime = finfo_file(finfo_open(FILEINFO_MIME_TYPE), $path);
         }
 

--- a/src/Intervention/Image/File.php
+++ b/src/Intervention/Image/File.php
@@ -68,11 +68,7 @@ class File
     {
         $path = $this->basePath();
 
-        if ($path === null) {
-            return false;
-        }
-
-        if (file_exists($path) && is_file($path)) {
+        if ($path !== null && file_exists($path) && is_file($path)) {
             return filesize($path);
         }
         

--- a/src/Intervention/Image/File.php
+++ b/src/Intervention/Image/File.php
@@ -68,6 +68,10 @@ class File
     {
         $path = $this->basePath();
 
+        if ($path === null) {
+            return false;
+        }
+
         if (file_exists($path) && is_file($path)) {
             return filesize($path);
         }

--- a/src/Intervention/Image/Gd/Decoder.php
+++ b/src/Intervention/Image/Gd/Decoder.php
@@ -16,7 +16,7 @@ class Decoder extends \Intervention\Image\AbstractDecoder
      */
     public function initFromPath($path)
     {
-        if ( ! file_exists($path)) {
+        if ($path === null || ! file_exists($path)) {
             throw new NotReadableException(
                 "Unable to find file ({$path})."
             );


### PR DESCRIPTION
If $path is null, to check if file exists have no much sense, then check if its null and return false.

I've created an issue about that. https://github.com/Intervention/image/issues/1206