### PR TITLE
Suppress "PHP Deprecated:  Implicit conversion from float

### DIFF
--- a/src/Intervention/Image/Gd/Shapes/EllipseShape.php
+++ b/src/Intervention/Image/Gd/Shapes/EllipseShape.php
@@ -54,8 +54,8 @@ class EllipseShape extends AbstractShape
             $border_color = new Color($this->border_color);
             imagesetthickness($image->getCore(), $this->border_width);
 
-            // gd's imageellipse doesn't respect imagesetthickness so i use imagearc with 359.9 degrees here
-            imagearc($image->getCore(), $x, $y, $this->width, $this->height, 0, 359.99, $border_color->getInt());
+            // gd's imageellipse doesn't respect imagesetthickness so i use imagearc with 360 degrees here
+            imagearc($image->getCore(), $x, $y, $this->width, $this->height, 0, 360, $border_color->getInt());
         } else {
             imagefilledellipse($image->getCore(), $x, $y, $this->width, $this->height, $background->getInt());
         }


### PR DESCRIPTION
Suppress "PHP Deprecated:  Implicit conversion from float 359.99 to int loses precision" on PHP 8.1

Fix wrong argument type. Expected type of $end_angle is int.
See https://www.php.net/manual/en/function.imagearc.php