### PR TITLE
Add throws annotation related to Image manipulation

### DIFF
--- a/src/Intervention/Image/AbstractDriver.php
+++ b/src/Intervention/Image/AbstractDriver.php
@@ -86,6 +86,7 @@ abstract class AbstractDriver
      * @param  string $name
      * @param  array $arguments
      * @return \Intervention\Image\Commands\AbstractCommand
+     * @throws \Intervention\Image\Exception\ImageException
      */
     public function executeCommand($image, $name, $arguments)
     {

--- a/src/Intervention/Image/Commands/AbstractCommand.php
+++ b/src/Intervention/Image/Commands/AbstractCommand.php
@@ -23,6 +23,7 @@ abstract class AbstractCommand
      *
      * @param  \Intervention\Image\Image $image
      * @return mixed
+     * @throws \Intervention\Image\Exception\ImageException
      */
     abstract public function execute($image);
 

--- a/src/Intervention/Image/Image.php
+++ b/src/Intervention/Image/Image.php
@@ -100,8 +100,9 @@ class Image extends File
      * usually any AbstractCommand
      *
      * @param  string $name
-     * @param  Array  $arguments
+     * @param  array  $arguments
      * @return mixed
+     * @throws \Intervention\Image\Exception\ImageException
      */
     public function __call($name, $arguments)
     {

--- a/src/Intervention/Image/ImageManager.php
+++ b/src/Intervention/Image/ImageManager.php
@@ -48,6 +48,8 @@ class ImageManager
      * @param  mixed $data
      *
      * @return \Intervention\Image\Image
+     *
+     * @throws \Intervention\Image\Exception\ImageException
      */
     public function make($data)
     {

--- a/src/Intervention/Image/ImageManagerStatic.php
+++ b/src/Intervention/Image/ImageManagerStatic.php
@@ -51,7 +51,7 @@ class ImageManagerStatic
      * @param  mixed $data
      *
      * @return \Intervention\Image\Image
-     * @throws \Intervention\Image\Exception\NotReadableException
+     * @throws \Intervention\Image\Exception\ImageException
      */
     public static function make($data)
     {


### PR DESCRIPTION
Hi @olivervogel,

I recently used this library and got exceptions when calling some methods but most of them were undocumented.
Keeping a `@throws` phpdoc up to date is useful
- For the user to know which method can thrown exception, and which exception are thrown
- For PHPStorm to report uncaught exceptions
- For static analysis tools (like PHPStan) to also report uncaught exceptions

I tried to add some on Image manipulation (the methods I'm using so far).
Is it ok to merge such phpdoc update ?
Thanks a lot.