### PR TITLE
Fix bug with very long file/path names

### DIFF
--- a/src/Drivers/Gd/Decoders/FilePathImageDecoder.php
+++ b/src/Drivers/Gd/Decoders/FilePathImageDecoder.php
@@ -12,12 +12,16 @@ class FilePathImageDecoder extends BinaryImageDecoder implements DecoderInterfac
 {
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
-        if (! is_string($input)) {
+        if (!is_string($input)) {
+            throw new DecoderException('Unable to decode input');
+        }
+
+        if (strlen($input) > PHP_MAXPATHLEN) {
             throw new DecoderException('Unable to decode input');
         }
 
         try {
-            if (! @is_file($input)) {
+            if (!@is_file($input)) {
                 throw new DecoderException('Unable to decode input');
             }
         } catch (Exception) {

--- a/src/Drivers/Imagick/Decoders/FilePathImageDecoder.php
+++ b/src/Drivers/Imagick/Decoders/FilePathImageDecoder.php
@@ -16,6 +16,10 @@ class FilePathImageDecoder extends BinaryImageDecoder implements DecoderInterfac
             throw new DecoderException('Unable to decode input');
         }
 
+        if (strlen($input) > PHP_MAXPATHLEN) {
+            throw new DecoderException('Unable to decode input');
+        }
+
         try {
             if (!@is_file($input)) {
                 throw new DecoderException('Unable to decode input');
@@ -25,7 +29,7 @@ class FilePathImageDecoder extends BinaryImageDecoder implements DecoderInterfac
         }
 
         // decode image
-        $image =  parent::decode(file_get_contents($input));
+        $image = parent::decode(file_get_contents($input));
 
         // set file path on origin
         $image->origin()->setFilePath($input);


### PR DESCRIPTION
PHP enconters problems on some machines when `is_file()` in the FilePathImageDecoders receive values that are longer than the maximum-path-length of the host.

This fix checks if the input is in this maximum path length.

See #708 