### PR TITLE
Remove redundant DrawableInterface for Rectangle class

### DIFF
--- a/src/Geometry/Rectangle.php
+++ b/src/Geometry/Rectangle.php
@@ -5,11 +5,10 @@ declare(strict_types=1);
 namespace Intervention\Image\Geometry;
 
 use Intervention\Image\Geometry\Tools\RectangleResizer;
-use Intervention\Image\Interfaces\DrawableInterface;
 use Intervention\Image\Interfaces\PointInterface;
 use Intervention\Image\Interfaces\SizeInterface;
 
-class Rectangle extends Polygon implements SizeInterface, DrawableInterface
+class Rectangle extends Polygon implements SizeInterface
 {
     /**
      * Create new rectangle instance


### PR DESCRIPTION
`DrawableInterface` is already implemented by Polygon and it is not needed on Rectangle. *Just found this little detail while checking the methods for the documentation update.*