### PR TITLE
GD/Decoder: check for imagecreatefromjpeg function

### DIFF
--- a/src/Intervention/Image/Gd/Decoder.php
+++ b/src/Intervention/Image/Gd/Decoder.php
@@ -35,6 +35,12 @@ class Decoder extends \Intervention\Image\AbstractDecoder
             case 'image/jpg':
             case 'image/jpeg':
             case 'image/pjpeg':
+                if ( ! function_exists('imagecreatefromjpeg')) {
+                    throw new NotReadableException(
+                        "Unsupported image type. GD/PHP installation does not support jpeg format."
+                    );
+                }
+
                 $core = @imagecreatefromjpeg($path);
                 if (!$core) {
                     $core= @imagecreatefromstring(file_get_contents($path));


### PR DESCRIPTION
`ext-gd` can be compiled without libjpeg support as well.

in fact, `docker-php-ext-install gd` in docker image does that unless reconfigured to use jpeg:

```
docker-php-ext-configure gd --with-jpeg
docker-php-ext-install gd
```

this MR adds a check not to fail with fatal error, but throw an exception