### PR TITLE
Add strokeWidth and strokeColor support.

### DIFF
--- a/src/Drivers/Gd/Modifiers/TextModifier.php
+++ b/src/Drivers/Gd/Modifiers/TextModifier.php
@@ -32,7 +32,7 @@ class TextModifier extends DriverSpecialized implements ModifierInterface
         
         $strokeWidth = $this->font->strokeWidth();
         $strokeColor = $this->driver()->colorProcessor($image->colorspace())->colorToNative(
-            $this->driver()->handleInput( 'red' )
+            $this->driver()->handleInput($this->font->strokeColor())
         );
     
         foreach ($image as $frame) {

--- a/src/Drivers/Gd/Modifiers/TextModifier.php
+++ b/src/Drivers/Gd/Modifiers/TextModifier.php
@@ -36,8 +36,9 @@ class TextModifier extends DriverSpecialized implements ModifierInterface
             $this->driver()->handleInput($this->font->strokeColor())
         );
         
-        if ( $strokeWidth && $strokeWidth > $strokeLimit )
+        if ( $strokeWidth && $strokeWidth > $strokeLimit ){
             $strokeWidth = $strokeLimit;
+        }
     
         foreach ($image as $frame) {
             if ($this->font->hasFilename()) {

--- a/src/Drivers/Gd/Modifiers/TextModifier.php
+++ b/src/Drivers/Gd/Modifiers/TextModifier.php
@@ -29,11 +29,36 @@ class TextModifier extends DriverSpecialized implements ModifierInterface
         $color = $this->driver()->colorProcessor($image->colorspace())->colorToNative(
             $this->driver()->handleInput($this->font->color())
         );
-
+        
+        $strokeWidth = $this->font->strokeWidth();
+        $strokeColor = $this->driver()->colorProcessor($image->colorspace())->colorToNative(
+            $this->driver()->handleInput( 'red' )
+        );
+    
         foreach ($image as $frame) {
             if ($this->font->hasFilename()) {
                 foreach ($lines as $line) {
                     imagealphablending($frame->native(), true);
+                    
+                    if ( $strokeWidth > 0 )
+                    {
+                        for ($x = -1; $x <= 1; $x++) {
+                            for ($y = -1; $y <= 1; $y++) {
+                                
+                                imagettftext(
+                                    $frame->native(),
+                                    $fontProcessor->nativeFontSize($this->font),
+                                    $this->font->angle() * -1,
+                                    $line->position()->x() + $x * $strokeWidth,
+                                    $line->position()->y() + $y * $strokeWidth,
+                                    $strokeColor,
+                                    $this->font->filename(),
+                                    (string) $line
+                                );
+                            }
+                        }
+                    }
+                    
                     imagettftext(
                         $frame->native(),
                         $fontProcessor->nativeFontSize($this->font),
@@ -44,9 +69,28 @@ class TextModifier extends DriverSpecialized implements ModifierInterface
                         $this->font->filename(),
                         (string) $line
                     );
+                    
                 }
             } else {
                 foreach ($lines as $line) {
+                    
+                    if ( $strokeWidth > 0 )
+                    {
+                        for ($x = -1; $x <= 1; $x++) {
+                            for ($y = -1; $y <= 1; $y++) {
+                                
+                                imagestring(
+                                    $frame->native(),
+                                    $this->gdFont(),
+                                    $line->position()->x() + $x * $strokeWidth,
+                                    $line->position()->y() + $y * $strokeWidth,
+                                    (string) $line,
+                                    $color
+                                );
+                            }
+                        }
+                    }
+                    
                     imagestring(
                         $frame->native(),
                         $this->gdFont(),

--- a/src/Drivers/Gd/Modifiers/TextModifier.php
+++ b/src/Drivers/Gd/Modifiers/TextModifier.php
@@ -31,22 +31,24 @@ class TextModifier extends DriverSpecialized implements ModifierInterface
         );
         
         $strokeWidth = $this->font->strokeWidth();
-        $strokeColor = $this->driver()->colorProcessor($image->colorspace())->colorToNative(
-            $this->driver()->handleInput($this->font->strokeColor())
-        );
+        
+        if ( $strokeWidth > 0 ) {
+            $strokeColor = $this->driver()->colorProcessor($image->colorspace())->colorToNative(
+                $this->driver()->handleInput($this->font->strokeColor())
+            );
+            
+            if ( $strokeWidth > 10 ){
+                throw new FontException( 'Stroke width cannot be thicker than 10, please pick lower number.' );
+            }
+        }
             
         foreach ($image as $frame) {
             if ($this->font->hasFilename()) {
                 foreach ($lines as $line) {
                     imagealphablending($frame->native(), true);
                     
-                    if ( $strokeColor && $strokeWidth > 0 )
+                    if ( $strokeWidth > 0 )
                     {
-                        // Hard limit, above numbers would work fine but will start eating resources considerably
-                        if ( $strokeWidth > 10 ){
-                            $strokeWidth    = 10; 
-                        }
-                        
                         for ($x = -$strokeWidth; $x <= $strokeWidth; $x++) {
                             for ($y = -$strokeWidth; $y <= $strokeWidth; $y++) {
                                 

--- a/src/Drivers/Gd/Modifiers/TextModifier.php
+++ b/src/Drivers/Gd/Modifiers/TextModifier.php
@@ -30,32 +30,32 @@ class TextModifier extends DriverSpecialized implements ModifierInterface
             $this->driver()->handleInput($this->font->color())
         );
         
-        $strokeLimit = $this->font->strokeLimit();
         $strokeWidth = $this->font->strokeWidth();
         $strokeColor = $this->driver()->colorProcessor($image->colorspace())->colorToNative(
             $this->driver()->handleInput($this->font->strokeColor())
         );
-        
-        if ( $strokeWidth && $strokeWidth > $strokeLimit ){
-            $strokeWidth = $strokeLimit;
-        }
-    
+            
         foreach ($image as $frame) {
             if ($this->font->hasFilename()) {
                 foreach ($lines as $line) {
                     imagealphablending($frame->native(), true);
                     
-                    if ( $strokeWidth > 0 )
+                    if ( $strokeColor && $strokeWidth > 0 )
                     {
-                        for ($x = -1; $x <= 1; $x++) {
-                            for ($y = -1; $y <= 1; $y++) {
+                        // Hard limit, above numbers would work fine but will start eating resources considerably
+                        if ( $strokeWidth > 10 ){
+                            $strokeWidth    = 10; 
+                        }
+                        
+                        for ($x = -$strokeWidth; $x <= $strokeWidth; $x++) {
+                            for ($y = -$strokeWidth; $y <= $strokeWidth; $y++) {
                                 
                                 imagettftext(
                                     $frame->native(),
                                     $fontProcessor->nativeFontSize($this->font),
                                     $this->font->angle() * -1,
-                                    $line->position()->x() + $x * $strokeWidth,
-                                    $line->position()->y() + $y * $strokeWidth,
+                                    $line->position()->x() + $x,
+                                    $line->position()->y() + $y,
                                     $strokeColor,
                                     $this->font->filename(),
                                     (string) $line
@@ -81,14 +81,14 @@ class TextModifier extends DriverSpecialized implements ModifierInterface
                     
                     if ( $strokeWidth > 0 )
                     {
-                        for ($x = -1; $x <= 1; $x++) {
-                            for ($y = -1; $y <= 1; $y++) {
+                        for ($x = -$strokeWidth; $x <= $strokeWidth; $x++) {
+                            for ($y = -$strokeWidth; $y <= $strokeWidth; $y++) {
                                 
                                 imagestring(
                                     $frame->native(),
                                     $this->gdFont(),
-                                    $line->position()->x() + $x * $strokeWidth,
-                                    $line->position()->y() + $y * $strokeWidth,
+                                    $line->position()->x() + $x,
+                                    $line->position()->y() + $y,
                                     (string) $line,
                                     $color
                                 );

--- a/src/Drivers/Gd/Modifiers/TextModifier.php
+++ b/src/Drivers/Gd/Modifiers/TextModifier.php
@@ -30,10 +30,14 @@ class TextModifier extends DriverSpecialized implements ModifierInterface
             $this->driver()->handleInput($this->font->color())
         );
         
+        $strokeLimit = $this->font->strokeLimit();
         $strokeWidth = $this->font->strokeWidth();
         $strokeColor = $this->driver()->colorProcessor($image->colorspace())->colorToNative(
             $this->driver()->handleInput($this->font->strokeColor())
         );
+        
+        if ( $strokeWidth && $strokeWidth > $strokeLimit )
+            $strokeWidth = $strokeLimit;
     
         foreach ($image as $frame) {
             if ($this->font->hasFilename()) {

--- a/src/Drivers/Imagick/FontProcessor.php
+++ b/src/Drivers/Imagick/FontProcessor.php
@@ -50,7 +50,7 @@ class FontProcessor extends AbstractFontProcessor
      * @throws ImagickDrawException
      * @throws ImagickException
      */
-    public function toImagickDraw(FontInterface $font, ?ImagickPixel $color = null, ?ImagickPixel $strokeColor = null): ImagickDraw
+    public function toImagickDraw(FontInterface $font, ?ImagickPixel $color = null): ImagickDraw
     {
         if (!$font->hasFilename()) {
             throw new FontException('No font file specified.');
@@ -65,14 +65,6 @@ class FontProcessor extends AbstractFontProcessor
 
         if ($color) {
             $draw->setFillColor($color);
-        }
-        
-        $strokeWidth = $font->strokeWidth();
-        
-        if ( $strokeColor && $strokeWidth > 0 )
-        {
-            $draw->setStrokeColor( $strokeColor );
-            $draw->setStrokeWidth( $strokeWidth ); 
         }
                
         return $draw;

--- a/src/Drivers/Imagick/FontProcessor.php
+++ b/src/Drivers/Imagick/FontProcessor.php
@@ -50,7 +50,7 @@ class FontProcessor extends AbstractFontProcessor
      * @throws ImagickDrawException
      * @throws ImagickException
      */
-    public function toImagickDraw(FontInterface $font, ?ImagickPixel $color = null): ImagickDraw
+    public function toImagickDraw(FontInterface $font, ?ImagickPixel $color = null, ?ImagickPixel $strokeColor = null): ImagickDraw
     {
         if (!$font->hasFilename()) {
             throw new FontException('No font file specified.');
@@ -66,7 +66,15 @@ class FontProcessor extends AbstractFontProcessor
         if ($color) {
             $draw->setFillColor($color);
         }
-
+        
+        $strokeWidth = $font->strokeWidth();
+        
+        if ( $strokeColor && $strokeWidth > 0 )
+        {
+            $draw->setStrokeColor( $strokeColor );
+            $draw->setStrokeWidth( $strokeWidth ); 
+        }
+               
         return $draw;
     }
 }

--- a/src/Drivers/Imagick/Modifiers/TextModifier.php
+++ b/src/Drivers/Imagick/Modifiers/TextModifier.php
@@ -38,18 +38,21 @@ class TextModifier extends DriverSpecialized implements ModifierInterface
             $this->driver()->handleInput($this->font->strokeColor())
         );
         
-        if ( $strokeWidth && $strokeWidth > $strokeLimit )
+        if ( $strokeWidth && $strokeWidth > $strokeLimit ){
             $strokeWidth = $strokeLimit;
+        }
         
         $draw = $fontProcessor->toImagickDraw($this->font, $color);
+        
+        if ( $strokeColor && $strokeWidth > 0 ){
+            $drawStroke = $fontProcessor->toImagickDraw($this->font, $strokeColor);
+        }
 
         foreach ($image as $frame) {
             foreach ($lines as $line) {
                 
                 if ( $strokeColor && $strokeWidth > 0 )
-                {
-                    $drawStroke = $fontProcessor->toImagickDraw($this->font, $strokeColor);
-                    
+                {                    
                     for ($x = -1; $x <= 1; $x++) {
                         for ($y = -1; $y <= 1; $y++) {
                             $frame->native()->annotateImage(

--- a/src/Drivers/Imagick/Modifiers/TextModifier.php
+++ b/src/Drivers/Imagick/Modifiers/TextModifier.php
@@ -31,28 +31,27 @@ class TextModifier extends DriverSpecialized implements ModifierInterface
         $color = $this->driver()->colorProcessor($image->colorspace())->colorToNative(
             $this->driver()->handleInput($this->font->color())
         );
-        
-        $strokeWidth = $this->font->strokeWidth();
-        $strokeColor = $this->driver()->colorProcessor($image->colorspace())->colorToNative(
-            $this->driver()->handleInput($this->font->strokeColor())
-        );
-                
+                        
         $draw = $fontProcessor->toImagickDraw($this->font, $color);
+        $strokeWidth = $this->font->strokeWidth();
         
-        if ( $strokeColor && $strokeWidth > 0 ){
+        if ( $strokeWidth > 0 ){
+            $strokeColor = $this->driver()->colorProcessor($image->colorspace())->colorToNative(
+                $this->driver()->handleInput($this->font->strokeColor())
+            );
+            
+            if ( $strokeWidth > 10 ){
+                throw new FontException( 'Stroke width cannot be thicker than 10, please pick lower number.' );
+            }
+            
             $drawStroke = $fontProcessor->toImagickDraw($this->font, $strokeColor);
         }
 
         foreach ($image as $frame) {
             foreach ($lines as $line) {
                 
-                if ( $strokeColor && $strokeWidth > 0 )
+                if ( $strokeWidth > 0 )
                 {         
-                    // Hard limit, above numbers would work fine but will start eating resources considerably
-                    if ( $strokeWidth > 10 ){
-                        $strokeWidth    = 10; 
-                    }
-                    
                     for ($x = -$strokeWidth; $x <= $strokeWidth; $x++) {
                         for ($y = -$strokeWidth; $y <= $strokeWidth; $y++) {
 

--- a/src/Drivers/Imagick/Modifiers/TextModifier.php
+++ b/src/Drivers/Imagick/Modifiers/TextModifier.php
@@ -32,16 +32,11 @@ class TextModifier extends DriverSpecialized implements ModifierInterface
             $this->driver()->handleInput($this->font->color())
         );
         
-        $strokeLimit = $this->font->strokeLimit();
         $strokeWidth = $this->font->strokeWidth();
         $strokeColor = $this->driver()->colorProcessor($image->colorspace())->colorToNative(
             $this->driver()->handleInput($this->font->strokeColor())
         );
-        
-        if ( $strokeWidth && $strokeWidth > $strokeLimit ){
-            $strokeWidth = $strokeLimit;
-        }
-        
+                
         $draw = $fontProcessor->toImagickDraw($this->font, $color);
         
         if ( $strokeColor && $strokeWidth > 0 ){
@@ -52,13 +47,19 @@ class TextModifier extends DriverSpecialized implements ModifierInterface
             foreach ($lines as $line) {
                 
                 if ( $strokeColor && $strokeWidth > 0 )
-                {                    
-                    for ($x = -1; $x <= 1; $x++) {
-                        for ($y = -1; $y <= 1; $y++) {
+                {         
+                    // Hard limit, above numbers would work fine but will start eating resources considerably
+                    if ( $strokeWidth > 10 ){
+                        $strokeWidth    = 10; 
+                    }
+                    
+                    for ($x = -$strokeWidth; $x <= $strokeWidth; $x++) {
+                        for ($y = -$strokeWidth; $y <= $strokeWidth; $y++) {
+
                             $frame->native()->annotateImage(
                                 $drawStroke,
-                                $line->position()->x() + $x * $strokeWidth,
-                                $line->position()->y() + $y * $strokeWidth,
+                                $line->position()->x() + $x,
+                                $line->position()->y() + $y,
                                 $this->font->angle(),
                                 (string) $line
                             );

--- a/src/Drivers/Imagick/Modifiers/TextModifier.php
+++ b/src/Drivers/Imagick/Modifiers/TextModifier.php
@@ -31,8 +31,11 @@ class TextModifier extends DriverSpecialized implements ModifierInterface
         $color = $this->driver()->colorProcessor($image->colorspace())->colorToNative(
             $this->driver()->handleInput($this->font->color())
         );
-
-        $draw = $fontProcessor->toImagickDraw($this->font, $color);
+        $strokeColor = $this->driver()->colorProcessor($image->colorspace())->colorToNative(
+            $this->driver()->handleInput($this->font->strokeColor())
+        );
+        
+        $draw = $fontProcessor->toImagickDraw($this->font, $color, $strokeColor );
 
         foreach ($image as $frame) {
             foreach ($lines as $line) {

--- a/src/Interfaces/FontInterface.php
+++ b/src/Interfaces/FontInterface.php
@@ -27,7 +27,7 @@ interface FontInterface
      * @param mixed $strokeColor
      * @return FontInterface
      */
-    public function setStrokeColor(mixed $strokeColor): self;
+    public function setStrokeColor(mixed $color): self;
 
     /**
      * Get stroke color of font

--- a/src/Interfaces/FontInterface.php
+++ b/src/Interfaces/FontInterface.php
@@ -19,7 +19,37 @@ interface FontInterface
      *
      * @return mixed
      */
-    public function color(): mixed;
+    public function color(): mixed;    
+    
+    /**
+     * Set stroke color of font
+     *
+     * @param mixed $strokeColor
+     * @return FontInterface
+     */
+    public function setStrokeColor(mixed $strokeColor): self;
+
+    /**
+     * Get stroke color of font
+     *
+     * @return mixed
+     */
+    public function strokeColor(): mixed;
+
+    /**
+    /**
+     * Set stroke width of font
+     *
+     * @param mixed $strokeWidth
+     * @return FontInterface
+     */
+    public function setStrokeWidth(?int $strokeWidth): self;
+
+    /**
+     * Get stroke width of font
+     *
+     * @return mixed
+     */
     public function strokeWidth(): ?int;
 
     /**

--- a/src/Interfaces/FontInterface.php
+++ b/src/Interfaces/FontInterface.php
@@ -51,6 +51,20 @@ interface FontInterface
      * @return int
      */
     public function strokeWidth(): int;
+    
+    /**
+     * Set stroke limit to prevent the outline of the text from being too excessive
+     *
+     * @return int
+     */
+    public function setStrokeLimit(int $width): self;
+    
+    /**
+     * Get stroke limit to prevent the outline of the text from being too excessive
+     *
+     * @return int
+     */
+    public function strokeLimit(): int;
 
     /**
      * Set font size

--- a/src/Interfaces/FontInterface.php
+++ b/src/Interfaces/FontInterface.php
@@ -20,6 +20,7 @@ interface FontInterface
      * @return mixed
      */
     public function color(): mixed;
+    public function strokeWidth(): ?int;
 
     /**
      * Set font size

--- a/src/Interfaces/FontInterface.php
+++ b/src/Interfaces/FontInterface.php
@@ -40,7 +40,7 @@ interface FontInterface
     /**
      * Set stroke width of font
      *
-     * @param mixed $strokeWidth
+     * @param int $strokeWidth
      * @return FontInterface
      */
     public function setStrokeWidth(?int $strokeWidth): self;
@@ -48,7 +48,7 @@ interface FontInterface
     /**
      * Get stroke width of font
      *
-     * @return mixed
+     * @return int
      */
     public function strokeWidth(): ?int;
 

--- a/src/Interfaces/FontInterface.php
+++ b/src/Interfaces/FontInterface.php
@@ -43,7 +43,7 @@ interface FontInterface
      * @param int $strokeWidth
      * @return FontInterface
      */
-    public function setStrokeWidth(?int $strokeWidth): self;
+    public function setStrokeWidth(int $width): self;
 
     /**
      * Get stroke width of font

--- a/src/Interfaces/FontInterface.php
+++ b/src/Interfaces/FontInterface.php
@@ -50,7 +50,7 @@ interface FontInterface
      *
      * @return int
      */
-    public function strokeWidth(): ?int;
+    public function strokeWidth(): int;
 
     /**
      * Set font size

--- a/src/Interfaces/FontInterface.php
+++ b/src/Interfaces/FontInterface.php
@@ -53,20 +53,6 @@ interface FontInterface
     public function strokeWidth(): int;
     
     /**
-     * Set stroke limit to prevent the outline of the text from being too excessive
-     *
-     * @return int
-     */
-    public function setStrokeLimit(int $width): self;
-    
-    /**
-     * Get stroke limit to prevent the outline of the text from being too excessive
-     *
-     * @return int
-     */
-    public function strokeLimit(): int;
-
-    /**
      * Set font size
      *
      * @param float $size

--- a/src/Typography/Font.php
+++ b/src/Typography/Font.php
@@ -152,7 +152,7 @@ class Font implements FontInterface
      */
     public function setStrokeWidth(int $width): FontInterface
     {
-        $this->strokeWidth = $strokeWidth;
+        $this->strokeWidth = $width;
 
         return $this;
     }

--- a/src/Typography/Font.php
+++ b/src/Typography/Font.php
@@ -150,7 +150,7 @@ class Font implements FontInterface
      *
      * @see FontInterface::setStrokeWidth()
      */
-    public function setStrokeWidth(?int $strokeWidth): FontInterface
+    public function setStrokeWidth(int $width): FontInterface
     {
         $this->strokeWidth = $strokeWidth;
 

--- a/src/Typography/Font.php
+++ b/src/Typography/Font.php
@@ -13,6 +13,7 @@ class Font implements FontInterface
     protected mixed $color = '000000';
     protected mixed $strokeColor = 'ffffff';
     protected int $strokeWidth = 0;
+    protected int $strokeLimit = 5; 
     protected ?string $filename = null;
     protected string $alignment = 'left';
     protected string $valignment = 'bottom';
@@ -156,7 +157,7 @@ class Font implements FontInterface
 
         return $this;
     }
-    
+        
     /**
      * {@inheritdoc}
      *
@@ -165,6 +166,28 @@ class Font implements FontInterface
     public function strokeWidth(): int
     {
         return $this->strokeWidth;
+    }
+    
+    /**
+     * {@inheritdoc}
+     *
+     * @see FontInterface::setStrokeWidth()
+     */
+    public function setStrokeLimit(int $width): FontInterface
+    {
+        $this->strokeLimit = $width;
+
+        return $this;
+    }
+    
+    /**
+     * {@inheritdoc}
+     *
+     * @see FontInterface::strokeLimit()
+     */
+    public function strokeLimit(): int
+    {
+        return $this->strokeLimit;
     }
 
     /**

--- a/src/Typography/Font.php
+++ b/src/Typography/Font.php
@@ -11,7 +11,7 @@ class Font implements FontInterface
     protected float $size = 12;
     protected float $angle = 0;
     protected mixed $color = '000000';
-    protected mixed $strokeColor = 'red';
+    protected mixed $strokeColor = 'ffffff';
     protected ?int $strokeWidth = 0;
     protected ?string $filename = null;
     protected string $alignment = 'left';

--- a/src/Typography/Font.php
+++ b/src/Typography/Font.php
@@ -162,7 +162,7 @@ class Font implements FontInterface
      *
      * @see FontInterface::strokeWidth()
      */
-    public function strokeWidth(): ?int
+    public function strokeWidth(): int
     {
         return $this->strokeWidth;
     }

--- a/src/Typography/Font.php
+++ b/src/Typography/Font.php
@@ -13,7 +13,6 @@ class Font implements FontInterface
     protected mixed $color = '000000';
     protected mixed $strokeColor = 'ffffff';
     protected int $strokeWidth = 0;
-    protected int $strokeLimit = 5; 
     protected ?string $filename = null;
     protected string $alignment = 'left';
     protected string $valignment = 'bottom';
@@ -168,28 +167,6 @@ class Font implements FontInterface
         return $this->strokeWidth;
     }
     
-    /**
-     * {@inheritdoc}
-     *
-     * @see FontInterface::setStrokeWidth()
-     */
-    public function setStrokeLimit(int $width): FontInterface
-    {
-        $this->strokeLimit = $width;
-
-        return $this;
-    }
-    
-    /**
-     * {@inheritdoc}
-     *
-     * @see FontInterface::strokeLimit()
-     */
-    public function strokeLimit(): int
-    {
-        return $this->strokeLimit;
-    }
-
     /**
      * {@inheritdoc}
      *

--- a/src/Typography/Font.php
+++ b/src/Typography/Font.php
@@ -11,6 +11,8 @@ class Font implements FontInterface
     protected float $size = 12;
     protected float $angle = 0;
     protected mixed $color = '000000';
+    protected mixed $strokeColor = 'red';
+    protected ?int $strokeWidth = 0;
     protected ?string $filename = null;
     protected string $alignment = 'left';
     protected string $valignment = 'bottom';
@@ -118,6 +120,51 @@ class Font implements FontInterface
     public function color(): mixed
     {
         return $this->color;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see FontInterface::setStrokeColor()
+     */
+    public function setStrokeColor(mixed $strokeColor): FontInterface
+    {
+        $this->strokeColor = $strokeColor;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see FontInterface::strokeColor()
+     */
+    public function strokeColor(): mixed
+    {
+        return $this->strokeColor;
+    }
+
+    
+    /**
+     * {@inheritdoc}
+     *
+     * @see FontInterface::setStrokeWidth()
+     */
+    public function setStrokeWidth(?int $strokeWidth): FontInterface
+    {
+        $this->strokeWidth = $strokeWidth;
+
+        return $this;
+    }
+    
+    /**
+     * {@inheritdoc}
+     *
+     * @see FontInterface::strokeWidth()
+     */
+    public function strokeWidth(): ?int
+    {
+        return $this->strokeWidth;
     }
 
     /**

--- a/src/Typography/Font.php
+++ b/src/Typography/Font.php
@@ -129,7 +129,7 @@ class Font implements FontInterface
      */
     public function setStrokeColor(mixed $color): FontInterface
     {
-        $this->strokeColor = $strokeColor;
+        $this->strokeColor = $color;
 
         return $this;
     }

--- a/src/Typography/Font.php
+++ b/src/Typography/Font.php
@@ -127,7 +127,7 @@ class Font implements FontInterface
      *
      * @see FontInterface::setStrokeColor()
      */
-    public function setStrokeColor(mixed $strokeColor): FontInterface
+    public function setStrokeColor(mixed $color): FontInterface
     {
         $this->strokeColor = $strokeColor;
 

--- a/src/Typography/Font.php
+++ b/src/Typography/Font.php
@@ -12,7 +12,7 @@ class Font implements FontInterface
     protected float $angle = 0;
     protected mixed $color = '000000';
     protected mixed $strokeColor = 'ffffff';
-    protected ?int $strokeWidth = 0;
+    protected int $strokeWidth = 0;
     protected ?string $filename = null;
     protected string $alignment = 'left';
     protected string $valignment = 'bottom';

--- a/src/Typography/FontFactory.php
+++ b/src/Typography/FontFactory.php
@@ -36,11 +36,10 @@ class FontFactory
         return $this->filename($value);
     }
 
-    public function stroke(int $width, mixed $color = 'ffffff',int $limit = 5): self
+    public function stroke(int $width, mixed $color = 'ffffff'): self
     {
         $this->font->setStrokeWidth($width);
         $this->font->setStrokeColor($color);
-        $this->font->setStrokeLimit($limit);
         
         return $this;
     }

--- a/src/Typography/FontFactory.php
+++ b/src/Typography/FontFactory.php
@@ -36,7 +36,7 @@ class FontFactory
         return $this->filename($value);
     }
 
-    public function stroke(int $width, mixed $color = 'ffffff'): self
+    public function stroke(mixed $color, int $width = 1): self
     {
         $this->font->setStrokeWidth($width);
         $this->font->setStrokeColor($color);

--- a/src/Typography/FontFactory.php
+++ b/src/Typography/FontFactory.php
@@ -36,6 +36,20 @@ class FontFactory
         return $this->filename($value);
     }
 
+    public function strokeColor(mixed $value): self
+    {
+        $this->font->setStrokeColor($value);
+
+        return $this;
+    }
+
+    public function strokeWidth( ?int $value): self
+    {
+        $this->font->setStrokeWidth($value);
+
+        return $this;
+    }
+
     public function color(mixed $value): self
     {
         $this->font->setColor($value);

--- a/src/Typography/FontFactory.php
+++ b/src/Typography/FontFactory.php
@@ -36,17 +36,11 @@ class FontFactory
         return $this->filename($value);
     }
 
-    public function strokeColor(mixed $value): self
+    public function stroke(int $width, mixed $color = 'ffffff'): self
     {
-        $this->font->setStrokeColor($value);
-
-        return $this;
-    }
-
-    public function strokeWidth( ?int $value): self
-    {
-        $this->font->setStrokeWidth($value);
-
+        $this->font->setStrokeWidth($width);
+        $this->font->setStrokeColor($color);
+        
         return $this;
     }
 

--- a/src/Typography/FontFactory.php
+++ b/src/Typography/FontFactory.php
@@ -36,10 +36,11 @@ class FontFactory
         return $this->filename($value);
     }
 
-    public function stroke(int $width, mixed $color = 'ffffff'): self
+    public function stroke(int $width, mixed $color = 'ffffff',int $limit = 5): self
     {
         $this->font->setStrokeWidth($width);
         $this->font->setStrokeColor($color);
+        $this->font->setStrokeLimit($limit);
         
         return $this;
     }


### PR DESCRIPTION
Added strokeWidth and strokeColor support to "develop" branch to avoid conflicts.

- Supports both GD and Imagick Drivers.
- Text Stroking is on-demand, not by default.

Tested on PHP 8.1 with both drivers.

Aware of [Goldengide](https://github.com/Goldengide) PR, this is similar.