### PR TITLE
Fix current working directory in laravel octane environment

### DIFF
--- a/src/Intervention/Image/Facades/Image.php
+++ b/src/Intervention/Image/Facades/Image.php
@@ -14,6 +14,8 @@ class Image extends Facade
 {
     protected static function getFacadeAccessor()
     {
+        chdir(str_replace('/vendor/laravel/octane/bin', '/public', getcwd()));
+
         return 'image';
     }
 }


### PR DESCRIPTION
When using Octane Swoole in Laravel, I encountered an issue with the Intervention/Image package, where images and font paths were not loading properly. Specifically, the code snippet below failed to load the image and font correctly:

```php
$img = Image::make('image/banner.png');
$img->text($pemenang->peg_nama, $center_x, 290, function ($font) {
    $font->file('font/Lato-Black.ttf');
});
```

Both `image/banner.png` and `font/Lato-Black.ttf` are located inside the `public` directory.

Upon further investigation, I realized that Octane uses a different working directory compared to the standard Laravel setup. When Octane is running, the current working directory is set to `/my-project/vendor/laravel/octane/bin`, whereas without Octane, it defaults to `/my-project/public`.

This difference in working directories caused the issue, leading to the incorrect file check when trying to access `image/banner.png` and `font/Lato-Black.ttf`. https://github.com/Intervention/image/blob/54934ae8ea3661fd189437df90fb09ec3b679c74/src/Intervention/Image/AbstractDecoder.php#L200

To address this problem, this pull request aims to change the current working directory in Octane to `/public`, making it consistent with the non-Octane setup. By doing so, Intervention/Image and other file-related functionalities within Laravel will work seamlessly in Octane Swoole environment.