### PR TITLE
Implement Blending Color

### DIFF
--- a/src/Colors/Rgb/Decoders/TransparentColorDecoder.php
+++ b/src/Colors/Rgb/Decoders/TransparentColorDecoder.php
@@ -18,6 +18,6 @@ class TransparentColorDecoder extends HexColorDecoder
             throw new DecoderException('Unable to decode input');
         }
 
-        return parent::decode('#ff00ff00');
+        return parent::decode('#ffffff00');
     }
 }

--- a/src/Drivers/Gd/Cloner.php
+++ b/src/Drivers/Gd/Cloner.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Intervention\Image\Drivers\Gd;
+
+use GdImage;
+use Intervention\Image\Colors\Rgb\Color;
+use Intervention\Image\Geometry\Rectangle;
+use Intervention\Image\Interfaces\ColorInterface;
+use Intervention\Image\Interfaces\SizeInterface;
+
+class Cloner
+{
+    /**
+     * Create a clone of the given GdImage
+     *
+     * @param GdImage $gd
+     * @return GdImage
+     */
+    public static function clone(GdImage $gd): GdImage
+    {
+        // create empty canvas with same size
+        $clone = static::cloneEmpty($gd);
+
+        // transfer actual image to clone
+        imagecopy($clone, $gd, 0, 0, 0, 0, imagesx($gd), imagesy($gd));
+
+        return $clone;
+    }
+
+    /**
+     * Create an "empty" clone of the given GdImage
+     *
+     * This only retains the basic data without transferring the actual image.
+     * It is optionally possible to change the size of the result and set a
+     * background color.
+     *
+     * @param GdImage $gd
+     * @param null|SizeInterface $size
+     * @param ColorInterface $background
+     * @return GdImage
+     */
+    public static function cloneEmpty(
+        GdImage $gd,
+        ?SizeInterface $size = null,
+        ColorInterface $background = new Color(255, 255, 255, 0)
+    ): GdImage {
+        // define size
+        $size = match (true) {
+            is_null($size) => new Rectangle(imagesx($gd), imagesy($gd)),
+            default => $size,
+        };
+
+        // create new gd image with same size or new given size
+        $clone = imagecreatetruecolor($size->width(), $size->height());
+
+        // copy resolution to clone
+        $resolution = imageresolution($gd);
+        if (is_array($resolution) && array_key_exists(0, $resolution) && array_key_exists(1, $resolution)) {
+            imageresolution($clone, $resolution[0], $resolution[1]);
+        }
+
+        // fill with background
+        $processor = new ColorProcessor();
+        imagefill($clone, 0, 0, $processor->colorToNative($background));
+        imagealphablending($clone, true);
+        imagesavealpha($clone, true);
+
+        return $clone;
+    }
+
+    /**
+     * Create a clone of an GdImage that is positioned on the specified background color.
+     * Possible transparent areas are mixed with this color.
+     *
+     * @param GdImage $gd
+     * @param ColorInterface $background
+     * @return GdImage
+     */
+    public static function cloneBlended(GdImage $gd, ColorInterface $background): GdImage
+    {
+        // create empty canvas with same size
+        $clone = static::cloneEmpty($gd, background: $background);
+
+        // transfer actual image to clone
+        imagecopy($clone, $gd, 0, 0, 0, 0, imagesx($gd), imagesy($gd));
+
+        return $clone;
+    }
+}

--- a/src/Drivers/Gd/Decoders/BinaryImageDecoder.php
+++ b/src/Drivers/Gd/Decoders/BinaryImageDecoder.php
@@ -9,6 +9,7 @@ use Intervention\Image\Interfaces\DecoderInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Gif\Decoder as GifDecoder;
 use Intervention\Gif\Splitter as GifSplitter;
+use Intervention\Image\Drivers\Gd\Cloner;
 use Intervention\Image\Drivers\Gd\Core;
 use Intervention\Image\Drivers\Gd\Driver;
 use Intervention\Image\Exceptions\DecoderException;
@@ -38,17 +39,15 @@ class BinaryImageDecoder extends AbstractDecoder implements DecoderInterface
             throw new DecoderException('Unable to decode input');
         }
 
-        if (!imageistruecolor($gd)) {
-            imagepalettetotruecolor($gd);
-        }
-
-        imagesavealpha($gd, true);
+        // clone image to normalize transparency to #ffffff00
+        $normalized = Cloner::clone($gd);
+        imagedestroy($gd);
 
         // build image instance
         $image =  new Image(
             new Driver(),
             new Core([
-                new Frame($gd)
+                new Frame($normalized)
             ]),
             $this->extractExifData($input)
         );

--- a/src/Drivers/Gd/Decoders/BinaryImageDecoder.php
+++ b/src/Drivers/Gd/Decoders/BinaryImageDecoder.php
@@ -9,7 +9,6 @@ use Intervention\Image\Interfaces\DecoderInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Gif\Decoder as GifDecoder;
 use Intervention\Gif\Splitter as GifSplitter;
-use Intervention\Image\Drivers\Gd\Cloner;
 use Intervention\Image\Drivers\Gd\Core;
 use Intervention\Image\Drivers\Gd\Driver;
 use Intervention\Image\Exceptions\DecoderException;
@@ -39,15 +38,16 @@ class BinaryImageDecoder extends AbstractDecoder implements DecoderInterface
             throw new DecoderException('Unable to decode input');
         }
 
-        // clone image to normalize transparency to #ffffff00
-        $normalized = Cloner::clone($gd);
-        imagedestroy($gd);
+        if (!imageistruecolor($gd)) {
+            imagepalettetotruecolor($gd);
+        }
+        imagesavealpha($gd, true);
 
         // build image instance
         $image =  new Image(
             new Driver(),
             new Core([
-                new Frame($normalized)
+                new Frame($gd)
             ]),
             $this->extractExifData($input)
         );

--- a/src/Drivers/Gd/Driver.php
+++ b/src/Drivers/Gd/Driver.php
@@ -47,7 +47,7 @@ class Driver extends AbstractDriver
         // build new transparent GDImage
         $data = imagecreatetruecolor($width, $height);
         imagesavealpha($data, true);
-        $background = imagecolorallocatealpha($data, 255, 0, 255, 127);
+        $background = imagecolorallocatealpha($data, 255, 255, 255, 127);
         imagealphablending($data, false);
         imagefill($data, 0, 0, $background);
         imagecolortransparent($data, $background);

--- a/src/Drivers/Gd/Encoders/JpegEncoder.php
+++ b/src/Drivers/Gd/Encoders/JpegEncoder.php
@@ -3,6 +3,7 @@
 namespace Intervention\Image\Drivers\Gd\Encoders;
 
 use Intervention\Image\Drivers\DriverSpecializedEncoder;
+use Intervention\Image\Drivers\Gd\Cloner;
 use Intervention\Image\EncodedImage;
 use Intervention\Image\Interfaces\ImageInterface;
 
