### PR TITLE
duplicate Countable Interface in image.php

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -2,7 +2,6 @@
 
 namespace Intervention\Image;
 
-use Countable;
 use Traversable;
 use Intervention\Image\Analyzers\ColorspaceAnalyzer;
 use Intervention\Image\Analyzers\HeightAnalyzer;

--- a/src/Image.php
+++ b/src/Image.php
@@ -83,7 +83,7 @@ use Intervention\Image\Modifiers\SharpenModifier;
 use Intervention\Image\Modifiers\TextModifier;
 use Intervention\Image\Typography\FontFactory;
 
-final class Image implements ImageInterface, Countable
+final class Image implements ImageInterface
 {
     /**
      * The origin from which the image was created


### PR DESCRIPTION
`image.php` implemented two interface, `ImageInterface` and  `Countable`.
but `ImageInterface` interface already included `Countable`, So, this one is extra and can be deleted.