### PR TITLE
GD: add support of AVIF (read image from path)

### DIFF
--- a/src/Intervention/Image/Gd/Decoder.php
+++ b/src/Intervention/Image/Gd/Decoder.php
@@ -82,7 +82,7 @@ class Decoder extends \Intervention\Image\AbstractDecoder
             
             default:
                 throw new NotReadableException(
-                    sprintf("Unsupported image type %s. GD driver is only able to decode JPG, PNG, GIF, BMP or WebP files.", strtolower($mime))
+                    sprintf("Unsupported image type %s. GD driver is only able to decode JPG, PNG, GIF, BMP, WebP or AVIF files.", strtolower($mime))
                 );
         }
 

--- a/src/Intervention/Image/Gd/Decoder.php
+++ b/src/Intervention/Image/Gd/Decoder.php
@@ -71,6 +71,15 @@ class Decoder extends \Intervention\Image\AbstractDecoder
                 $core = @imagecreatefrombmp($path);
                 break;
 
+            case 'image/avif':
+                if ( ! function_exists('imagecreatefromavif')) {
+                    throw new NotReadableException(
+                        "Unsupported image type. GD/PHP installation does not support AVIF format."
+                    );
+                }
+                $core = @imagecreatefromavif($path);
+                break;
+            
             default:
                 throw new NotReadableException(
                     sprintf("Unsupported image type %s. GD driver is only able to decode JPG, PNG, GIF, BMP or WebP files.", strtolower($mime))


### PR DESCRIPTION
Fixes

_NotReadableException
Unsupported image type image/avif. GD driver is only able to decode JPG, PNG, GIF, BMP or WebP files._

https://www.php.net/manual/en/function.imagecreatefromavif.php