@@ -13,9 +14,10 @@ class JpegEncoder extends DriverSpecializedEncoder
 {
     public function encode(ImageInterface $image): EncodedImage
     {
-        $gd = $image->core()->native();
-        $data = $this->getBuffered(function () use ($gd) {
-            imagejpeg($gd, null, $this->quality);
+        $output = Cloner::cloneBlended($image->core()->native(), background: $image->blendingColor());
+
+        $data = $this->getBuffered(function () use ($output) {
+            imagejpeg($output, null, $this->quality);
         });
 
         return new EncodedImage($data, 'image/jpeg');

--- a/src/Drivers/Gd/Frame.php
+++ b/src/Drivers/Gd/Frame.php
@@ -107,35 +107,6 @@ class Frame implements FrameInterface
      */
     public function __clone(): void
     {
-        // create new clone image
-        $width = imagesx($this->native);
-        $height = imagesy($this->native);
-        $clone = match (imageistruecolor($this->native)) {
-            true => imagecreatetruecolor($width, $height),
-            default => imagecreate($width, $height),
-        };
-
-        // transfer resolution to clone
-        $resolution = imageresolution($this->native);
-        if (is_array($resolution) && array_key_exists(0, $resolution) && array_key_exists(1, $resolution)) {
-            imageresolution($clone, $resolution[0], $resolution[1]);
-        }
-
-        // transfer transparency to clone
-        $transIndex = imagecolortransparent($this->native);
-        if ($transIndex != -1) {
-            $rgba = imagecolorsforindex($clone, $transIndex);
-            $transColor = imagecolorallocatealpha($clone, $rgba['red'], $rgba['green'], $rgba['blue'], 127);
-            imagefill($clone, 0, 0, $transColor);
-            imagecolortransparent($clone, $transColor);
-        } else {
-            imagealphablending($clone, false);
-            imagesavealpha($clone, true);
-        }
-
-        // transfer actual image to clone
-        imagecopy($clone, $this->native, 0, 0, 0, 0, $width, $height);
-
-        $this->native = $clone;
+        $this->native = Cloner::clone($this->native);
     }
 }

--- a/src/Drivers/Gd/Modifiers/BlendTransparencyModifier.php
+++ b/src/Drivers/Gd/Modifiers/BlendTransparencyModifier.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Intervention\Image\Drivers\Gd\Modifiers;
+
+use Intervention\Image\Drivers\DriverSpecializedModifier;
+use Intervention\Image\Drivers\Gd\Cloner;
+use Intervention\Image\Interfaces\ImageInterface;
+
+class BlendTransparencyModifier extends DriverSpecializedModifier
+{
+    public function apply(ImageInterface $image): ImageInterface
+    {
+        // decode blending color
+        $color =  $this->driver()->handleInput(
+            $this->color ? $this->color : $image->blendingColor()
+        );
+
+        foreach ($image as $frame) {
+            // create new canvas with blending color as background
+            $modified = Cloner::cloneBlended(
+                $frame->native(),
+                background: $color
+            );
+
+            // set new gd image
+            $frame->setNative($modified);
+        }
+
+        return $image;
+    }
+}

--- a/src/Drivers/Gd/Modifiers/BlendTransparencyModifier.php
+++ b/src/Drivers/Gd/Modifiers/BlendTransparencyModifier.php
@@ -6,6 +6,9 @@ use Intervention\Image\Drivers\DriverSpecializedModifier;
 use Intervention\Image\Drivers\Gd\Cloner;
 use Intervention\Image\Interfaces\ImageInterface;
 
+/**
+ * @property mixed $color
+ */
 class BlendTransparencyModifier extends DriverSpecializedModifier
 {
     public function apply(ImageInterface $image): ImageInterface

--- a/src/Drivers/Gd/Modifiers/CoverModifier.php
+++ b/src/Drivers/Gd/Modifiers/CoverModifier.php
@@ -2,6 +2,7 @@
 
 namespace Intervention\Image\Drivers\Gd\Modifiers;
 
+use Intervention\Image\Drivers\Gd\Cloner;
 use Intervention\Image\Drivers\Gd\SpecializedModifier;
 use Intervention\Image\Interfaces\FrameInterface;
 use Intervention\Image\Interfaces\ImageInterface;
@@ -28,31 +29,12 @@ class CoverModifier extends SpecializedModifier
     protected function modifyFrame(FrameInterface $frame, SizeInterface $crop, SizeInterface $resize): void
     {
         // create new image
-        $modified = $this->driver()->createImage(
-            $resize->width(),
-            $resize->height()
-        )->core()->native();
-
-        // get original image
-        $original = $frame->native();
-
-        // retain resolution
-        $this->copyResolution($original, $modified);
-
-        // preserve transparency
-        $transIndex = imagecolortransparent($original);
-
-        if ($transIndex != -1) {
-            $rgba = imagecolorsforindex($modified, $transIndex);
-            $transColor = imagecolorallocatealpha($modified, $rgba['red'], $rgba['green'], $rgba['blue'], 127);
-            imagefill($modified, 0, 0, $transColor);
-            imagecolortransparent($modified, $transColor);
-        }
+        $modified = Cloner::cloneEmpty($frame->native(), $resize);
 
         // copy content from resource
         imagecopyresampled(
             $modified,
-            $original,
+            $frame->native(),
             0,
             0,
             $crop->pivot()->x(),

--- a/src/Drivers/Gd/Modifiers/CropModifier.php
+++ b/src/Drivers/Gd/Modifiers/CropModifier.php
@@ -63,13 +63,12 @@ class CropModifier extends SpecializedModifier
         );
 
         imagealphablending($modified, false); // do not blend / just overwrite
-        // imagecolortransparent($modified, $transparent);
         imagefilledrectangle(
             $modified,
             $offset_x * -1,
             $offset_y * -1,
-            $targetWidth,
-            $targetHeight,
+            $targetWidth - $this->offset_x - 1,
+            $targetHeight - $this->offset_y - 1,
             $transparent
         );
 
@@ -86,8 +85,6 @@ class CropModifier extends SpecializedModifier
             $targetWidth,
             $targetHeight
         );
-
-        imagealphablending($modified, true);
 
         // set new content as recource
         $frame->setNative($modified);

--- a/src/Drivers/Gd/Modifiers/CropModifier.php
+++ b/src/Drivers/Gd/Modifiers/CropModifier.php
@@ -2,8 +2,12 @@
 
 namespace Intervention\Image\Drivers\Gd\Modifiers;
 
+use Intervention\Image\Colors\Rgb\Channels\Blue;
+use Intervention\Image\Colors\Rgb\Channels\Green;
+use Intervention\Image\Colors\Rgb\Channels\Red;
 use Intervention\Image\Drivers\Gd\Cloner;
 use Intervention\Image\Drivers\Gd\SpecializedModifier;
+use Intervention\Image\Interfaces\ColorInterface;
 use Intervention\Image\Interfaces\FrameInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SizeInterface;
@@ -12,6 +16,7 @@ use Intervention\Image\Interfaces\SizeInterface;
  * @method SizeInterface crop(ImageInterface $image)
  * @property int $offset_x
  * @property int $offset_y
+ * @property mixed $background
  */
 class CropModifier extends SpecializedModifier
 {
@@ -19,18 +24,23 @@ class CropModifier extends SpecializedModifier
     {
         $originalSize = $image->size();
         $crop = $this->crop($image);
+        $background = $this->driver()->handleInput($this->background);
 
         foreach ($image as $frame) {
-            $this->cropFrame($frame, $originalSize, $crop);
+            $this->cropFrame($frame, $originalSize, $crop, $background);
         }
 
         return $image;
     }
 
-    protected function cropFrame(FrameInterface $frame, SizeInterface $originalSize, SizeInterface $resizeTo): void
-    {
+    protected function cropFrame(
+        FrameInterface $frame,
+        SizeInterface $originalSize,
+        SizeInterface $resizeTo,
+        ColorInterface $background
+    ): void {
         // create new image
-        $modified = Cloner::cloneEmpty($frame->native(), $resizeTo);
+        $modified = Cloner::cloneEmpty($frame->native(), $resizeTo, $background);
 
         // define offset
         $offset_x = ($resizeTo->pivot()->x() + $this->offset_x);
@@ -41,6 +51,27 @@ class CropModifier extends SpecializedModifier
         $targetHeight = min($resizeTo->height(), $originalSize->height());
         $targetWidth = $targetWidth < $originalSize->width() ? $targetWidth + $offset_x : $targetWidth;
         $targetHeight = $targetHeight < $originalSize->height() ? $targetHeight + $offset_y : $targetHeight;
+
+        // make image area transparent to keep transparency
+        // even if background-color is set
+        $transparent = imagecolorallocatealpha(
+            $modified,
+            $background->channel(Red::class)->value(),
+            $background->channel(Green::class)->value(),
+            $background->channel(Blue::class)->value(),
+            127,
+        );
+
+        imagealphablending($modified, false); // do not blend / just overwrite
+        // imagecolortransparent($modified, $transparent);
+        imagefilledrectangle(
+            $modified,
+            $offset_x * -1,
+            $offset_y * -1,
+            $targetWidth,
+            $targetHeight,
+            $transparent
+        );
 
         // copy content from resource
         imagecopyresampled(
@@ -55,6 +86,8 @@ class CropModifier extends SpecializedModifier
             $targetWidth,
             $targetHeight
         );
+
+        imagealphablending($modified, true);
 
         // set new content as recource
         $frame->setNative($modified);

--- a/src/Drivers/Gd/Modifiers/CropModifier.php
+++ b/src/Drivers/Gd/Modifiers/CropModifier.php
@@ -92,7 +92,7 @@ class CropModifier extends SpecializedModifier
         }
 
         // cover the possible newly created areas with background color
-        if ($this->offset_x < 0 || $resizeTo->pivot()->x() != 0) {
+        if ((($this->offset_x * -1) - $resizeTo->pivot()->x() - 1) > 0) {
             imagefilledrectangle(
                 $modified,
                 0,
@@ -104,7 +104,7 @@ class CropModifier extends SpecializedModifier
         }
 
         // cover the possible newly created areas with background color
-        if ($this->offset_y < 0 || $resizeTo->pivot()->y() != 0) {
+        if ((($this->offset_y * -1) - $resizeTo->pivot()->y() - 1) > 0) {
             imagefilledrectangle(
                 $modified,
                 ($this->offset_x * -1) - $resizeTo->pivot()->x(),

--- a/src/Drivers/Gd/Modifiers/CropModifier.php
+++ b/src/Drivers/Gd/Modifiers/CropModifier.php
@@ -64,12 +64,14 @@ class CropModifier extends SpecializedModifier
             $targetHeight
         );
 
+        // don't alpha blend for covering areas
         imagealphablending($modified, false);
+
         // cover the possible newly created areas with background color
         if ($resizeTo->width() > $originalSize->width() || $this->offset_x > 0) {
             imagefilledrectangle(
                 $modified,
-                $originalSize->width() + ($this->offset_x * -1),
+                $originalSize->width() + ($this->offset_x * -1) - $resizeTo->pivot()->x(),
                 0,
                 $resizeTo->width(),
                 $resizeTo->height(),
@@ -78,37 +80,37 @@ class CropModifier extends SpecializedModifier
         }
 
         // cover the possible newly created areas with background color
-        if ($resizeTo->width() > $originalSize->height() || $this->offset_y > 0) {
+        if ($resizeTo->height() > $originalSize->height() || $this->offset_y > 0) {
             imagefilledrectangle(
                 $modified,
-                ($this->offset_x * -1),
-                $originalSize->height() + ($this->offset_y * -1),
-                ($this->offset_x * -1) + $originalSize->width() - 1,
+                ($this->offset_x * -1) - $resizeTo->pivot()->x(),
+                $originalSize->height() + ($this->offset_y * -1) - $resizeTo->pivot()->y(),
+                ($this->offset_x * -1) + $originalSize->width() - 1 - $resizeTo->pivot()->x(),
                 $resizeTo->height(),
                 $background
             );
         }
 
         // cover the possible newly created areas with background color
-        if ($this->offset_x < 0) {
+        if ($this->offset_x < 0 || $resizeTo->pivot()->x() != 0) {
             imagefilledrectangle(
                 $modified,
                 0,
                 0,
-                ($this->offset_x * -1) - 1,
+                ($this->offset_x * -1) - $resizeTo->pivot()->x() - 1,
                 $resizeTo->height(),
                 $background
             );
         }
 
         // cover the possible newly created areas with background color
-        if ($this->offset_y < 0) {
+        if ($this->offset_y < 0 || $resizeTo->pivot()->y() != 0) {
             imagefilledrectangle(
                 $modified,
-                $this->offset_x * -1,
+                ($this->offset_x * -1) - $resizeTo->pivot()->x(),
                 0,
-                ($this->offset_x * -1) + $originalSize->width() - 1,
-                ($this->offset_y * -1) - 1,
+                ($this->offset_x * -1) + $originalSize->width() - $resizeTo->pivot()->x() - 1,
+                ($this->offset_y * -1) - $resizeTo->pivot()->y() - 1,
                 $background
             );
         }

--- a/src/Drivers/Gd/Modifiers/CropModifier.php
+++ b/src/Drivers/Gd/Modifiers/CropModifier.php
@@ -17,32 +17,43 @@ class CropModifier extends SpecializedModifier
 {
     public function apply(ImageInterface $image): ImageInterface
     {
+        $originalSize = $image->size();
         $crop = $this->crop($image);
 
         foreach ($image as $frame) {
-            $this->cropFrame($frame, $crop);
+            $this->cropFrame($frame, $originalSize, $crop);
         }
 
         return $image;
     }
 
-    protected function cropFrame(FrameInterface $frame, SizeInterface $resizeTo): void
+    protected function cropFrame(FrameInterface $frame, SizeInterface $originalSize, SizeInterface $resizeTo): void
     {
         // create new image
         $modified = Cloner::cloneEmpty($frame->native(), $resizeTo);
+
+        // define offset
+        $offset_x = ($resizeTo->pivot()->x() + $this->offset_x);
+        $offset_y = ($resizeTo->pivot()->y() + $this->offset_y);
+
+        // define target width & height
+        $targetWidth = min($resizeTo->width(), $originalSize->width());
+        $targetHeight = min($resizeTo->height(), $originalSize->height());
+        $targetWidth = $targetWidth < $originalSize->width() ? $targetWidth + $offset_x : $targetWidth;
+        $targetHeight = $targetHeight < $originalSize->height() ? $targetHeight + $offset_y : $targetHeight;
 
         // copy content from resource
         imagecopyresampled(
             $modified,
             $frame->native(),
+            $offset_x * -1,
+            $offset_y * -1,
             0,
             0,
-            $resizeTo->pivot()->x() + $this->offset_x,
-            $resizeTo->pivot()->y() + $this->offset_y,
-            $resizeTo->width(),
-            $resizeTo->height(),
-            $resizeTo->width(),
-            $resizeTo->height(),
+            $targetWidth,
+            $targetHeight,
+            $targetWidth,
+            $targetHeight
         );
 
         // set new content as recource

--- a/src/Drivers/Gd/Modifiers/CropModifier.php
+++ b/src/Drivers/Gd/Modifiers/CropModifier.php
@@ -2,6 +2,7 @@
 
 namespace Intervention\Image\Drivers\Gd\Modifiers;
 
+use Intervention\Image\Drivers\Gd\Cloner;
 use Intervention\Image\Drivers\Gd\SpecializedModifier;
 use Intervention\Image\Interfaces\FrameInterface;
 use Intervention\Image\Interfaces\ImageInterface;
@@ -28,31 +29,12 @@ class CropModifier extends SpecializedModifier
     protected function cropFrame(FrameInterface $frame, SizeInterface $resizeTo): void
     {
         // create new image
-        $modified = $this->driver()
-            ->createImage($resizeTo->width(), $resizeTo->height())
-            ->core()
-            ->native();
-
-        // get original image
-        $original = $frame->native();
-
-        // retain resolution
-        $this->copyResolution($original, $modified);
-
-        // preserve transparency
-        $transIndex = imagecolortransparent($original);
-
-        if ($transIndex != -1) {
-            $rgba = imagecolorsforindex($modified, $transIndex);
-            $transColor = imagecolorallocatealpha($modified, $rgba['red'], $rgba['green'], $rgba['blue'], 127);
-            imagefill($modified, 0, 0, $transColor);
-            imagecolortransparent($modified, $transColor);
-        }
+        $modified = Cloner::cloneEmpty($frame->native(), $resizeTo);
 
         // copy content from resource
         imagecopyresampled(
             $modified,
-            $original,
+            $frame->native(),
             0,
             0,
             $resizeTo->pivot()->x() + $this->offset_x,

--- a/src/Drivers/Gd/Modifiers/QuantizeColorsModifier.php
+++ b/src/Drivers/Gd/Modifiers/QuantizeColorsModifier.php
@@ -2,6 +2,7 @@
 
 namespace Intervention\Image\Drivers\Gd\Modifiers;
 
+use Intervention\Image\Drivers\Gd\Cloner;
 use Intervention\Image\Drivers\Gd\SpecializedModifier;
 use Intervention\Image\Exceptions\InputException;
 use Intervention\Image\Interfaces\ImageInterface;
@@ -33,10 +34,7 @@ class QuantizeColorsModifier extends SpecializedModifier
 
         foreach ($image as $frame) {
             // create new image for color quantization
-            $reduced = imagecreatetruecolor($width, $height);
-
-            // retain resolution
-            $this->copyResolution($frame->native(), $reduced);
+            $reduced = Cloner::cloneEmpty($frame->native(), background: $image->blendingColor());
 
             // fill with background
             imagefill($reduced, 0, 0, $background);

--- a/src/Drivers/Gd/Modifiers/ResizeCanvasModifier.php
+++ b/src/Drivers/Gd/Modifiers/ResizeCanvasModifier.php
@@ -5,6 +5,7 @@ namespace Intervention\Image\Drivers\Gd\Modifiers;
 use Intervention\Image\Colors\Rgb\Channels\Blue;
 use Intervention\Image\Colors\Rgb\Channels\Green;
 use Intervention\Image\Colors\Rgb\Channels\Red;
+use Intervention\Image\Drivers\Gd\Cloner;
 use Intervention\Image\Drivers\Gd\SpecializedModifier;
 use Intervention\Image\Interfaces\ColorInterface;
 use Intervention\Image\Interfaces\FrameInterface;
@@ -35,16 +36,8 @@ class ResizeCanvasModifier extends SpecializedModifier
         SizeInterface $resize,
         ColorInterface $background,
     ): void {
-        // create new gd image
-        $modified = $this->driver()->createImage(
-            $resize->width(),
-            $resize->height()
-        )->modify(
-            new FillModifier($background)
-        )->core()->native();
-
-        // retain resolution
-        $this->copyResolution($frame->native(), $modified);
+        // create new canvas with target size & target background color
+        $modified = Cloner::cloneEmpty($frame->native(), $resize, $background);
 
         // make image area transparent to keep transparency
         // even if background-color is set
@@ -57,7 +50,7 @@ class ResizeCanvasModifier extends SpecializedModifier
         );
 
         imagealphablending($modified, false); // do not blend / just overwrite
-        imagecolortransparent($modified, $transparent);
+        // imagecolortransparent($modified, $transparent);
         imagefilledrectangle(
             $modified,
             $resize->pivot()->x() * -1,

--- a/src/Drivers/Gd/Modifiers/ResizeModifier.php
+++ b/src/Drivers/Gd/Modifiers/ResizeModifier.php
@@ -2,6 +2,7 @@
 
 namespace Intervention\Image\Drivers\Gd\Modifiers;
 
+use Intervention\Image\Drivers\Gd\Cloner;
 use Intervention\Image\Drivers\Gd\SpecializedModifier;
 use Intervention\Image\Interfaces\FrameInterface;
 use Intervention\Image\Interfaces\ImageInterface;
@@ -25,35 +26,13 @@ class ResizeModifier extends SpecializedModifier
 
     private function resizeFrame(FrameInterface $frame, SizeInterface $resizeTo): void
     {
-        // create new image
-        $modified = imagecreatetruecolor(
-            $resizeTo->width(),
-            $resizeTo->height()
-        );
-
-        // get current GDImage
-        $current = $frame->native();
-
-        // retain resolution
-        $this->copyResolution($current, $modified);
-
-        // preserve transparency
-        $transIndex = imagecolortransparent($current);
-
-        if ($transIndex != -1) {
-            $rgba = imagecolorsforindex($modified, $transIndex);
-            $transColor = imagecolorallocatealpha($modified, $rgba['red'], $rgba['green'], $rgba['blue'], 127);
-            imagefill($modified, 0, 0, $transColor);
-            imagecolortransparent($modified, $transColor);
-        } else {
-            imagealphablending($modified, false);
-            imagesavealpha($modified, true);
-        }
+        // create empty canvas in target size
+        $modified = Cloner::cloneEmpty($frame->native(), $resizeTo);
 
         // copy content from resource
         imagecopyresampled(
             $modified,
-            $current,
+            $frame->native(),
             $resizeTo->pivot()->x(),
             $resizeTo->pivot()->y(),
             0,

--- a/src/Drivers/Gd/Modifiers/RotateModifier.php
+++ b/src/Drivers/Gd/Modifiers/RotateModifier.php
@@ -5,6 +5,7 @@ namespace Intervention\Image\Drivers\Gd\Modifiers;
 use Intervention\Image\Colors\Rgb\Channels\Blue;
 use Intervention\Image\Colors\Rgb\Channels\Green;
 use Intervention\Image\Colors\Rgb\Channels\Red;
+use Intervention\Image\Drivers\Gd\Cloner;
 use Intervention\Image\Drivers\Gd\SpecializedModifier;
 use Intervention\Image\Geometry\Rectangle;
 use Intervention\Image\Interfaces\ColorInterface;
@@ -74,15 +75,7 @@ class RotateModifier extends SpecializedModifier
             ->rotate($this->rotationAngle() * -1);
 
         // create new gd image
-        $modified = $this->driver()->createImage(
-            imagesx($rotated),
-            imagesy($rotated)
-        )->modify(new FillModifier($background))
-            ->core()
-            ->native();
-
-        // retain resolution
-        $this->copyResolution($frame->native(), $modified);
+        $modified = Cloner::cloneEmpty($frame->native(), $container, $background);
 
         // draw the cutout on new gd image to have a transparent
         // background where the rotated image will be placed

--- a/src/Drivers/Gd/SpecializedModifier.php
+++ b/src/Drivers/Gd/SpecializedModifier.php
@@ -2,16 +2,8 @@
 
 namespace Intervention\Image\Drivers\Gd;
 
-use GdImage;
 use Intervention\Image\Drivers\DriverSpecializedModifier;
 
 abstract class SpecializedModifier extends DriverSpecializedModifier
 {
-    protected function copyResolution(GdImage $source, GdImage $target): void
-    {
-        $resolution = imageresolution($source);
-        if (is_array($resolution) && array_key_exists(0, $resolution) && array_key_exists(1, $resolution)) {
-            imageresolution($target, $resolution[0], $resolution[1]);
-        }
-    }
 }

--- a/src/Drivers/Imagick/Driver.php
+++ b/src/Drivers/Imagick/Driver.php
@@ -46,7 +46,7 @@ class Driver extends AbstractDriver
      */
     public function createImage(int $width, int $height): ImageInterface
     {
-        $background = new ImagickPixel('rgba(0, 0, 0, 0)');
+        $background = new ImagickPixel('rgba(255, 255, 255, 0)');
 
         $imagick = new Imagick();
         $imagick->newImage($width, $height, $background, 'png');
@@ -54,6 +54,7 @@ class Driver extends AbstractDriver
         $imagick->setImageType(Imagick::IMGTYPE_UNDEFINED);
         $imagick->setColorspace(Imagick::COLORSPACE_SRGB);
         $imagick->setImageResolution(96, 96);
+        $imagick->setImageBackgroundColor($background);
 
         return new Image($this, new Core($imagick));
     }

--- a/src/Drivers/Imagick/Encoders/JpegEncoder.php
+++ b/src/Drivers/Imagick/Encoders/JpegEncoder.php
@@ -17,15 +17,21 @@ class JpegEncoder extends DriverSpecializedEncoder
         $format = 'jpeg';
         $compression = Imagick::COMPRESSION_JPEG;
 
+        // resolve blending color because jpeg has no transparency
+        $background = $this->driver()
+            ->colorProcessor($image->colorspace())
+            ->colorToNative($image->blendingColor());
+
         $imagick = $image->core()->native();
-        $imagick->setImageBackgroundColor('white');
-        $imagick->setBackgroundColor('white');
+        $imagick->setImageBackgroundColor($background);
+        $imagick->setBackgroundColor($background);
         $imagick->setFormat($format);
         $imagick->setImageFormat($format);
         $imagick->setCompression($compression);
         $imagick->setImageCompression($compression);
         $imagick->setCompressionQuality($this->quality);
         $imagick->setImageCompressionQuality($this->quality);
+        $imagick->setImageAlphaChannel(Imagick::ALPHACHANNEL_REMOVE);
 
         return new EncodedImage($imagick->getImagesBlob(), 'image/jpeg');
     }

--- a/src/Drivers/Imagick/Encoders/JpegEncoder.php
+++ b/src/Drivers/Imagick/Encoders/JpegEncoder.php
@@ -22,6 +22,10 @@ class JpegEncoder extends DriverSpecializedEncoder
             ->colorProcessor($image->colorspace())
             ->colorToNative($image->blendingColor());
 
+        // set alpha value to 1 because Imagick renders
+        // possible full transparent colors as black
+        $background->setColorValue(Imagick::COLOR_ALPHA, 1);
+
         $imagick = $image->core()->native();
         $imagick->setImageBackgroundColor($background);
         $imagick->setBackgroundColor($background);

--- a/src/Drivers/Imagick/Frame.php
+++ b/src/Drivers/Imagick/Frame.php
@@ -3,6 +3,7 @@
 namespace Intervention\Image\Drivers\Imagick;
 
 use Imagick;
+use ImagickPixel;
 use Intervention\Image\Geometry\Rectangle;
 use Intervention\Image\Image;
 use Intervention\Image\Interfaces\DriverInterface;
@@ -14,6 +15,9 @@ class Frame implements FrameInterface
 {
     public function __construct(protected Imagick $native)
     {
+        $background = new ImagickPixel('rgba(255, 255, 255, 0)');
+        $this->native->setImageBackgroundColor($background);
+        $this->native->setBackgroundColor($background);
     }
 
     /**

--- a/src/Drivers/Imagick/Modifiers/BlendTransparencyModifier.php
+++ b/src/Drivers/Imagick/Modifiers/BlendTransparencyModifier.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Intervention\Image\Drivers\Imagick\Modifiers;
+
+use Imagick;
+use Intervention\Image\Drivers\DriverSpecializedModifier;
+use Intervention\Image\Interfaces\ImageInterface;
+
+class BlendTransparencyModifier extends DriverSpecializedModifier
+{
+    public function apply(ImageInterface $image): ImageInterface
+    {
+        // decode blending color
+        $color =  $this->driver()->handleInput(
+            $this->color ? $this->color : $image->blendingColor()
+        );
+
+        // get imagickpixel from color
+        $pixel = $this->driver()
+            ->colorProcessor($image->colorspace())
+            ->colorToNative($color);
+
+        // merge transparent areas with the background color
+        foreach ($image as $frame) {
+            $frame->native()->setImageBackgroundColor($pixel);
+            $frame->native()->setImageAlphaChannel(Imagick::ALPHACHANNEL_REMOVE);
+            $frame->native()->mergeImageLayers(Imagick::LAYERMETHOD_FLATTEN);
+        }
+
+        return $image;
+    }
+}

--- a/src/Drivers/Imagick/Modifiers/BlendTransparencyModifier.php
+++ b/src/Drivers/Imagick/Modifiers/BlendTransparencyModifier.php
@@ -6,6 +6,9 @@ use Imagick;
 use Intervention\Image\Drivers\DriverSpecializedModifier;
 use Intervention\Image\Interfaces\ImageInterface;
 
+/**
+ * @property mixed $color
+ */
 class BlendTransparencyModifier extends DriverSpecializedModifier
 {
     public function apply(ImageInterface $image): ImageInterface

--- a/src/Drivers/Imagick/Modifiers/CropModifier.php
+++ b/src/Drivers/Imagick/Modifiers/CropModifier.php
@@ -2,6 +2,7 @@
 
 namespace Intervention\Image\Drivers\Imagick\Modifiers;
 
+use ImagickDraw;
 use Intervention\Image\Drivers\DriverSpecializedModifier;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SizeInterface;
@@ -10,20 +11,73 @@ use Intervention\Image\Interfaces\SizeInterface;
  * @method SizeInterface crop(ImageInterface $image)
  * @property int $offset_x
  * @property int $offset_y
+ * @property mixed $background
  */
 class CropModifier extends DriverSpecializedModifier
 {
     public function apply(ImageInterface $image): ImageInterface
     {
+        $originalSize = $image->size();
         $crop = $this->crop($image);
+        $background = $this->driver()->colorProcessor($image->colorspace())->colorToNative(
+            $this->driver()->handleInput($this->background)
+        );
+
+        $draw = new ImagickDraw();
+        $draw->setFillColor($background);
 
         foreach ($image as $frame) {
+            // crop image
             $frame->native()->extentImage(
                 $crop->width(),
                 $crop->height(),
                 $crop->pivot()->x() + $this->offset_x,
                 $crop->pivot()->y() + $this->offset_y
             );
+
+            // cover the possible newly created areas with background color
+            if ($crop->width() > $originalSize->width()) {
+                $draw->rectangle(
+                    $originalSize->width() + ($this->offset_x * -1),
+                    0,
+                    $crop->width(),
+                    $crop->height()
+                );
+                $frame->native()->drawImage($draw);
+            }
+
+            // cover the possible newly created areas with background color
+            if ($crop->height() > $originalSize->height()) {
+                $draw->rectangle(
+                    0,
+                    $originalSize->height() + ($this->offset_y * -1),
+                    $crop->width(),
+                    $crop->height()
+                );
+                $frame->native()->drawImage($draw);
+            }
+
+            // cover the possible newly created areas with background color
+            if ($this->offset_x < 0) {
+                $draw->rectangle(
+                    0,
+                    0,
+                    ($this->offset_x * -1) - 1,
+                    $originalSize->height() + ($this->offset_y * -1)
+                );
+                $frame->native()->drawImage($draw);
+            }
+
+            // cover the possible newly created areas with background color
+            if ($this->offset_y < 0) {
+                $draw->rectangle(
+                    0,
+                    0,
+                    $crop->width(),
+                    ($this->offset_y * -1) - 1,
+                );
+                $frame->native()->drawImage($draw);
+            }
         }
 
         return $image;

--- a/src/Drivers/Imagick/Modifiers/CropModifier.php
+++ b/src/Drivers/Imagick/Modifiers/CropModifier.php
@@ -46,7 +46,7 @@ class CropModifier extends DriverSpecializedModifier
             // cover the possible newly created areas with background color
             if ($crop->width() > $originalSize->width() || $this->offset_x > 0) {
                 $draw->rectangle(
-                    $originalSize->width() + ($this->offset_x * -1),
+                    $originalSize->width() + ($this->offset_x * -1) - $crop->pivot()->x(),
                     0,
                     $crop->width(),
                     $crop->height()
@@ -56,30 +56,30 @@ class CropModifier extends DriverSpecializedModifier
             // cover the possible newly created areas with background color
             if ($crop->height() > $originalSize->height() || $this->offset_y > 0) {
                 $draw->rectangle(
-                    ($this->offset_x * -1),
-                    $originalSize->height() + ($this->offset_y * -1),
-                    ($this->offset_x * -1) + $originalSize->width() - 1,
+                    ($this->offset_x * -1) - $crop->pivot()->x(),
+                    $originalSize->height() + ($this->offset_y * -1) - $crop->pivot()->y(),
+                    ($this->offset_x * -1) + $originalSize->width() - 1 - $crop->pivot()->x(),
                     $crop->height()
                 );
             }
 
             // cover the possible newly created areas with background color
-            if ($this->offset_x < 0) {
+            if ($this->offset_x < 0 || $crop->pivot()->x() != 0) {
                 $draw->rectangle(
                     0,
                     0,
-                    ($this->offset_x * -1) - 1,
+                    ($this->offset_x * -1) - $crop->pivot()->x() - 1,
                     $crop->height()
                 );
             }
 
             // cover the possible newly created areas with background color
-            if ($this->offset_y < 0) {
+            if ($this->offset_y < 0 || $crop->pivot()->y() != 0) {
                 $draw->rectangle(
-                    $this->offset_x * -1,
+                    ($this->offset_x * -1) - $crop->pivot()->x(),
                     0,
-                    ($this->offset_x * -1) + $originalSize->width() - 1,
-                    ($this->offset_y * -1) - 1,
+                    ($this->offset_x * -1) + $originalSize->width() - $crop->pivot()->x() - 1,
+                    ($this->offset_y * -1) - $crop->pivot()->y() - 1,
                 );
             }
 

--- a/src/Drivers/Imagick/Modifiers/CropModifier.php
+++ b/src/Drivers/Imagick/Modifiers/CropModifier.php
@@ -36,7 +36,7 @@ class CropModifier extends DriverSpecializedModifier
             );
 
             // cover the possible newly created areas with background color
-            if ($crop->width() > $originalSize->width()) {
+            if ($crop->width() > $originalSize->width() || $this->offset_x > 0) {
                 $draw->rectangle(
                     $originalSize->width() + ($this->offset_x * -1),
                     0,
@@ -47,7 +47,7 @@ class CropModifier extends DriverSpecializedModifier
             }
 
             // cover the possible newly created areas with background color
-            if ($crop->height() > $originalSize->height()) {
+            if ($crop->height() > $originalSize->height() || $this->offset_y > 0) {
                 $draw->rectangle(
                     0,
                     $originalSize->height() + ($this->offset_y * -1),

--- a/src/Drivers/Imagick/Modifiers/CropModifier.php
+++ b/src/Drivers/Imagick/Modifiers/CropModifier.php
@@ -64,7 +64,7 @@ class CropModifier extends DriverSpecializedModifier
             }
 
             // cover the possible newly created areas with background color
-            if ($this->offset_x < 0 || $crop->pivot()->x() != 0) {
+            if ((($this->offset_x * -1) - $crop->pivot()->x() - 1) > 0) {
                 $draw->rectangle(
                     0,
                     0,
@@ -74,7 +74,7 @@ class CropModifier extends DriverSpecializedModifier
             }
 
             // cover the possible newly created areas with background color
-            if ($this->offset_y < 0 || $crop->pivot()->y() != 0) {
+            if ((($this->offset_y * -1) - $crop->pivot()->y() - 1) > 0) {
                 $draw->rectangle(
                     ($this->offset_x * -1) - $crop->pivot()->x(),
                     0,

--- a/src/Drivers/Imagick/Modifiers/CropModifier.php
+++ b/src/Drivers/Imagick/Modifiers/CropModifier.php
@@ -35,6 +35,14 @@ class CropModifier extends DriverSpecializedModifier
                 $crop->pivot()->y() + $this->offset_y
             );
 
+            // repage
+            $frame->native()->setImagePage(
+                $crop->width(),
+                $crop->height(),
+                0,
+                0,
+            );
+
             // cover the possible newly created areas with background color
             if ($crop->width() > $originalSize->width() || $this->offset_x > 0) {
                 $draw->rectangle(

--- a/src/Drivers/Imagick/Modifiers/CropModifier.php
+++ b/src/Drivers/Imagick/Modifiers/CropModifier.php
@@ -43,18 +43,16 @@ class CropModifier extends DriverSpecializedModifier
                     $crop->width(),
                     $crop->height()
                 );
-                $frame->native()->drawImage($draw);
             }
 
             // cover the possible newly created areas with background color
             if ($crop->height() > $originalSize->height() || $this->offset_y > 0) {
                 $draw->rectangle(
-                    0,
+                    ($this->offset_x * -1),
                     $originalSize->height() + ($this->offset_y * -1),
-                    $crop->width(),
+                    ($this->offset_x * -1) + $originalSize->width() - 1,
                     $crop->height()
                 );
-                $frame->native()->drawImage($draw);
             }
 
             // cover the possible newly created areas with background color
@@ -63,21 +61,21 @@ class CropModifier extends DriverSpecializedModifier
                     0,
                     0,
                     ($this->offset_x * -1) - 1,
-                    $originalSize->height() + ($this->offset_y * -1)
+                    $crop->height()
                 );
-                $frame->native()->drawImage($draw);
             }
 
             // cover the possible newly created areas with background color
             if ($this->offset_y < 0) {
                 $draw->rectangle(
+                    $this->offset_x * -1,
                     0,
-                    0,
-                    $crop->width(),
+                    ($this->offset_x * -1) + $originalSize->width() - 1,
                     ($this->offset_y * -1) - 1,
                 );
-                $frame->native()->drawImage($draw);
             }
+
+            $frame->native()->drawImage($draw);
         }
 
         return $image;

--- a/src/Drivers/Imagick/Modifiers/CropModifier.php
+++ b/src/Drivers/Imagick/Modifiers/CropModifier.php
@@ -3,6 +3,7 @@
 namespace Intervention\Image\Drivers\Imagick\Modifiers;
 
 use ImagickDraw;
+use ImagickPixel;
 use Intervention\Image\Drivers\DriverSpecializedModifier;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SizeInterface;
@@ -23,10 +24,15 @@ class CropModifier extends DriverSpecializedModifier
             $this->driver()->handleInput($this->background)
         );
 
+        $transparent = new ImagickPixel('transparent');
+
         $draw = new ImagickDraw();
         $draw->setFillColor($background);
 
         foreach ($image as $frame) {
+            $frame->native()->setBackgroundColor($transparent);
+            $frame->native()->setImageBackgroundColor($transparent);
+
             // crop image
             $frame->native()->extentImage(
                 $crop->width(),

--- a/src/Image.php
+++ b/src/Image.php
@@ -11,6 +11,7 @@ use Intervention\Image\Analyzers\PixelColorsAnalyzer;
 use Intervention\Image\Analyzers\ProfileAnalyzer;
 use Intervention\Image\Analyzers\ResolutionAnalyzer;
 use Intervention\Image\Analyzers\WidthAnalyzer;
+use Intervention\Image\Colors\Rgb\Color;
 use Intervention\Image\Encoders\AutoEncoder;
 use Intervention\Image\Encoders\AvifEncoder;
 use Intervention\Image\Encoders\BmpEncoder;
@@ -93,6 +94,14 @@ final class Image implements ImageInterface
     protected Origin $origin;
 
     /**
+     * Color is mixed with transparent areas when converting to a format which
+     * does not support transparency.
+     *
+     * @var ColorInterface
+     */
+    protected ColorInterface $blendingColor;
+
+    /**
      * Create new instance
      *
      * @param DriverInterface $driver
@@ -106,6 +115,9 @@ final class Image implements ImageInterface
         protected CollectionInterface $exif = new Collection()
     ) {
         $this->origin = new Origin();
+        $this->blendingColor = $this->colorspace()->importColor(
+            new Color(255, 255, 255, 0)
+        );
     }
 
     /**
@@ -366,6 +378,28 @@ final class Image implements ImageInterface
     public function pickColors(int $x, int $y): CollectionInterface
     {
         return $this->analyze(new PixelColorsAnalyzer($x, $y));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see ImageInterface::blendingColor()
+     */
+    public function blendingColor(): ColorInterface
+    {
+        return $this->blendingColor;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see ImageInterface::setBlendingColor()
+     */
+    public function setBlendingColor(mixed $color): ImageInterface
+    {
+        $this->blendingColor = $this->driver()->handleInput($color);
+
+        return $this;
     }
 
     /**

--- a/src/Image.php
+++ b/src/Image.php
@@ -715,9 +715,10 @@ final class Image implements ImageInterface
         int $height,
         int $offset_x = 0,
         int $offset_y = 0,
+        mixed $background = 'ffffff',
         string $position = 'top-left'
     ): ImageInterface {
-        return $this->modify(new CropModifier($width, $height, $offset_x, $offset_y, $position));
+        return $this->modify(new CropModifier($width, $height, $offset_x, $offset_y, $background, $position));
     }
 
     /**

--- a/src/Image.php
+++ b/src/Image.php
@@ -45,6 +45,7 @@ use Intervention\Image\Interfaces\ModifierInterface;
 use Intervention\Image\Interfaces\ProfileInterface;
 use Intervention\Image\Interfaces\ResolutionInterface;
 use Intervention\Image\Interfaces\SizeInterface;
+use Intervention\Image\Modifiers\BlendTransparencyModifier;
 use Intervention\Image\Modifiers\BlurModifier;
 use Intervention\Image\Modifiers\BrightnessModifier;
 use Intervention\Image\Modifiers\ColorizeModifier;
@@ -400,6 +401,16 @@ final class Image implements ImageInterface
         $this->blendingColor = $this->driver()->handleInput($color);
 
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see ImageInterface::blendTransparency()
+     */
+    public function blendTransparency(mixed $color = null): ImageInterface
+    {
+        return $this->modify(new BlendTransparencyModifier($color));
     }
 
     /**

--- a/src/Interfaces/ImageInterface.php
+++ b/src/Interfaces/ImageInterface.php
@@ -491,6 +491,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $height
      * @param int $offset_x
      * @param int $offset_y
+     * @param mixed $background
      * @param string $position
      * @return ImageInterface
      */
@@ -499,6 +500,7 @@ interface ImageInterface extends IteratorAggregate, Countable
         int $height,
         int $offset_x = 0,
         int $offset_y = 0,
+        mixed $background = 'ffffff',
         string $position = 'top-left'
     ): ImageInterface;
 

--- a/src/Interfaces/ImageInterface.php
+++ b/src/Interfaces/ImageInterface.php
@@ -203,6 +203,14 @@ interface ImageInterface extends IteratorAggregate, Countable
     public function setBlendingColor(mixed $color): ImageInterface;
 
     /**
+     * Replace transparent areas of the image with given color
+     *
+     * @param mixed $color
+     * @return ImageInterface
+     */
+    public function blendTransparency(mixed $color = null): ImageInterface;
+
+    /**
      * Retrieve ICC color profile of image
      *
      * @return ProfileInterface

--- a/src/Interfaces/ImageInterface.php
+++ b/src/Interfaces/ImageInterface.php
@@ -186,6 +186,23 @@ interface ImageInterface extends IteratorAggregate, Countable
     public function pickColors(int $x, int $y): CollectionInterface;
 
     /**
+     * Return color that is mixed with transparent areas when converting to a format which
+     * does not support transparency.
+     *
+     * @return ColorInterface
+     */
+    public function blendingColor(): ColorInterface;
+
+    /**
+     * Set blending color will have no effect unless image is converted into a format
+     * which does not support transparency.
+     *
+     * @param  mixed $color
+     * @return ImageInterface
+     */
+    public function setBlendingColor(mixed $color): ImageInterface;
+
+    /**
      * Retrieve ICC color profile of image
      *
      * @return ProfileInterface

--- a/src/Modifiers/BlendTransparencyModifier.php
+++ b/src/Modifiers/BlendTransparencyModifier.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Intervention\Image\Modifiers;
+
+class BlendTransparencyModifier extends AbstractModifier
+{
+    public function __construct(public mixed $color = null)
+    {
+    }
+}

--- a/src/Modifiers/CropModifier.php
+++ b/src/Modifiers/CropModifier.php
@@ -13,6 +13,7 @@ class CropModifier extends AbstractModifier
         public int $height,
         public int $offset_x = 0,
         public int $offset_y = 0,
+        public mixed $background = 'f00',
         public string $position = 'top-left'
     ) {
     }

--- a/tests/Drivers/Gd/ClonerTest.php
+++ b/tests/Drivers/Gd/ClonerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Intervention\Image\Tests\Drivers\Gd;
+
+use Intervention\Image\Colors\Rgb\Color;
+use Intervention\Image\Drivers\Gd\Cloner;
+use Intervention\Image\Geometry\Rectangle;
+use Intervention\Image\Tests\TestCase;
+
+class ClonerTest extends TestCase
+{
+    public function testClone(): void
+    {
+        $gd = imagecreatefromgif($this->getTestImagePath('gradient.gif'));
+        $clone = Cloner::clone($gd);
+
+        $this->assertEquals(16, imagesx($gd));
+        $this->assertEquals(16, imagesy($gd));
+        $this->assertEquals(16, imagesx($clone));
+        $this->assertEquals(16, imagesy($clone));
+
+        $this->assertEquals(
+            imagecolorsforindex($gd, imagecolorat($gd, 10, 10)),
+            imagecolorsforindex($clone, imagecolorat($clone, 10, 10))
+        );
+    }
+
+    public function testCloneEmpty(): void
+    {
+        $gd = imagecreatefromgif($this->getTestImagePath('gradient.gif'));
+        $clone = Cloner::cloneEmpty($gd, new Rectangle(12, 12), new Color(255, 0, 0, 0));
+
+        $this->assertEquals(16, imagesx($gd));
+        $this->assertEquals(16, imagesy($gd));
+        $this->assertEquals(12, imagesx($clone));
+        $this->assertEquals(12, imagesy($clone));
+
+        $this->assertEquals(
+            ['red' => 0, 'green' => 255, 'blue' => 2, 'alpha' => 0],
+            imagecolorsforindex($gd, imagecolorat($gd, 10, 10)),
+        );
+
+        $this->assertEquals(
+            ['red' => 255, 'green' => 0, 'blue' => 0, 'alpha' => 127],
+            imagecolorsforindex($clone, imagecolorat($clone, 10, 10))
+        );
+    }
+
+    public function testCLoneBlended(): void
+    {
+        $gd = imagecreatefromgif($this->getTestImagePath('gradient.gif'));
+        $clone = Cloner::cloneBlended($gd, new Color(255, 0, 255, 255));
+
+        $this->assertEquals(16, imagesx($gd));
+        $this->assertEquals(16, imagesy($gd));
+        $this->assertEquals(16, imagesx($clone));
+        $this->assertEquals(16, imagesy($clone));
+
+        $this->assertEquals(
+            ['red' => 0, 'green' => 0, 'blue' => 0, 'alpha' => 127],
+            imagecolorsforindex($gd, imagecolorat($gd, 1, 0)),
+        );
+
+        $this->assertEquals(
+            ['red' => 255, 'green' => 0, 'blue' => 255, 'alpha' => 0],
+            imagecolorsforindex($clone, imagecolorat($clone, 1, 0))
+        );
+    }
+}

--- a/tests/Drivers/Gd/ImageTest.php
+++ b/tests/Drivers/Gd/ImageTest.php
@@ -4,6 +4,7 @@ namespace Intervention\Image\Tests\Drivers\Gd;
 
 use Intervention\Image\Analyzers\WidthAnalyzer;
 use Intervention\Image\Collection;
+use Intervention\Image\Colors\Rgb\Color;
 use Intervention\Image\Drivers\Gd\Core;
 use Intervention\Image\Drivers\Gd\Driver;
 use Intervention\Image\Drivers\Gd\Frame;
@@ -53,10 +54,10 @@ class ImageTest extends TestCase
         $this->assertEquals(4, $result->width());
 
         $this->assertEquals('ff0000', $image->pickColor(0, 0)->toHex());
-        $this->assertEquals('00000000', $image->pickColor(1, 0)->toHex());
+        $this->assertTransparency($image->pickColor(1, 0));
 
         $this->assertEquals('ff0000', $clone->pickColor(0, 0)->toHex());
-        $this->assertEquals('00000000', $clone->pickColor(1, 0)->toHex());
+        $this->assertTransparency($image->pickColor(1, 0));
     }
 
     public function testDriver(): void
@@ -209,5 +210,15 @@ class ImageTest extends TestCase
     public function testText(): void
     {
         $this->assertInstanceOf(Image::class, $this->image->text('test', 0, 0, new Font()));
+    }
+
+    public function testSetGetBlendingColor(): void
+    {
+        $image = $this->readTestImage('gradient.gif');
+        $this->assertInstanceOf(ColorInterface::class, $image->blendingColor());
+        $this->assertColor(255, 255, 255, 0, $image->blendingColor());
+        $result = $image->setBlendingColor(new Color(1, 2, 3, 4));
+        $this->assertColor(1, 2, 3, 4, $result->blendingColor());
+        $this->assertColor(1, 2, 3, 4, $image->blendingColor());
     }
 }

--- a/tests/Drivers/Gd/InputHandlerTest.php
+++ b/tests/Drivers/Gd/InputHandlerTest.php
@@ -138,6 +138,6 @@ class GdInputHandlerTest extends TestCase
         $input = 'transparent';
         $result = $handler->handle($input);
         $this->assertInstanceOf(RgbColor::class, $result);
-        $this->assertEquals([255, 0, 255, 0], $result->toArray());
+        $this->assertEquals([255, 255, 255, 0], $result->toArray());
     }
 }

--- a/tests/Drivers/Gd/Modifiers/ContainModifierTest.php
+++ b/tests/Drivers/Gd/Modifiers/ContainModifierTest.php
@@ -23,7 +23,7 @@ class ContainModifierTest extends TestCase
         $this->assertEquals(200, $image->width());
         $this->assertEquals(100, $image->height());
         $this->assertColor(255, 255, 0, 255, $image->pickColor(0, 0));
-        $this->assertColor(255, 255, 0, 0, $image->pickColor(140, 10)); // transparent
+        $this->assertTransparency($image->pickColor(140, 10));
         $this->assertColor(255, 255, 0, 255, $image->pickColor(175, 10));
     }
 }

--- a/tests/Drivers/Gd/Modifiers/CropModifierTest.php
+++ b/tests/Drivers/Gd/Modifiers/CropModifierTest.php
@@ -17,11 +17,23 @@ class CropModifierTest extends TestCase
     public function testModify(): void
     {
         $image = $this->readTestImage('blocks.png');
-        $image = $image->modify(new CropModifier(200, 200, 0, 0, 'bottom-right'));
+        $image = $image->modify(new CropModifier(200, 200, 0, 0, 'ffffff', 'bottom-right'));
         $this->assertEquals(200, $image->width());
         $this->assertEquals(200, $image->height());
         $this->assertColor(255, 0, 0, 255, $image->pickColor(5, 5));
         $this->assertColor(255, 0, 0, 255, $image->pickColor(100, 100));
         $this->assertColor(255, 0, 0, 255, $image->pickColor(190, 190));
+    }
+
+    public function testModifyExtend(): void
+    {
+        $image = $this->readTestImage('blocks.png');
+        $image = $image->modify(new CropModifier(800, 100, -10, -10, 'ff0000', 'top-left'));
+        $this->assertEquals(800, $image->width());
+        $this->assertEquals(100, $image->height());
+        $this->assertColor(255, 0, 0, 255, $image->pickColor(9, 9));
+        $this->assertColor(0, 0, 255, 255, $image->pickColor(16, 16));
+        $this->assertColor(0, 0, 255, 255, $image->pickColor(445, 16));
+        $this->assertTransparency($image->pickColor(460, 16));
     }
 }

--- a/tests/Drivers/Gd/Modifiers/FlipFlopModifierTest.php
+++ b/tests/Drivers/Gd/Modifiers/FlipFlopModifierTest.php
@@ -21,7 +21,7 @@ class FlipFlopModifierTest extends TestCase
         $image = $this->readTestImage('tile.png');
         $this->assertEquals('b4e000', $image->pickColor(0, 0)->toHex());
         $image->modify(new FlipModifier());
-        $this->assertEquals('00000000', $image->pickColor(0, 0)->toHex());
+        $this->assertTransparency($image->pickColor(0, 0));
     }
 
     public function testFlopImage(): void
@@ -29,6 +29,6 @@ class FlipFlopModifierTest extends TestCase
         $image = $this->readTestImage('tile.png');
         $this->assertEquals('b4e000', $image->pickColor(0, 0)->toHex());
         $image->modify(new FlopModifier());
-        $this->assertEquals('00000000', $image->pickColor(0, 0)->toHex());
+        $this->assertTransparency($image->pickColor(0, 0));
     }
 }

--- a/tests/Drivers/Imagick/ImageTest.php
+++ b/tests/Drivers/Imagick/ImageTest.php
@@ -5,6 +5,7 @@ namespace Intervention\Image\Tests\Drivers\Imagick;
 use Imagick;
 use Intervention\Image\Analyzers\WidthAnalyzer;
 use Intervention\Image\Collection;
+use Intervention\Image\Colors\Rgb\Color;
 use Intervention\Image\Drivers\Imagick\Core;
 use Intervention\Image\Drivers\Imagick\Driver;
 use Intervention\Image\Drivers\Imagick\Frame;
@@ -203,5 +204,15 @@ class ImageTest extends TestCase
     public function testSharpen(): void
     {
         $this->assertInstanceOf(Image::class, $this->image->sharpen(12));
+    }
+
+    public function testSetGetBlendingColor(): void
+    {
+        $image = $this->readTestImage('gradient.gif');
+        $this->assertInstanceOf(ColorInterface::class, $image->blendingColor());
+        $this->assertColor(255, 255, 255, 0, $image->blendingColor());
+        $result = $image->setBlendingColor(new Color(1, 2, 3, 4));
+        $this->assertColor(1, 2, 3, 4, $result->blendingColor());
+        $this->assertColor(1, 2, 3, 4, $image->blendingColor());
     }
 }

--- a/tests/Drivers/Imagick/ImageTest.php
+++ b/tests/Drivers/Imagick/ImageTest.php
@@ -53,10 +53,10 @@ class ImageTest extends TestCase
         $this->assertEquals(4, $result->width());
 
         $this->assertEquals('ff0000', $image->pickColor(0, 0)->toHex());
-        $this->assertEquals('00000000', $image->pickColor(1, 0)->toHex());
+        $this->assertTransparency($image->pickColor(1, 0));
 
         $this->assertEquals('ff0000', $clone->pickColor(0, 0)->toHex());
-        $this->assertEquals('00000000', $clone->pickColor(1, 0)->toHex());
+        $this->assertTransparency($clone->pickColor(1, 0));
     }
 
     public function testDriver(): void

--- a/tests/Drivers/Imagick/InputHandlerTest.php
+++ b/tests/Drivers/Imagick/InputHandlerTest.php
@@ -138,6 +138,6 @@ class InputHandlerTest extends TestCase
         $input = 'transparent';
         $result = $handler->handle($input);
         $this->assertInstanceOf(RgbColor::class, $result);
-        $this->assertEquals([255, 0, 255, 0], $result->toArray());
+        $this->assertEquals([255, 255, 255, 0], $result->toArray());
     }
 }

--- a/tests/Drivers/Imagick/Modifiers/CropModifierTest.php
+++ b/tests/Drivers/Imagick/Modifiers/CropModifierTest.php
@@ -17,11 +17,23 @@ class CropModifierTest extends TestCase
     public function testModify(): void
     {
         $image = $this->readTestImage('blocks.png');
-        $image = $image->modify(new CropModifier(200, 200, 0, 0, 'bottom-right'));
+        $image = $image->modify(new CropModifier(200, 200, 0, 0, 'ffffff', 'bottom-right'));
         $this->assertEquals(200, $image->width());
         $this->assertEquals(200, $image->height());
         $this->assertColor(255, 0, 0, 255, $image->pickColor(5, 5));
         $this->assertColor(255, 0, 0, 255, $image->pickColor(100, 100));
         $this->assertColor(255, 0, 0, 255, $image->pickColor(190, 190));
+    }
+
+    public function testModifyExtend(): void
+    {
+        $image = $this->readTestImage('blocks.png');
+        $image = $image->modify(new CropModifier(800, 100, -10, -10, 'ff0000', 'top-left'));
+        $this->assertEquals(800, $image->width());
+        $this->assertEquals(100, $image->height());
+        $this->assertColor(255, 0, 0, 255, $image->pickColor(9, 9));
+        $this->assertColor(0, 0, 255, 255, $image->pickColor(16, 16));
+        $this->assertColor(0, 0, 255, 255, $image->pickColor(445, 16));
+        $this->assertTransparency($image->pickColor(460, 16));
     }
 }


### PR DESCRIPTION
## Transparency

Intervention Image supports image formats with alpha channels during decoding
and output. Transparent areas are preserved as long as the destination format
supports transparency.

If the target format does not support transparency, no alpha channel can be
preserved. In this case the transparent areas will be blended with a color. This
color can be specified in advance.

### Setting the blending color

> public function setBlendingColor(mixed $color): ImageInterface
Sets the blending color based on the specified color value. This can be
specified in one of the supported [color formats](/v3/introduction/formats#color-formats).

This color is only used if an output format is selected that does not support
an alpha channel and the transparency must therefore be replaced. **In other
cases, setting the color has no effect.** The default value is white.

#### Examples

```php
use Intervention\Image\ImageManager;
use Intervention\Image\Drivers\Gd\Driver;

// create new manager instance with desired driver
$manager = new ImageManager(Driver::class);

// read a PNG file with transparency
$image = $manager->read('images/example.png');

// define the replacement color for transparent areas
$image->setBlendingColor('#ff5500'); // orange

// encode file as jpeg
$image->toJpeg();
```

### Getting the blending color

> public function blendingColor(): ColorInterface
Reads out the current blending color of the image.

#### Examples

```php
use Intervention\Image\ImageManager;
use Intervention\Image\Drivers\Gd\Driver;

// create new manager instance with desired driver
$manager = new ImageManager(Driver::class);

// read an image
$image = $manager->read('images/example.png');

// read the replacement color for transparent areas
$color = $image->blendingColor(); // default white
```

### Merging transparent areas with color

> public function blendTransparency(mixed $color = null): ColorInterface
When switching to a non-transparent image format, the transparency is
automatically replaced with the set blending color, but this can also be done
manually. This function call can also be applied to image formats that can
actually contain transparency.

The `color` parameter can optionally be used to specify a color in the common
[color formats](/v3/introduction/formats#color-formats). By default, this is
the current or previously set blending color.

#### Parameters

| Name | Type | Description |
| - | - | - |
| color | mixed | Color to replace transparent areas (optional) |

#### Examples

```php
use Intervention\Image\ImageManager;
use Intervention\Image\Drivers\Gd\Driver;

// create new manager instance with desired driver
$manager = new ImageManager(Driver::class);

// read a transparent image
$image = $manager->read('images/example.png');

// merge the transparent areas with orange
$image->blendTransparency('f50');
```