### PR TITLE
Fix transparency bugs

### DIFF
--- a/src/Drivers/Gd/Modifiers/ResizeModifier.php
+++ b/src/Drivers/Gd/Modifiers/ResizeModifier.php
@@ -46,7 +46,12 @@ class ResizeModifier extends SpecializedModifier
             imagefill($modified, 0, 0, $transColor);
             imagecolortransparent($modified, $transColor);
         } else {
-            imagealphablending($modified, false);
+            $transColor = imagecolorallocatealpha($modified, 255, 255, 255, 127);
+            imagealphablending($modified, true);
+            imagefill($modified, 0, 0, $transColor);
+            imagecolortransparent($modified, $transColor);
+
+            imagealphablending($modified, true);
             imagesavealpha($modified, true);
         }
 
@@ -63,6 +68,7 @@ class ResizeModifier extends SpecializedModifier
             $frame->size()->width(),
             $frame->size()->height()
         );
+
 
         // set new content as recource
         $frame->setNative($modified);

--- a/src/Drivers/Imagick/Encoders/JpegEncoder.php
+++ b/src/Drivers/Imagick/Encoders/JpegEncoder.php
@@ -18,14 +18,15 @@ class JpegEncoder extends DriverSpecializedEncoder
         $compression = Imagick::COMPRESSION_JPEG;
 
         $imagick = $image->core()->native();
-        $imagick->setImageBackgroundColor('white');
-        $imagick->setBackgroundColor('white');
         $imagick->setFormat($format);
         $imagick->setImageFormat($format);
         $imagick->setCompression($compression);
         $imagick->setImageCompression($compression);
         $imagick->setCompressionQuality($this->quality);
         $imagick->setImageCompressionQuality($this->quality);
+        $imagick->setImageBackgroundColor('white');
+        $imagick->setBackgroundColor('white');
+        $imagick->setImageAlphaChannel(Imagick::ALPHACHANNEL_REMOVE);
 
         return new EncodedImage($imagick->getImagesBlob(), 'image/jpeg');
     }


### PR DESCRIPTION
- Image transparency was replaced by black color, when rendered as a format with no alpha channel support. See: #1251 
- Given background color in `rotate()` was ignored when encoding from images with transparency to formats with no alpha channel