### PR TITLE
Add Decoder and Encoder thrown exception

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -99,7 +99,7 @@ jobs:
         run: vendor/bin/phpunit --no-coverage
 
       - name: Run analyzer
-        run: vendor/bin/phpstan analyze --level=4 ./src
+        run: vendor/bin/phpstan
 
       - name: Validate coding standards
         run: vendor/bin/phpcs

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,0 +1,20 @@
+parameters:
+    level: 4
+    paths:
+        - src
+    exceptions:
+        check:
+            missingCheckedExceptionInThrows: true
+        uncheckedExceptionClasses:
+            - Intervention\Image\Exceptions\AnimationException
+            - Intervention\Image\Exceptions\ColorException
+            - Intervention\Image\Exceptions\DriverException
+            - Intervention\Image\Exceptions\GeometryException
+            - Intervention\Image\Exceptions\FontException
+            - Intervention\Image\Exceptions\InputException
+            - Intervention\Image\Exceptions\NotSupportedException
+            - Intervention\Image\Exceptions\NotWritableException
+            - ImagickException
+            - ImagickDrawException
+            - ImagickPixelException
+            - Error

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Intervention\Image;
 
-use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Interfaces\CollectionInterface;
 use ArrayIterator;
 use Countable;
@@ -198,10 +197,6 @@ class Collection implements CollectionInterface, IteratorAggregate, Countable
      */
     public function slice(int $offset, ?int $length = null): CollectionInterface
     {
-        if ($offset >= count($this->items)) {
-            throw new RuntimeException('Offset exceeds the maximum value.');
-        }
-
         $this->items = array_slice($this->items, $offset, $length);
 
         return $this;

--- a/src/Drivers/AbstractDecoder.php
+++ b/src/Drivers/AbstractDecoder.php
@@ -25,8 +25,8 @@ abstract class AbstractDecoder extends DriverSpecialized implements DecoderInter
      * Try to decode given input to image or color object
      *
      * @param mixed $input
-     * @return ImageInterface|ColorInterface
      * @throws DecoderException
+     * @return ImageInterface|ColorInterface
      */
     final public function handle(mixed $input): ImageInterface|ColorInterface
     {

--- a/src/Drivers/AbstractDrawModifier.php
+++ b/src/Drivers/AbstractDrawModifier.php
@@ -20,6 +20,9 @@ abstract class AbstractDrawModifier extends DriverSpecialized implements Modifie
         return $this->drawable->position();
     }
 
+    /**
+     * @throws DecoderException
+     */
     public function backgroundColor(): ColorInterface
     {
         try {
@@ -31,6 +34,9 @@ abstract class AbstractDrawModifier extends DriverSpecialized implements Modifie
         return $color;
     }
 
+    /**
+     * @throws DecoderException
+     */
     public function borderColor(): ColorInterface
     {
         try {

--- a/src/Drivers/AbstractInputHandler.php
+++ b/src/Drivers/AbstractInputHandler.php
@@ -32,6 +32,7 @@ abstract class AbstractInputHandler implements InputHandlerInterface
      * Stack the decoder array into a nested decoder object
      *
      * @return AbstractDecoder
+     * @throws DecoderException
      */
     protected function chain(): AbstractDecoder
     {

--- a/src/Drivers/AbstractInputHandler.php
+++ b/src/Drivers/AbstractInputHandler.php
@@ -31,8 +31,8 @@ abstract class AbstractInputHandler implements InputHandlerInterface
     /**
      * Stack the decoder array into a nested decoder object
      *
-     * @return AbstractDecoder
      * @throws DecoderException
+     * @return AbstractDecoder
      */
     protected function chain(): AbstractDecoder
     {

--- a/src/Drivers/Gd/Decoders/AbstractDecoder.php
+++ b/src/Drivers/Gd/Decoders/AbstractDecoder.php
@@ -13,8 +13,8 @@ abstract class AbstractDecoder extends GenericAbstractDecoder
      * Return media (mime) type of the file at given file path
      *
      * @param string $filepath
-     * @return string
      * @throws DecoderException
+     * @return string
      */
     protected function getMediaTypeByFilePath(string $filepath): string
     {
@@ -35,8 +35,8 @@ abstract class AbstractDecoder extends GenericAbstractDecoder
      * Return media (mime) type of the given image data
      *
      * @param string $data
-     * @return string
      * @throws DecoderException
+     * @return string
      */
     protected function getMediaTypeByBinary(string $data): string
     {

--- a/src/Drivers/Gd/Decoders/AbstractDecoder.php
+++ b/src/Drivers/Gd/Decoders/AbstractDecoder.php
@@ -14,6 +14,7 @@ abstract class AbstractDecoder extends GenericAbstractDecoder
      *
      * @param string $filepath
      * @return string
+     * @throws DecoderException
      */
     protected function getMediaTypeByFilePath(string $filepath): string
     {
@@ -35,6 +36,7 @@ abstract class AbstractDecoder extends GenericAbstractDecoder
      *
      * @param string $data
      * @return string
+     * @throws DecoderException
      */
     protected function getMediaTypeByBinary(string $data): string
     {

--- a/src/Drivers/Gd/Decoders/BinaryImageDecoder.php
+++ b/src/Drivers/Gd/Decoders/BinaryImageDecoder.php
@@ -36,8 +36,8 @@ class BinaryImageDecoder extends GdImageDecoder implements DecoderInterface
      * Decode image from given binary data
      *
      * @param string $input
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     private function decodeBinary(string $input): ImageInterface
     {

--- a/src/Drivers/Gd/Driver.php
+++ b/src/Drivers/Gd/Driver.php
@@ -6,7 +6,7 @@ namespace Intervention\Image\Drivers\Gd;
 
 use Intervention\Image\Drivers\AbstractDriver;
 use Intervention\Image\Exceptions\DecoderException;
-use Intervention\Image\Exceptions\RuntimeException;
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Image;
 use Intervention\Image\Interfaces\ColorInterface;
 use Intervention\Image\Interfaces\ColorProcessorInterface;
@@ -36,7 +36,7 @@ class Driver extends AbstractDriver
     public function checkHealth(): void
     {
         if (!extension_loaded('gd') || !function_exists('gd_info')) {
-            throw new RuntimeException(
+            throw new DriverException(
                 'GD PHP extension must be installed to use this driver.'
             );
         }

--- a/src/Drivers/Gd/Driver.php
+++ b/src/Drivers/Gd/Driver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Intervention\Image\Drivers\Gd;
 
 use Intervention\Image\Drivers\AbstractDriver;
+use Intervention\Image\Exceptions\DecoderException;
 use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Image;
 use Intervention\Image\Interfaces\ColorInterface;
@@ -79,6 +80,9 @@ class Driver extends AbstractDriver
             ) {
             }
 
+            /**
+             * @throws DecoderException
+             */
             public function add($source, float $delay = 1): self
             {
                 $this->core->add(

--- a/src/Drivers/Gd/Encoders/GifEncoder.php
+++ b/src/Drivers/Gd/Encoders/GifEncoder.php
@@ -7,6 +7,7 @@ namespace Intervention\Image\Drivers\Gd\Encoders;
 use Intervention\Gif\Builder as GifBuilder;
 use Intervention\Image\Drivers\DriverSpecializedEncoder;
 use Intervention\Image\EncodedImage;
+use Intervention\Image\Exceptions\EncoderException;
 use Intervention\Image\Interfaces\ImageInterface;
 
 class GifEncoder extends DriverSpecializedEncoder
@@ -25,6 +26,9 @@ class GifEncoder extends DriverSpecializedEncoder
         return new EncodedImage($data, 'image/gif');
     }
 
+    /**
+     * @throws EncoderException
+     */
     protected function encodeAnimated(ImageInterface $image): EncodedImage
     {
         $builder = GifBuilder::canvas(

--- a/src/Drivers/Gd/Encoders/GifEncoder.php
+++ b/src/Drivers/Gd/Encoders/GifEncoder.php
@@ -43,7 +43,11 @@ class GifEncoder extends DriverSpecializedEncoder
             );
         }
 
-        $builder->setLoops($image->loops());
+        try {
+            $builder->setLoops($image->loops());
+        } catch (\Exception $e) {
+            throw new EncoderException($e->getMessage(), $e->getCode(), $e);
+        }
 
         return new EncodedImage($builder->encode(), 'image/gif');
     }

--- a/src/Drivers/Gd/Modifiers/FillModifier.php
+++ b/src/Drivers/Gd/Modifiers/FillModifier.php
@@ -6,6 +6,7 @@ namespace Intervention\Image\Drivers\Gd\Modifiers;
 
 use Intervention\Image\Drivers\DriverSpecialized;
 use Intervention\Image\Drivers\Gd\Frame;
+use Intervention\Image\Exceptions\DecoderException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Geometry\Point;
 use Intervention\Image\Interfaces\ModifierInterface;
@@ -32,6 +33,9 @@ class FillModifier extends DriverSpecialized implements ModifierInterface
         return $image;
     }
 
+    /**
+     * @throws DecoderException
+     */
     private function color(ImageInterface $image): int
     {
         return $this->driver()->colorProcessor($image->colorspace())->colorToNative(

--- a/src/Drivers/Imagick/Core.php
+++ b/src/Drivers/Imagick/Core.php
@@ -9,7 +9,6 @@ use ImagickException;
 use Iterator;
 use Intervention\Image\Interfaces\CoreInterface;
 use Intervention\Image\Exceptions\AnimationException;
-use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Interfaces\CollectionInterface;
 use Intervention\Image\Interfaces\FrameInterface;
 
@@ -98,10 +97,6 @@ class Core implements CoreInterface, Iterator
      */
     public function slice(int $offset, ?int $length = null): CollectionInterface
     {
-        if ($offset >= $this->count()) {
-            throw new RuntimeException('Offset exceeds the maximum value.');
-        }
-
         $allowed_indexes = [];
         $length = is_null($length) ? $this->count() : $length;
         for ($i = $offset; $i < $offset + $length; $i++) {

--- a/src/Drivers/Imagick/Driver.php
+++ b/src/Drivers/Imagick/Driver.php
@@ -8,7 +8,7 @@ use Imagick;
 use ImagickPixel;
 use Intervention\Image\Drivers\AbstractDriver;
 use Intervention\Image\Exceptions\DecoderException;
-use Intervention\Image\Exceptions\RuntimeException;
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Image;
 use Intervention\Image\Interfaces\ColorInterface;
 use Intervention\Image\Interfaces\ColorProcessorInterface;
@@ -38,7 +38,7 @@ class Driver extends AbstractDriver
     public function checkHealth(): void
     {
         if (!extension_loaded('imagick') || !class_exists('Imagick')) {
-            throw new RuntimeException(
+            throw new DriverException(
                 'Imagick PHP extension must be installed to use this driver.'
             );
         }

--- a/src/Drivers/Imagick/Driver.php
+++ b/src/Drivers/Imagick/Driver.php
@@ -7,6 +7,7 @@ namespace Intervention\Image\Drivers\Imagick;
 use Imagick;
 use ImagickPixel;
 use Intervention\Image\Drivers\AbstractDriver;
+use Intervention\Image\Exceptions\DecoderException;
 use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Image;
 use Intervention\Image\Interfaces\ColorInterface;
@@ -81,6 +82,9 @@ class Driver extends AbstractDriver
             ) {
             }
 
+            /**
+             * @throws DecoderException
+             */
             public function add($source, float $delay = 1): self
             {
                 $native = $this->driver->handleInput($source)->core()->native();

--- a/src/Drivers/Imagick/FontProcessor.php
+++ b/src/Drivers/Imagick/FontProcessor.php
@@ -45,10 +45,10 @@ class FontProcessor extends AbstractFontProcessor
      *
      * @param FontInterface $font
      * @param null|ImagickPixel $color
-     * @return ImagickDraw
      * @throws FontException
      * @throws ImagickDrawException
      * @throws ImagickException
+     * @return ImagickDraw
      */
     public function toImagickDraw(FontInterface $font, ?ImagickPixel $color = null): ImagickDraw
     {

--- a/src/Encoders/FileExtensionEncoder.php
+++ b/src/Encoders/FileExtensionEncoder.php
@@ -41,8 +41,8 @@ class FileExtensionEncoder extends AutoEncoder
      * Create matching encoder for given file extension
      *
      * @param string $extension
-     * @return EncoderInterface
      * @throws EncoderException
+     * @return EncoderInterface
      */
     protected function encoderByFileExtension(?string $extension): EncoderInterface
     {

--- a/src/Encoders/MediaTypeEncoder.php
+++ b/src/Encoders/MediaTypeEncoder.php
@@ -34,8 +34,8 @@ class MediaTypeEncoder extends SpecializableEncoder implements EncoderInterface
      * Return new encoder by given media (MIME) type
      *
      * @param string $type
-     * @return EncoderInterface
      * @throws EncoderException
+     * @return EncoderInterface
      */
     protected function encoderByMediaType(string $type): EncoderInterface
     {

--- a/src/Exceptions/AnimationException.php
+++ b/src/Exceptions/AnimationException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Exceptions;
 
-class AnimationException extends \RuntimeException
+class AnimationException extends RuntimeException
 {
 }

--- a/src/Exceptions/ColorException.php
+++ b/src/Exceptions/ColorException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Exceptions;
 
-class ColorException extends \RuntimeException
+class ColorException extends RuntimeException
 {
 }

--- a/src/Exceptions/DecoderException.php
+++ b/src/Exceptions/DecoderException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Exceptions;
 
-class DecoderException extends \RuntimeException
+class DecoderException extends RuntimeException
 {
 }

--- a/src/Exceptions/DriverException.php
+++ b/src/Exceptions/DriverException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intervention\Image\Exceptions;
+
+class DriverException extends RuntimeException
+{
+}

--- a/src/Exceptions/EncoderException.php
+++ b/src/Exceptions/EncoderException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Exceptions;
 
-class EncoderException extends \RuntimeException
+class EncoderException extends RuntimeException
 {
 }

--- a/src/Exceptions/FontException.php
+++ b/src/Exceptions/FontException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Exceptions;
 
-class FontException extends \RuntimeException
+class FontException extends RuntimeException
 {
 }

--- a/src/Exceptions/GeometryException.php
+++ b/src/Exceptions/GeometryException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Exceptions;
 
-class GeometryException extends \RuntimeException
+class GeometryException extends RuntimeException
 {
 }

--- a/src/Exceptions/InputException.php
+++ b/src/Exceptions/InputException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Exceptions;
 
-class InputException extends \RuntimeException
+class InputException extends RuntimeException
 {
 }

--- a/src/Exceptions/NotSupportedException.php
+++ b/src/Exceptions/NotSupportedException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Exceptions;
 
-class NotSupportedException extends \RuntimeException
+class NotSupportedException extends RuntimeException
 {
 }

--- a/src/Exceptions/NotWritableException.php
+++ b/src/Exceptions/NotWritableException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Exceptions;
 
-class NotWritableException extends \RuntimeException
+class NotWritableException extends RuntimeException
 {
 }

--- a/src/Image.php
+++ b/src/Image.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Intervention\Image;
 
-use Intervention\Image\Exceptions\RuntimeException;
 use Traversable;
 use Intervention\Image\Analyzers\ColorspaceAnalyzer;
 use Intervention\Image\Analyzers\HeightAnalyzer;
@@ -892,8 +891,8 @@ final class Image implements ImageInterface
      * Alias of self::toJpeg()
      *
      * @param mixed $options
+     * @throws EncoderException
      * @return EncodedImageInterface
-     * @throws RuntimeException
      */
     public function toJpg(mixed ...$options): EncodedImageInterface
     {
@@ -914,8 +913,8 @@ final class Image implements ImageInterface
      * ALias of self::toJpeg2000()
      *
      * @param mixed $options
+     * @throws EncoderException
      * @return EncodedImageInterface
-     * @throws RuntimeException
      */
     public function toJp2(mixed ...$options): EncodedImageInterface
     {
@@ -965,8 +964,8 @@ final class Image implements ImageInterface
     /**
      * Alias if self::toBitmap()
      *
+     * @throws EncoderException
      * @return EncodedImageInterface
-     * @throws RuntimeException
      */
     public function toBmp(mixed ...$options): EncodedImageInterface
     {
@@ -997,8 +996,8 @@ final class Image implements ImageInterface
      * Alias of self::toTiff()
      *
      * @param mixed $options
+     * @throws EncoderException
      * @return EncodedImageInterface
-     * @throws RuntimeException
      */
     public function toTif(mixed ...$options): EncodedImageInterface
     {

--- a/src/Image.php
+++ b/src/Image.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image;
 
+use Intervention\Image\Exceptions\RuntimeException;
 use Traversable;
 use Intervention\Image\Analyzers\ColorspaceAnalyzer;
 use Intervention\Image\Analyzers\HeightAnalyzer;
@@ -892,6 +893,7 @@ final class Image implements ImageInterface
      *
      * @param mixed $options
      * @return EncodedImageInterface
+     * @throws RuntimeException
      */
     public function toJpg(mixed ...$options): EncodedImageInterface
     {
@@ -913,6 +915,7 @@ final class Image implements ImageInterface
      *
      * @param mixed $options
      * @return EncodedImageInterface
+     * @throws RuntimeException
      */
     public function toJp2(mixed ...$options): EncodedImageInterface
     {
@@ -963,6 +966,7 @@ final class Image implements ImageInterface
      * Alias if self::toBitmap()
      *
      * @return EncodedImageInterface
+     * @throws RuntimeException
      */
     public function toBmp(mixed ...$options): EncodedImageInterface
     {
@@ -994,6 +998,7 @@ final class Image implements ImageInterface
      *
      * @param mixed $options
      * @return EncodedImageInterface
+     * @throws RuntimeException
      */
     public function toTif(mixed ...$options): EncodedImageInterface
     {

--- a/src/ImageManager.php
+++ b/src/ImageManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image;
 
+use Intervention\Image\Exceptions\DecoderException;
 use Intervention\Image\Interfaces\DriverInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Drivers\Gd\Driver as GdDriver;
@@ -88,6 +89,7 @@ final class ImageManager
      * @param mixed $input
      * @param string|array|DecoderInterface $decoders
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function read(mixed $input, string|array|DecoderInterface $decoders = []): ImageInterface
     {

--- a/src/ImageManager.php
+++ b/src/ImageManager.php
@@ -88,8 +88,8 @@ final class ImageManager
      *
      * @param mixed $input
      * @param string|array|DecoderInterface $decoders
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function read(mixed $input, string|array|DecoderInterface $decoders = []): ImageInterface
     {

--- a/src/Interfaces/ColorInterface.php
+++ b/src/Interfaces/ColorInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Interfaces;
 
+use Intervention\Image\Exceptions\DecoderException;
+
 interface ColorInterface
 {
     /**
@@ -11,8 +13,8 @@ interface ColorInterface
      * and returns a corresponding color object
      *
      * @param mixed $input
+     * @throws DecoderException
      * @return ColorInterface
-     * @throws \Intervention\Image\Exceptions\DecoderException
      */
     public static function create(mixed $input): self;
 

--- a/src/Interfaces/DecoderInterface.php
+++ b/src/Interfaces/DecoderInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Interfaces;
 
+use Intervention\Image\Exceptions\DecoderException;
+
 interface DecoderInterface
 {
     /**
@@ -11,6 +13,7 @@ interface DecoderInterface
      *
      * @param mixed $input
      * @return ImageInterface|ColorInterface
+     * @throws DecoderException
      */
     public function decode(mixed $input): ImageInterface|ColorInterface;
 }

--- a/src/Interfaces/DecoderInterface.php
+++ b/src/Interfaces/DecoderInterface.php
@@ -12,8 +12,8 @@ interface DecoderInterface
      * Decode given input either to color or image
      *
      * @param mixed $input
-     * @return ImageInterface|ColorInterface
      * @throws DecoderException
+     * @return ImageInterface|ColorInterface
      */
     public function decode(mixed $input): ImageInterface|ColorInterface;
 }

--- a/src/Interfaces/DriverInterface.php
+++ b/src/Interfaces/DriverInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Intervention\Image\Interfaces;
 
 use Intervention\Image\Exceptions\DecoderException;
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\RuntimeException;
 
 interface DriverInterface
@@ -78,7 +79,7 @@ interface DriverInterface
      * Check whether all requirements for operating the driver are met and
      * throw exception if the check fails.
      *
-     * @throws RuntimeException
+     * @throws DriverException
      * @return void
      */
     public function checkHealth(): void;

--- a/src/Interfaces/DriverInterface.php
+++ b/src/Interfaces/DriverInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Intervention\Image\Interfaces;
 
 use Intervention\Image\Exceptions\DecoderException;
+use Intervention\Image\Exceptions\RuntimeException;
 
 interface DriverInterface
 {
@@ -53,8 +54,8 @@ interface DriverInterface
      *
      * @param mixed $input
      * @param array $decoders
-     * @return ImageInterface|ColorInterface
      * @throws DecoderException
+     * @return ImageInterface|ColorInterface
      */
     public function handleInput(mixed $input, array $decoders = []): ImageInterface|ColorInterface;
 
@@ -77,7 +78,7 @@ interface DriverInterface
      * Check whether all requirements for operating the driver are met and
      * throw exception if the check fails.
      *
-     * @throws \Intervention\Image\Exceptions\RuntimeException
+     * @throws RuntimeException
      * @return void
      */
     public function checkHealth(): void;

--- a/src/Interfaces/DriverInterface.php
+++ b/src/Interfaces/DriverInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Interfaces;
 
+use Intervention\Image\Exceptions\DecoderException;
+
 interface DriverInterface
 {
     /**
@@ -52,6 +54,7 @@ interface DriverInterface
      * @param mixed $input
      * @param array $decoders
      * @return ImageInterface|ColorInterface
+     * @throws DecoderException
      */
     public function handleInput(mixed $input, array $decoders = []): ImageInterface|ColorInterface;
 

--- a/src/Interfaces/EncoderInterface.php
+++ b/src/Interfaces/EncoderInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Interfaces;
 
+use Intervention\Image\Exceptions\EncoderException;
+
 interface EncoderInterface
 {
     /**
@@ -11,6 +13,7 @@ interface EncoderInterface
      *
      * @param ImageInterface $image
      * @return EncodedImageInterface
+     * @throws EncoderException
      */
     public function encode(ImageInterface $image): EncodedImageInterface;
 }

--- a/src/Interfaces/EncoderInterface.php
+++ b/src/Interfaces/EncoderInterface.php
@@ -12,8 +12,8 @@ interface EncoderInterface
      * Encode given image
      *
      * @param ImageInterface $image
-     * @return EncodedImageInterface
      * @throws EncoderException
+     * @return EncodedImageInterface
      */
     public function encode(ImageInterface $image): EncodedImageInterface;
 }

--- a/src/Interfaces/ImageInterface.php
+++ b/src/Interfaces/ImageInterface.php
@@ -67,8 +67,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Encode image with given encoder
      *
      * @param EncoderInterface $encoder
-     * @return EncodedImageInterface
      * @throws EncoderException
+     * @return EncodedImageInterface
      */
     public function encode(EncoderInterface $encoder = new AutoEncoder()): EncodedImageInterface;
 
@@ -77,8 +77,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * given, the image will be saved at its original location.
      *
      * @param null|string $path
-     * @return ImageInterface
      * @throws EncoderException
+     * @return ImageInterface
      */
     public function save(?string $path = null, ...$options): self;
 
@@ -86,8 +86,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Apply given modifier to current image
      *
      * @param ModifierInterface $modifier
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function modify(ModifierInterface $modifier): self;
 
@@ -115,8 +115,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * and the respective frame position is only determined approximately.
      *
      * @param int|string $position
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function removeAnimation(int|string $position = 0): self;
 
@@ -125,8 +125,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param int $offset
      * @param null|int $length
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function sliceAnimation(int $offset = 0, ?int $length = null): self;
 
@@ -172,8 +172,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param float $x
      * @param float $y
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function setResolution(float $x, float $y): self;
 
@@ -188,8 +188,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Transform image to given colorspace
      *
      * @param string|ColorspaceInterface $colorspace
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function setColorspace(string|ColorspaceInterface $colorspace): self;
 
@@ -225,8 +225,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * which does not support transparency.
      *
      * @param mixed $color
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function setBlendingColor(mixed $color): self;
 
@@ -234,8 +234,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Replace transparent areas of the image with given color
      *
      * @param mixed $color
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function blendTransparency(mixed $color = null): self;
 
@@ -250,16 +250,16 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Set given icc color profile to image
      *
      * @param ProfileInterface $profile
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function setProfile(ProfileInterface $profile): self;
 
     /**
      * Remove ICC color profile from the current image
      *
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function removeProfile(): self;
 
@@ -268,8 +268,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param int $limit
      * @param mixed $background
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function reduceColors(int $limit, mixed $background = 'transparent'): self;
 
@@ -277,16 +277,16 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Sharpen the current image with given strength
      *
      * @param int $amount
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function sharpen(int $amount = 10): self;
 
     /**
      * Turn image into a greyscale version
      *
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function greyscale(): self;
 
@@ -294,8 +294,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Adjust brightness of the current image
      *
      * @param int $level
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function brightness(int $level): self;
 
@@ -303,8 +303,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Adjust color contrast of the current image
      *
      * @param int $level
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function contrast(int $level): self;
 
@@ -312,8 +312,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Apply gamma correction on the current image
      *
      * @param float $gamma
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function gamma(float $gamma): self;
 
@@ -323,24 +323,24 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $red
      * @param int $green
      * @param int $blue
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function colorize(int $red = 0, int $green = 0, int $blue = 0): self;
 
     /**
      * Mirror the current image horizontally
      *
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function flip(): self;
 
     /**
      * Mirror the current image vertically
      *
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function flop(): self;
 
@@ -348,16 +348,16 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Blur current image by given strength
      *
      * @param int $amount
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function blur(int $amount = 5): self;
 
     /**
      * Invert the colors of the current image
      *
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function invert(): self;
 
@@ -365,8 +365,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Apply pixelation filter effect on current image
      *
      * @param int $size
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function pixelate(int $size): self;
 
@@ -375,8 +375,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param float $angle
      * @param string $background
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function rotate(float $angle, mixed $background = 'ffffff'): self;
 
@@ -387,8 +387,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $x
      * @param int $y
      * @param callable|FontInterface $font
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function text(string $text, int $x, int $y, callable|FontInterface $font): self;
 
@@ -397,8 +397,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param null|int $width
      * @param null|int $height
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function resize(?int $width = null, ?int $height = null): self;
 
@@ -407,8 +407,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param null|int $width
      * @param null|int $height
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function resizeDown(?int $width = null, ?int $height = null): self;
 
@@ -417,8 +417,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param null|int $width
      * @param null|int $height
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function scale(?int $width = null, ?int $height = null): self;
 
@@ -428,8 +428,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param null|int $width
      * @param null|int $height
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function scaleDown(?int $width = null, ?int $height = null): self;
 
@@ -441,8 +441,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $width
      * @param int $height
      * @param string $position
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function cover(int $width, int $height, string $position = 'center'): self;
 
@@ -452,8 +452,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $width
      * @param int $height
      * @param string $position
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function coverDown(int $width, int $height, string $position = 'center'): self;
 
@@ -467,8 +467,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param null|int $height
      * @param string $position
      * @param mixed $background
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function resizeCanvas(
         ?int $width = null,
@@ -486,8 +486,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param null|int $height
      * @param string $position
      * @param mixed $background
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function resizeCanvasRelative(
         ?int $width = null,
@@ -509,8 +509,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $height
      * @param string $background
      * @param string $position
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function pad(
         int $width,
@@ -527,8 +527,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $height
      * @param string $background
      * @param string $position
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function contain(
         int $width,
@@ -548,8 +548,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $offset_y
      * @param mixed $background
      * @param string $position
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function crop(
         int $width,
@@ -568,8 +568,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $offset_x
      * @param int $offset_y
      * @param int $opacity
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function place(
         mixed $element,
@@ -592,8 +592,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param mixed $color
      * @param null|int $x
      * @param null|int $y
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function fill(mixed $color, ?int $x = null, ?int $y = null): self;
 
@@ -603,8 +603,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $x
      * @param int $y
      * @param mixed $color
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function drawPixel(int $x, int $y, mixed $color): self;
 
@@ -614,8 +614,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $x
      * @param int $y
      * @param callable $init
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function drawRectangle(int $x, int $y, callable $init): self;
 
@@ -625,8 +625,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $x
      * @param int $y
      * @param callable $init
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function drawEllipse(int $x, int $y, callable $init): self;
 
@@ -636,8 +636,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $x
      * @param int $y
      * @param callable $init
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function drawCircle(int $x, int $y, callable $init): self;
 
@@ -645,8 +645,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Draw a polygon on the current image
      *
      * @param callable $init
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function drawPolygon(callable $init): self;
 
@@ -654,8 +654,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Draw a line on the current image
      *
      * @param callable $init
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function drawLine(callable $init): self;
 
@@ -664,8 +664,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * will be encoded to the format of the originally read image.
      *
      * @param null|string $type
-     * @return EncodedImageInterface
      * @throws EncoderException
+     * @return EncodedImageInterface
      */
     public function encodeByMediaType(?string $type = null, ...$options): EncodedImageInterface;
 
@@ -675,8 +675,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * originally read image.
      *
      * @param null|string $extension
-     * @return EncodedImageInterface
      * @throws EncoderException
+     * @return EncodedImageInterface
      */
     public function encodeByExtension(?string $extension = null, mixed ...$options): EncodedImageInterface;
 
@@ -686,8 +686,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * the format of the originally read image.
      *
      * @param null|string $path
-     * @return EncodedImageInterface
      * @throws EncoderException
+     * @return EncodedImageInterface
      */
     public function encodeByPath(?string $path = null, mixed ...$options): EncodedImageInterface;
 
@@ -695,8 +695,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Encode image to JPEG format
      *
      * @param mixed $options
-     * @return EncodedImageInterface
      * @throws EncoderException
+     * @return EncodedImageInterface
      */
 
     public function toJpeg(mixed ...$options): EncodedImageInterface;
@@ -705,8 +705,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Encode image to Jpeg2000 format
      *
      * @param mixed $options
-     * @return EncodedImageInterface
      * @throws EncoderException
+     * @return EncodedImageInterface
      */
     public function toJpeg2000(mixed ...$options): EncodedImageInterface;
 
@@ -714,8 +714,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Encode image to Webp format
      *
      * @param mixed $options
-     * @return EncodedImageInterface
      * @throws EncoderException
+     * @return EncodedImageInterface
      */
     public function toWebp(mixed ...$options): EncodedImageInterface;
 
@@ -723,8 +723,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Encode image to PNG format
      *
      * @param mixed $options
-     * @return EncodedImageInterface
      * @throws EncoderException
+     * @return EncodedImageInterface
      */
     public function toPng(mixed ...$options): EncodedImageInterface;
 
@@ -732,8 +732,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Encode image to GIF format
      *
      * @param mixed $options
-     * @return EncodedImageInterface
      * @throws EncoderException
+     * @return EncodedImageInterface
      */
     public function toGif(mixed ...$options): EncodedImageInterface;
 
@@ -741,8 +741,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Encode image to Bitmap format
      *
      * @param mixed $options
-     * @return EncodedImageInterface
      * @throws EncoderException
+     * @return EncodedImageInterface
      */
     public function toBitmap(mixed ...$options): EncodedImageInterface;
 
@@ -750,8 +750,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Encode image to AVIF format
      *
      * @param mixed $options
-     * @return EncodedImageInterface
      * @throws EncoderException
+     * @return EncodedImageInterface
      */
     public function toAvif(mixed ...$options): EncodedImageInterface;
 
@@ -759,8 +759,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Encode image to TIFF format
      *
      * @param mixed $options
-     * @return EncodedImageInterface
      * @throws EncoderException
+     * @return EncodedImageInterface
      */
     public function toTiff(mixed ...$options): EncodedImageInterface;
 
@@ -768,8 +768,8 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Encode image to HEIC format
      *
      * @param mixed $options
-     * @return EncodedImageInterface
      * @throws EncoderException
+     * @return EncodedImageInterface
      */
     public function toHeic(mixed ...$options): EncodedImageInterface;
 }

--- a/src/Interfaces/ImageInterface.php
+++ b/src/Interfaces/ImageInterface.php
@@ -6,6 +6,8 @@ namespace Intervention\Image\Interfaces;
 
 use Countable;
 use Intervention\Image\Encoders\AutoEncoder;
+use Intervention\Image\Exceptions\DecoderException;
+use Intervention\Image\Exceptions\EncoderException;
 use Intervention\Image\Origin;
 use IteratorAggregate;
 
@@ -66,6 +68,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param EncoderInterface $encoder
      * @return EncodedImageInterface
+     * @throws EncoderException
      */
     public function encode(EncoderInterface $encoder = new AutoEncoder()): EncodedImageInterface;
 
@@ -75,6 +78,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param null|string $path
      * @return ImageInterface
+     * @throws EncoderException
      */
     public function save(?string $path = null, ...$options): self;
 
@@ -83,6 +87,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param ModifierInterface $modifier
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function modify(ModifierInterface $modifier): self;
 
@@ -111,6 +116,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param int|string $position
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function removeAnimation(int|string $position = 0): self;
 
@@ -120,6 +126,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $offset
      * @param null|int $length
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function sliceAnimation(int $offset = 0, ?int $length = null): self;
 
@@ -166,6 +173,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param float $x
      * @param float $y
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function setResolution(float $x, float $y): self;
 
@@ -181,6 +189,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param string|ColorspaceInterface $colorspace
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function setColorspace(string|ColorspaceInterface $colorspace): self;
 
@@ -217,6 +226,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param mixed $color
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function setBlendingColor(mixed $color): self;
 
@@ -225,6 +235,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param mixed $color
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function blendTransparency(mixed $color = null): self;
 
@@ -240,6 +251,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param ProfileInterface $profile
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function setProfile(ProfileInterface $profile): self;
 
@@ -247,6 +259,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Remove ICC color profile from the current image
      *
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function removeProfile(): self;
 
@@ -256,6 +269,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $limit
      * @param mixed $background
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function reduceColors(int $limit, mixed $background = 'transparent'): self;
 
@@ -264,6 +278,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param int $amount
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function sharpen(int $amount = 10): self;
 
@@ -271,6 +286,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Turn image into a greyscale version
      *
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function greyscale(): self;
 
@@ -279,6 +295,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param int $level
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function brightness(int $level): self;
 
@@ -287,6 +304,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param int $level
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function contrast(int $level): self;
 
@@ -295,6 +313,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param float $gamma
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function gamma(float $gamma): self;
 
@@ -305,6 +324,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $green
      * @param int $blue
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function colorize(int $red = 0, int $green = 0, int $blue = 0): self;
 
@@ -312,6 +332,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Mirror the current image horizontally
      *
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function flip(): self;
 
@@ -319,6 +340,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Mirror the current image vertically
      *
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function flop(): self;
 
@@ -327,6 +349,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param int $amount
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function blur(int $amount = 5): self;
 
@@ -334,6 +357,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Invert the colors of the current image
      *
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function invert(): self;
 
@@ -342,6 +366,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param int $size
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function pixelate(int $size): self;
 
@@ -351,6 +376,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param float $angle
      * @param string $background
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function rotate(float $angle, mixed $background = 'ffffff'): self;
 
@@ -362,6 +388,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $y
      * @param callable|FontInterface $font
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function text(string $text, int $x, int $y, callable|FontInterface $font): self;
 
@@ -371,6 +398,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param null|int $width
      * @param null|int $height
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function resize(?int $width = null, ?int $height = null): self;
 
@@ -380,6 +408,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param null|int $width
      * @param null|int $height
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function resizeDown(?int $width = null, ?int $height = null): self;
 
@@ -389,6 +418,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param null|int $width
      * @param null|int $height
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function scale(?int $width = null, ?int $height = null): self;
 
@@ -399,6 +429,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param null|int $width
      * @param null|int $height
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function scaleDown(?int $width = null, ?int $height = null): self;
 
@@ -411,6 +442,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $height
      * @param string $position
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function cover(int $width, int $height, string $position = 'center'): self;
 
@@ -421,6 +453,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $height
      * @param string $position
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function coverDown(int $width, int $height, string $position = 'center'): self;
 
@@ -435,6 +468,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param string $position
      * @param mixed $background
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function resizeCanvas(
         ?int $width = null,
@@ -453,6 +487,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param string $position
      * @param mixed $background
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function resizeCanvasRelative(
         ?int $width = null,
@@ -475,6 +510,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param string $background
      * @param string $position
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function pad(
         int $width,
@@ -492,6 +528,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param string $background
      * @param string $position
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function contain(
         int $width,
@@ -512,6 +549,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param mixed $background
      * @param string $position
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function crop(
         int $width,
@@ -531,6 +569,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $offset_y
      * @param int $opacity
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function place(
         mixed $element,
@@ -554,6 +593,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param null|int $x
      * @param null|int $y
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function fill(mixed $color, ?int $x = null, ?int $y = null): self;
 
@@ -564,6 +604,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $y
      * @param mixed $color
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function drawPixel(int $x, int $y, mixed $color): self;
 
@@ -574,6 +615,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $y
      * @param callable $init
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function drawRectangle(int $x, int $y, callable $init): self;
 
@@ -584,6 +626,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $y
      * @param callable $init
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function drawEllipse(int $x, int $y, callable $init): self;
 
@@ -594,6 +637,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $y
      * @param callable $init
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function drawCircle(int $x, int $y, callable $init): self;
 
@@ -602,6 +646,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param callable $init
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function drawPolygon(callable $init): self;
 
@@ -610,6 +655,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param callable $init
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function drawLine(callable $init): self;
 
@@ -619,6 +665,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param null|string $type
      * @return EncodedImageInterface
+     * @throws EncoderException
      */
     public function encodeByMediaType(?string $type = null, ...$options): EncodedImageInterface;
 
@@ -629,6 +676,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param null|string $extension
      * @return EncodedImageInterface
+     * @throws EncoderException
      */
     public function encodeByExtension(?string $extension = null, mixed ...$options): EncodedImageInterface;
 
@@ -639,6 +687,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param null|string $path
      * @return EncodedImageInterface
+     * @throws EncoderException
      */
     public function encodeByPath(?string $path = null, mixed ...$options): EncodedImageInterface;
 
@@ -647,6 +696,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param mixed $options
      * @return EncodedImageInterface
+     * @throws EncoderException
      */
 
     public function toJpeg(mixed ...$options): EncodedImageInterface;
@@ -656,6 +706,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param mixed $options
      * @return EncodedImageInterface
+     * @throws EncoderException
      */
     public function toJpeg2000(mixed ...$options): EncodedImageInterface;
 
@@ -664,6 +715,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param mixed $options
      * @return EncodedImageInterface
+     * @throws EncoderException
      */
     public function toWebp(mixed ...$options): EncodedImageInterface;
 
@@ -672,6 +724,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param mixed $options
      * @return EncodedImageInterface
+     * @throws EncoderException
      */
     public function toPng(mixed ...$options): EncodedImageInterface;
 
@@ -680,6 +733,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param mixed $options
      * @return EncodedImageInterface
+     * @throws EncoderException
      */
     public function toGif(mixed ...$options): EncodedImageInterface;
 
@@ -688,6 +742,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param mixed $options
      * @return EncodedImageInterface
+     * @throws EncoderException
      */
     public function toBitmap(mixed ...$options): EncodedImageInterface;
 
@@ -696,6 +751,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param mixed $options
      * @return EncodedImageInterface
+     * @throws EncoderException
      */
     public function toAvif(mixed ...$options): EncodedImageInterface;
 
@@ -704,6 +760,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param mixed $options
      * @return EncodedImageInterface
+     * @throws EncoderException
      */
     public function toTiff(mixed ...$options): EncodedImageInterface;
 
@@ -712,6 +769,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param mixed $options
      * @return EncodedImageInterface
+     * @throws EncoderException
      */
     public function toHeic(mixed ...$options): EncodedImageInterface;
 }

--- a/src/Interfaces/InputHandlerInterface.php
+++ b/src/Interfaces/InputHandlerInterface.php
@@ -12,8 +12,8 @@ interface InputHandlerInterface
      * Try to decode the given input with each decoder of the the handler chain
      *
      * @param mixed $input
-     * @return ImageInterface|ColorInterface
      * @throws DecoderException
+     * @return ImageInterface|ColorInterface
      */
     public function handle($input): ImageInterface|ColorInterface;
 }

--- a/src/Interfaces/InputHandlerInterface.php
+++ b/src/Interfaces/InputHandlerInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Interfaces;
 
+use Intervention\Image\Exceptions\DecoderException;
+
 interface InputHandlerInterface
 {
     /**
@@ -11,6 +13,7 @@ interface InputHandlerInterface
      *
      * @param mixed $input
      * @return ImageInterface|ColorInterface
+     * @throws DecoderException
      */
     public function handle($input): ImageInterface|ColorInterface;
 }

--- a/src/Interfaces/ModifierInterface.php
+++ b/src/Interfaces/ModifierInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Interfaces;
 
+use Intervention\Image\Exceptions\DecoderException;
+
 interface ModifierInterface
 {
     /**
@@ -11,6 +13,7 @@ interface ModifierInterface
      *
      * @param ImageInterface $image
      * @return ImageInterface
+     * @throws DecoderException
      */
     public function apply(ImageInterface $image): ImageInterface;
 }

--- a/src/Interfaces/ModifierInterface.php
+++ b/src/Interfaces/ModifierInterface.php
@@ -12,8 +12,8 @@ interface ModifierInterface
      * Apply modifications of the current modifier to the given image
      *
      * @param ImageInterface $image
-     * @return ImageInterface
      * @throws DecoderException
+     * @return ImageInterface
      */
     public function apply(ImageInterface $image): ImageInterface;
 }


### PR DESCRIPTION
Hi @olivervogel, as suggested in https://github.com/Intervention/image/pull/1214#issuecomment-1848577030, I'm now using the version 3 of intervention/image. But there is still no phpdoc about possibly thrown exception.

Keeping a `@throws` phpdoc up to date is useful
- For the user to know which method can thrown exception, and which exception are thrown
- For PHPStorm to report uncaught exceptions
- For static analysis tools (like PHPStan) to also report uncaught exception

Since there is way too much exception in this tool, I started with the most frequent: EncoderException and DecoderException.

In my case this would be helpful to tell PHPStan/Phpstorm that I need to try/catch
- ImageInterface::encode method
- ImageInterface::* modifiers methods
- ImageManager::read method

If you're interested, I can continue
- with other exception
- with a PR introducing the check done by phpstan (https://phpstan.org/blog/bring-your-exceptions-under-control)

I just recommend this to be in another PR to minimize the size.