### PR TITLE
Fix ImageInterface encode() method argument

### DIFF
--- a/src/Interfaces/ImageInterface.php
+++ b/src/Interfaces/ImageInterface.php
@@ -66,7 +66,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param EncoderInterface $encoder
      * @return EncodedImageInterface
      */
-    public function encode(EncoderInterface $encoder): EncodedImageInterface;
+    public function encode(EncoderInterface $encoder = new AutoEncoder()): EncodedImageInterface;
 
     /**
      * Save the image to the specified path in the file system. If no path is

--- a/src/Interfaces/ImageInterface.php
+++ b/src/Interfaces/ImageInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Intervention\Image\Interfaces;
 
 use Countable;
+use Intervention\Image\Encoders\AutoEncoder;
 use Intervention\Image\Origin;
 use IteratorAggregate;
 


### PR DESCRIPTION
ImageInterface encode argument is not aligned with Image class.

**ImageInterface.php**

`public function encode(EncoderInterface $encoder): EncodedImageInterface;`

**Image.php**

`public function encode(EncoderInterface $encoder = new AutoEncoder()): EncodedImageInterface`

This is causing static analysis tools to fail as well as confuse IDEs with error:

`Method Intervention\Image\Interfaces\ImageInterface::encode() invoked with 0 parameters, 1 required.`