### PR TITLE
Add more `@throws` annotation

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -8,7 +8,6 @@ parameters:
         uncheckedExceptionClasses:
             - Intervention\Image\Exceptions\AnimationException
             - Intervention\Image\Exceptions\ColorException
-            - Intervention\Image\Exceptions\DriverException
             - Intervention\Image\Exceptions\GeometryException
             - Intervention\Image\Exceptions\FontException
             - Intervention\Image\Exceptions\InputException

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -8,7 +8,6 @@ parameters:
         uncheckedExceptionClasses:
             - Intervention\Image\Exceptions\AnimationException
             - Intervention\Image\Exceptions\ColorException
-            - Intervention\Image\Exceptions\GeometryException
             - Intervention\Image\Exceptions\InputException
             - Intervention\Image\Exceptions\NotSupportedException
             - ImagickException

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -13,7 +13,6 @@ parameters:
             - Intervention\Image\Exceptions\FontException
             - Intervention\Image\Exceptions\InputException
             - Intervention\Image\Exceptions\NotSupportedException
-            - Intervention\Image\Exceptions\NotWritableException
             - ImagickException
             - ImagickDrawException
             - ImagickPixelException

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -9,7 +9,6 @@ parameters:
             - Intervention\Image\Exceptions\AnimationException
             - Intervention\Image\Exceptions\ColorException
             - Intervention\Image\Exceptions\GeometryException
-            - Intervention\Image\Exceptions\FontException
             - Intervention\Image\Exceptions\InputException
             - Intervention\Image\Exceptions\NotSupportedException
             - ImagickException

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -6,9 +6,7 @@ parameters:
         check:
             missingCheckedExceptionInThrows: true
         uncheckedExceptionClasses:
-            - Intervention\Image\Exceptions\AnimationException
             - Intervention\Image\Exceptions\ColorException
-            - Intervention\Image\Exceptions\InputException
             - Intervention\Image\Exceptions\NotSupportedException
             - ImagickException
             - ImagickDrawException

--- a/src/Drivers/AbstractDecoder.php
+++ b/src/Drivers/AbstractDecoder.php
@@ -7,6 +7,7 @@ namespace Intervention\Image\Drivers;
 use Exception;
 use Intervention\Image\Collection;
 use Intervention\Image\Exceptions\DecoderException;
+use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Interfaces\CollectionInterface;
 use Intervention\Image\Interfaces\ColorInterface;
 use Intervention\Image\Interfaces\DecoderInterface;
@@ -25,7 +26,7 @@ abstract class AbstractDecoder extends DriverSpecialized implements DecoderInter
      * Try to decode given input to image or color object
      *
      * @param mixed $input
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface|ColorInterface
      */
     final public function handle(mixed $input): ImageInterface|ColorInterface

--- a/src/Drivers/AbstractDrawModifier.php
+++ b/src/Drivers/AbstractDrawModifier.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Intervention\Image\Drivers;
 
 use Intervention\Image\Exceptions\DecoderException;
+use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Interfaces\ColorInterface;
 use Intervention\Image\Interfaces\DrawableInterface;
 use Intervention\Image\Interfaces\ModifierInterface;
@@ -21,7 +22,7 @@ abstract class AbstractDrawModifier extends DriverSpecialized implements Modifie
     }
 
     /**
-     * @throws DecoderException
+     * @throws RuntimeException
      */
     public function backgroundColor(): ColorInterface
     {
@@ -35,7 +36,7 @@ abstract class AbstractDrawModifier extends DriverSpecialized implements Modifie
     }
 
     /**
-     * @throws DecoderException
+     * @throws RuntimeException
      */
     public function borderColor(): ColorInterface
     {

--- a/src/Drivers/AbstractDriver.php
+++ b/src/Drivers/AbstractDriver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers;
 
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\NotSupportedException;
 use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Interfaces\AnalyzerInterface;
@@ -16,6 +17,9 @@ use ReflectionClass;
 
 abstract class AbstractDriver implements DriverInterface
 {
+    /**
+     * @throws DriverException
+     */
     public function __construct()
     {
         $this->checkHealth();

--- a/src/Drivers/AbstractFontProcessor.php
+++ b/src/Drivers/AbstractFontProcessor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers;
 
+use Intervention\Image\Exceptions\FontException;
 use Intervention\Image\Geometry\Point;
 use Intervention\Image\Geometry\Rectangle;
 use Intervention\Image\Interfaces\FontInterface;
@@ -90,6 +91,7 @@ abstract class AbstractFontProcessor implements FontProcessorInterface
      *
      * @param TextBlock $block
      * @param FontInterface $font
+     * @throws FontException
      * @return TextBlock
      */
     protected function wrapTextBlock(TextBlock $block, FontInterface $font): TextBlock
@@ -111,6 +113,7 @@ abstract class AbstractFontProcessor implements FontProcessorInterface
      *
      * @param Line $line
      * @param FontInterface $font
+     * @throws FontException
      * @return array
      */
     protected function wrapLine(Line $line, FontInterface $font): array
@@ -152,6 +155,7 @@ abstract class AbstractFontProcessor implements FontProcessorInterface
      * @param TextBlock $block
      * @param FontInterface $font
      * @param PointInterface $position
+     * @throws FontException
      * @return PointInterface
      */
     protected function buildPivot(TextBlock $block, FontInterface $font, PointInterface $position): PointInterface

--- a/src/Drivers/Gd/Analyzers/PixelColorAnalyzer.php
+++ b/src/Drivers/Gd/Analyzers/PixelColorAnalyzer.php
@@ -27,6 +27,9 @@ class PixelColorAnalyzer extends DriverSpecialized implements AnalyzerInterface
         );
     }
 
+    /**
+     * @throws GeometryException
+     */
     protected function colorAt(ColorspaceInterface $colorspace, GdImage $gd): ColorInterface
     {
         $index = @imagecolorat($gd, $this->x, $this->y);

--- a/src/Drivers/Gd/Decoders/BinaryImageDecoder.php
+++ b/src/Drivers/Gd/Decoders/BinaryImageDecoder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Gd\Decoders;
 
+use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Interfaces\ColorInterface;
 use Intervention\Image\Interfaces\DecoderInterface;
 use Intervention\Image\Interfaces\ImageInterface;
@@ -36,7 +37,7 @@ class BinaryImageDecoder extends GdImageDecoder implements DecoderInterface
      * Decode image from given binary data
      *
      * @param string $input
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     private function decodeBinary(string $input): ImageInterface

--- a/src/Drivers/Gd/Decoders/Traits/CanDecodeGif.php
+++ b/src/Drivers/Gd/Decoders/Traits/CanDecodeGif.php
@@ -9,7 +9,6 @@ use Intervention\Gif\Splitter as GifSplitter;
 use Intervention\Image\Drivers\Gd\Core;
 use Intervention\Image\Drivers\Gd\Driver;
 use Intervention\Image\Drivers\Gd\Frame;
-use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Image;
 use Intervention\Image\Interfaces\ImageInterface;
@@ -20,7 +19,7 @@ trait CanDecodeGif
      * Decode image from given GIF source which can be either a file path or binary data
      *
      * @param mixed $input
-     * @throws DriverException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     protected function decodeGif(mixed $input): ImageInterface

--- a/src/Drivers/Gd/Decoders/Traits/CanDecodeGif.php
+++ b/src/Drivers/Gd/Decoders/Traits/CanDecodeGif.php
@@ -9,6 +9,8 @@ use Intervention\Gif\Splitter as GifSplitter;
 use Intervention\Image\Drivers\Gd\Core;
 use Intervention\Image\Drivers\Gd\Driver;
 use Intervention\Image\Drivers\Gd\Frame;
+use Intervention\Image\Exceptions\DriverException;
+use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Image;
 use Intervention\Image\Interfaces\ImageInterface;
 
@@ -18,6 +20,7 @@ trait CanDecodeGif
      * Decode image from given GIF source which can be either a file path or binary data
      *
      * @param mixed $input
+     * @throws DriverException
      * @return ImageInterface
      */
     protected function decodeGif(mixed $input): ImageInterface

--- a/src/Drivers/Gd/Driver.php
+++ b/src/Drivers/Gd/Driver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Intervention\Image\Drivers\Gd;
 
 use Intervention\Image\Drivers\AbstractDriver;
-use Intervention\Image\Exceptions\DecoderException;
 use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Image;

--- a/src/Drivers/Gd/Driver.php
+++ b/src/Drivers/Gd/Driver.php
@@ -7,6 +7,7 @@ namespace Intervention\Image\Drivers\Gd;
 use Intervention\Image\Drivers\AbstractDriver;
 use Intervention\Image\Exceptions\DecoderException;
 use Intervention\Image\Exceptions\DriverException;
+use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Image;
 use Intervention\Image\Interfaces\ColorInterface;
 use Intervention\Image\Interfaces\ColorProcessorInterface;
@@ -81,7 +82,7 @@ class Driver extends AbstractDriver
             }
 
             /**
-             * @throws DecoderException
+             * @throws RuntimeException
              */
             public function add($source, float $delay = 1): self
             {

--- a/src/Drivers/Gd/Driver.php
+++ b/src/Drivers/Gd/Driver.php
@@ -93,6 +93,9 @@ class Driver extends AbstractDriver
                 return $this;
             }
 
+            /**
+             * @throws RuntimeException
+             */
             public function __invoke(): ImageInterface
             {
                 return new Image(

--- a/src/Drivers/Gd/Encoders/GifEncoder.php
+++ b/src/Drivers/Gd/Encoders/GifEncoder.php
@@ -9,6 +9,7 @@ use Intervention\Gif\Builder as GifBuilder;
 use Intervention\Image\Drivers\DriverSpecializedEncoder;
 use Intervention\Image\EncodedImage;
 use Intervention\Image\Exceptions\EncoderException;
+use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Interfaces\ImageInterface;
 
 class GifEncoder extends DriverSpecializedEncoder
@@ -28,7 +29,7 @@ class GifEncoder extends DriverSpecializedEncoder
     }
 
     /**
-     * @throws EncoderException
+     * @throws RuntimeException
      */
     protected function encodeAnimated(ImageInterface $image): EncodedImage
     {

--- a/src/Drivers/Gd/Modifiers/CoverDownModifier.php
+++ b/src/Drivers/Gd/Modifiers/CoverDownModifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Gd\Modifiers;
 
+use Intervention\Image\Exceptions\GeometryException;
 use Intervention\Image\Interfaces\SizeInterface;
 
 /**
@@ -12,6 +13,9 @@ use Intervention\Image\Interfaces\SizeInterface;
  */
 class CoverDownModifier extends CoverModifier
 {
+    /**
+     * @throws GeometryException
+     */
     public function getResizeSize(SizeInterface $size): SizeInterface
     {
         return $size->scaleDown($this->width, $this->height);

--- a/src/Drivers/Gd/Modifiers/FillModifier.php
+++ b/src/Drivers/Gd/Modifiers/FillModifier.php
@@ -7,6 +7,7 @@ namespace Intervention\Image\Drivers\Gd\Modifiers;
 use Intervention\Image\Drivers\DriverSpecialized;
 use Intervention\Image\Drivers\Gd\Frame;
 use Intervention\Image\Exceptions\DecoderException;
+use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Geometry\Point;
 use Intervention\Image\Interfaces\ModifierInterface;
@@ -34,7 +35,7 @@ class FillModifier extends DriverSpecialized implements ModifierInterface
     }
 
     /**
-     * @throws DecoderException
+     * @throws RuntimeException
      */
     private function color(ImageInterface $image): int
     {

--- a/src/Drivers/Gd/Modifiers/PlaceModifier.php
+++ b/src/Drivers/Gd/Modifiers/PlaceModifier.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Intervention\Image\Drivers\Gd\Modifiers;
 
 use Intervention\Image\Drivers\DriverSpecialized;
+use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Interfaces\FrameInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\ModifierInterface;
@@ -44,6 +45,7 @@ class PlaceModifier extends DriverSpecialized implements ModifierInterface
      * @param FrameInterface $frame
      * @param ImageInterface $watermark
      * @param PointInterface $position
+     * @throws RuntimeException
      * @return void
      */
     private function placeOpaque(FrameInterface $frame, ImageInterface $watermark, PointInterface $position): void
@@ -76,6 +78,7 @@ class PlaceModifier extends DriverSpecialized implements ModifierInterface
      * @param FrameInterface $frame
      * @param ImageInterface $watermark
      * @param PointInterface $position
+     * @throws RuntimeException
      * @return void
      */
     private function placeTransparent(FrameInterface $frame, ImageInterface $watermark, PointInterface $position): void

--- a/src/Drivers/Gd/Modifiers/ResizeModifier.php
+++ b/src/Drivers/Gd/Modifiers/ResizeModifier.php
@@ -6,6 +6,7 @@ namespace Intervention\Image\Drivers\Gd\Modifiers;
 
 use Intervention\Image\Drivers\DriverSpecialized;
 use Intervention\Image\Drivers\Gd\Cloner;
+use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Interfaces\FrameInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\ModifierInterface;
@@ -50,6 +51,9 @@ class ResizeModifier extends DriverSpecialized implements ModifierInterface
         $frame->setNative($modified);
     }
 
+    /**
+     * @throws RuntimeException
+     */
     protected function getAdjustedSize(ImageInterface $image): SizeInterface
     {
         return $image->size()->resize($this->width, $this->height);

--- a/src/Drivers/Imagick/Driver.php
+++ b/src/Drivers/Imagick/Driver.php
@@ -7,8 +7,8 @@ namespace Intervention\Image\Drivers\Imagick;
 use Imagick;
 use ImagickPixel;
 use Intervention\Image\Drivers\AbstractDriver;
-use Intervention\Image\Exceptions\DecoderException;
 use Intervention\Image\Exceptions\DriverException;
+use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Image;
 use Intervention\Image\Interfaces\ColorInterface;
 use Intervention\Image\Interfaces\ColorProcessorInterface;
@@ -83,7 +83,7 @@ class Driver extends AbstractDriver
             }
 
             /**
-             * @throws DecoderException
+             * @throws RuntimeException
              */
             public function add($source, float $delay = 1): self
             {

--- a/src/Drivers/Imagick/Driver.php
+++ b/src/Drivers/Imagick/Driver.php
@@ -95,6 +95,9 @@ class Driver extends AbstractDriver
                 return $this;
             }
 
+            /**
+             * @throws RuntimeException
+             */
             public function __invoke(): ImageInterface
             {
                 return new Image(

--- a/src/Drivers/Imagick/Modifiers/CoverDownModifier.php
+++ b/src/Drivers/Imagick/Modifiers/CoverDownModifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Imagick\Modifiers;
 
+use Intervention\Image\Exceptions\GeometryException;
 use Intervention\Image\Interfaces\SizeInterface;
 
 /**
@@ -12,6 +13,9 @@ use Intervention\Image\Interfaces\SizeInterface;
  */
 class CoverDownModifier extends CoverModifier
 {
+    /**
+     * @throws GeometryException
+     */
     public function getResizeSize(SizeInterface $size): SizeInterface
     {
         return $size->scaleDown($this->width, $this->height);

--- a/src/Drivers/Imagick/Modifiers/ResizeModifier.php
+++ b/src/Drivers/Imagick/Modifiers/ResizeModifier.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Intervention\Image\Drivers\Imagick\Modifiers;
 
 use Intervention\Image\Drivers\DriverSpecialized;
+use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\ModifierInterface;
 use Intervention\Image\Interfaces\SizeInterface;
@@ -29,6 +30,9 @@ class ResizeModifier extends DriverSpecialized implements ModifierInterface
         return $image;
     }
 
+    /**
+     * @throws RuntimeException
+     */
     protected function getAdjustedSize(ImageInterface $image): SizeInterface
     {
         return $image->size()->resize($this->width, $this->height);

--- a/src/Drivers/Imagick/Modifiers/TextModifier.php
+++ b/src/Drivers/Imagick/Modifiers/TextModifier.php
@@ -52,6 +52,7 @@ class TextModifier extends DriverSpecialized implements ModifierInterface
     /**
      * Return imagick font processor
      *
+     * @throws FontException
      * @return FontProcessor
      */
     private function processor(): FontProcessor

--- a/src/Geometry/Rectangle.php
+++ b/src/Geometry/Rectangle.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Geometry;
 
+use Intervention\Image\Exceptions\GeometryException;
 use Intervention\Image\Geometry\Tools\RectangleResizer;
 use Intervention\Image\Interfaces\PointInterface;
 use Intervention\Image\Interfaces\SizeInterface;
@@ -281,6 +282,9 @@ class Rectangle extends Polygon implements SizeInterface
         return $this->points[2];
     }
 
+    /**
+     * @throws GeometryException
+     */
     protected function resizer(?int $width = null, ?int $height = null): RectangleResizer
     {
         return new RectangleResizer($width, $height);

--- a/src/Geometry/Tools/RectangleResizer.php
+++ b/src/Geometry/Tools/RectangleResizer.php
@@ -10,6 +10,9 @@ use Intervention\Image\Interfaces\SizeInterface;
 
 class RectangleResizer
 {
+    /**
+     * @throws GeometryException
+     */
     public function __construct(
         protected ?int $width = null,
         protected ?int $height = null,
@@ -27,6 +30,9 @@ class RectangleResizer
         }
     }
 
+    /**
+     * @throws GeometryException
+     */
     public static function to(...$arguments): self
     {
         return new self(...$arguments);
@@ -52,6 +58,9 @@ class RectangleResizer
         return $this->hasTargetHeight() ? $this->height : null;
     }
 
+    /**
+     * @throws GeometryException
+     */
     protected function getTargetSize(): SizeInterface
     {
         if (!$this->hasTargetWidth() || !$this->hasTargetHeight()) {
@@ -201,6 +210,7 @@ class RectangleResizer
      * Scale given size to cover target size
      *
      * @param SizeInterface $size Size to be resized
+     * @throws GeometryException
      * @return SizeInterface
      */
     public function cover(SizeInterface $size): SizeInterface
@@ -224,6 +234,7 @@ class RectangleResizer
      * Scale given size to contain target size
      *
      * @param SizeInterface $size Size to be resized
+     * @throws GeometryException
      * @return SizeInterface
      */
     public function contain(SizeInterface $size): SizeInterface
@@ -247,6 +258,7 @@ class RectangleResizer
      * Scale given size to contain target size but prevent upsizing
      *
      * @param SizeInterface $size Size to be resized
+     * @throws GeometryException
      * @return SizeInterface
      */
     public function containDown(SizeInterface $size): SizeInterface

--- a/src/Image.php
+++ b/src/Image.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image;
 
+use Intervention\Image\Exceptions\RuntimeException;
 use Traversable;
 use Intervention\Image\Analyzers\ColorspaceAnalyzer;
 use Intervention\Image\Analyzers\HeightAnalyzer;
@@ -112,6 +113,7 @@ final class Image implements ImageInterface
      * @param DriverInterface $driver
      * @param CoreInterface $core
      * @param CollectionInterface $exif
+     * @throws RuntimeException
      * @return void
      */
     public function __construct(
@@ -891,7 +893,7 @@ final class Image implements ImageInterface
      * Alias of self::toJpeg()
      *
      * @param mixed $options
-     * @throws EncoderException
+     * @throws RuntimeException
      * @return EncodedImageInterface
      */
     public function toJpg(mixed ...$options): EncodedImageInterface
@@ -913,7 +915,7 @@ final class Image implements ImageInterface
      * ALias of self::toJpeg2000()
      *
      * @param mixed $options
-     * @throws EncoderException
+     * @throws RuntimeException
      * @return EncodedImageInterface
      */
     public function toJp2(mixed ...$options): EncodedImageInterface
@@ -964,7 +966,7 @@ final class Image implements ImageInterface
     /**
      * Alias if self::toBitmap()
      *
-     * @throws EncoderException
+     * @throws RuntimeException
      * @return EncodedImageInterface
      */
     public function toBmp(mixed ...$options): EncodedImageInterface
@@ -996,7 +998,7 @@ final class Image implements ImageInterface
      * Alias of self::toTiff()
      *
      * @param mixed $options
-     * @throws EncoderException
+     * @throws RuntimeException
      * @return EncodedImageInterface
      */
     public function toTif(mixed ...$options): EncodedImageInterface

--- a/src/ImageManager.php
+++ b/src/ImageManager.php
@@ -57,6 +57,7 @@ final class ImageManager
      *
      * @param int $width
      * @param int $height
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function create(int $width, int $height): ImageInterface

--- a/src/ImageManager.php
+++ b/src/ImageManager.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Intervention\Image;
 
-use Intervention\Image\Exceptions\DecoderException;
 use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Interfaces\DriverInterface;
 use Intervention\Image\Interfaces\ImageInterface;

--- a/src/ImageManager.php
+++ b/src/ImageManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Intervention\Image;
 
 use Intervention\Image\Exceptions\DecoderException;
+use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Interfaces\DriverInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Drivers\Gd\Driver as GdDriver;
@@ -88,7 +89,7 @@ final class ImageManager
      *
      * @param mixed $input
      * @param string|array|DecoderInterface $decoders
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function read(mixed $input, string|array|DecoderInterface $decoders = []): ImageInterface

--- a/src/Interfaces/AnalyzerInterface.php
+++ b/src/Interfaces/AnalyzerInterface.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Interfaces;
 
+use Intervention\Image\Exceptions\RuntimeException;
+
 interface AnalyzerInterface
 {
     /**
      * Analyze given image and return the retrieved data
      *
      * @param ImageInterface $image
+     * @throws RuntimeException
      * @return mixed
      */
     public function analyze(ImageInterface $image): mixed;

--- a/src/Interfaces/ColorChannelInterface.php
+++ b/src/Interfaces/ColorChannelInterface.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Interfaces;
 
-use Intervention\Image\Exceptions\ColorException;
-
 interface ColorChannelInterface
 {
     /**

--- a/src/Interfaces/ColorChannelInterface.php
+++ b/src/Interfaces/ColorChannelInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Interfaces;
 
+use Intervention\Image\Exceptions\ColorException;
+
 interface ColorChannelInterface
 {
     /**

--- a/src/Interfaces/ColorInterface.php
+++ b/src/Interfaces/ColorInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Intervention\Image\Interfaces;
 
 use Intervention\Image\Exceptions\DecoderException;
+use Intervention\Image\Exceptions\RuntimeException;
 
 interface ColorInterface
 {
@@ -13,7 +14,7 @@ interface ColorInterface
      * and returns a corresponding color object
      *
      * @param mixed $input
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ColorInterface
      */
     public static function create(mixed $input): self;

--- a/src/Interfaces/ColorInterface.php
+++ b/src/Interfaces/ColorInterface.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Interfaces;
 
-use Intervention\Image\Exceptions\DecoderException;
 use Intervention\Image\Exceptions\RuntimeException;
 
 interface ColorInterface

--- a/src/Interfaces/CoreInterface.php
+++ b/src/Interfaces/CoreInterface.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Interfaces;
 
+use Intervention\Image\Exceptions\AnimationException;
+
 interface CoreInterface extends CollectionInterface
 {
     /**
      * return driver's representation of the image core.
      *
+     * @throws AnimationException
      * @return mixed
      */
     public function native(): mixed;
@@ -32,6 +35,7 @@ interface CoreInterface extends CollectionInterface
      * Return frame of given position in an animated image
      *
      * @param int $position
+     * @throws AnimationException
      * @return FrameInterface
      */
     public function frame(int $position): FrameInterface;
@@ -63,7 +67,16 @@ interface CoreInterface extends CollectionInterface
     /**
      * Get first frame in core
      *
+     * @throws AnimationException
      * @return FrameInterface
      */
     public function first(): FrameInterface;
+
+    /**
+     * Get last frame in core
+     *
+     * @throws AnimationException
+     * @return FrameInterface
+     */
+    public function last(): FrameInterface;
 }

--- a/src/Interfaces/DecoderInterface.php
+++ b/src/Interfaces/DecoderInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Intervention\Image\Interfaces;
 
 use Intervention\Image\Exceptions\DecoderException;
+use Intervention\Image\Exceptions\RuntimeException;
 
 interface DecoderInterface
 {
@@ -12,7 +13,7 @@ interface DecoderInterface
      * Decode given input either to color or image
      *
      * @param mixed $input
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface|ColorInterface
      */
     public function decode(mixed $input): ImageInterface|ColorInterface;

--- a/src/Interfaces/DriverInterface.php
+++ b/src/Interfaces/DriverInterface.php
@@ -38,6 +38,7 @@ interface DriverInterface
      *
      * @param int $width
      * @param int $height
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function createImage(int $width, int $height): ImageInterface;

--- a/src/Interfaces/DriverInterface.php
+++ b/src/Interfaces/DriverInterface.php
@@ -6,6 +6,7 @@ namespace Intervention\Image\Interfaces;
 
 use Intervention\Image\Exceptions\DecoderException;
 use Intervention\Image\Exceptions\DriverException;
+use Intervention\Image\Exceptions\RuntimeException;
 
 interface DriverInterface
 {
@@ -54,7 +55,7 @@ interface DriverInterface
      *
      * @param mixed $input
      * @param array $decoders
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface|ColorInterface
      */
     public function handleInput(mixed $input, array $decoders = []): ImageInterface|ColorInterface;

--- a/src/Interfaces/EncoderInterface.php
+++ b/src/Interfaces/EncoderInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Interfaces;
 
-use Intervention\Image\Exceptions\EncoderException;
+use Intervention\Image\Exceptions\RuntimeException;
 
 interface EncoderInterface
 {
@@ -12,7 +12,7 @@ interface EncoderInterface
      * Encode given image
      *
      * @param ImageInterface $image
-     * @throws EncoderException
+     * @throws RuntimeException
      * @return EncodedImageInterface
      */
     public function encode(ImageInterface $image): EncodedImageInterface;

--- a/src/Interfaces/FileInterface.php
+++ b/src/Interfaces/FileInterface.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Interfaces;
 
+use Intervention\Image\Exceptions\RuntimeException;
+
 interface FileInterface
 {
     /**
      * Save data in given path in file system
      *
      * @param string $filepath
+     * @throws RuntimeException
      * @return void
      */
     public function save(string $filepath): void;

--- a/src/Interfaces/FontProcessorInterface.php
+++ b/src/Interfaces/FontProcessorInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Interfaces;
 
+use Intervention\Image\Exceptions\FontException;
 use Intervention\Image\Typography\TextBlock;
 
 interface FontProcessorInterface
@@ -11,6 +12,7 @@ interface FontProcessorInterface
     /**
      * Calculate size of bounding box of given text in conjuction with the given font
      *
+     * @throws FontException
      * @return SizeInterface
      */
     public function boxSize(string $text, FontInterface $font): SizeInterface;
@@ -22,6 +24,7 @@ interface FontProcessorInterface
      * @param string $text
      * @param FontInterface $font
      * @param PointInterface $position
+     * @throws FontException
      * @return TextBlock
      */
     public function textBlock(string $text, FontInterface $font, PointInterface $position): TextBlock;
@@ -36,6 +39,7 @@ interface FontProcessorInterface
     /**
      * Calculate the typographical font size in pixels
      *
+     * @throws FontException
      * @return int
      */
     public function typographicalSize(FontInterface $font): int;
@@ -44,6 +48,7 @@ interface FontProcessorInterface
      * Calculates typographical cap height
      *
      * @param FontInterface $font
+     * @throws FontException
      * @return int
      */
     public function capHeight(FontInterface $font): int;
@@ -52,6 +57,7 @@ interface FontProcessorInterface
      * Calculates typographical leading size
      *
      * @param FontInterface $font
+     * @throws FontException
      * @return int
      */
     public function leading(FontInterface $font): int;

--- a/src/Interfaces/FrameInterface.php
+++ b/src/Interfaces/FrameInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Interfaces;
 
+use Intervention\Image\Exceptions\RuntimeException;
+
 interface FrameInterface
 {
     /**
@@ -25,6 +27,7 @@ interface FrameInterface
      * Transform frame into an image
      *
      * @param DriverInterface $driver
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function toImage(DriverInterface $driver): ImageInterface;

--- a/src/Interfaces/ImageInterface.php
+++ b/src/Interfaces/ImageInterface.php
@@ -6,8 +6,6 @@ namespace Intervention\Image\Interfaces;
 
 use Countable;
 use Intervention\Image\Encoders\AutoEncoder;
-use Intervention\Image\Exceptions\DecoderException;
-use Intervention\Image\Exceptions\EncoderException;
 use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Origin;
 use IteratorAggregate;
@@ -46,6 +44,7 @@ interface ImageInterface extends IteratorAggregate, Countable
     /**
      * Return width of current image
      *
+     * @throws RuntimeException
      * @return int
      */
     public function width(): int;
@@ -53,6 +52,7 @@ interface ImageInterface extends IteratorAggregate, Countable
     /**
      * Return height of current image
      *
+     * @throws RuntimeException
      * @return int
      */
     public function height(): int;
@@ -60,6 +60,7 @@ interface ImageInterface extends IteratorAggregate, Countable
     /**
      * Return size of current image
      *
+     * @throws RuntimeException
      * @return SizeInterface
      */
     public function size(): SizeInterface;
@@ -68,7 +69,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Encode image with given encoder
      *
      * @param EncoderInterface $encoder
-     * @throws EncoderException
+     * @throws RuntimeException
      * @return EncodedImageInterface
      */
     public function encode(EncoderInterface $encoder = new AutoEncoder()): EncodedImageInterface;
@@ -96,6 +97,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Analyzer current image with given analyzer
      *
      * @param AnalyzerInterface $analyzer
+     * @throws RuntimeException
      * @return mixed
      */
     public function analyze(AnalyzerInterface $analyzer): mixed;
@@ -164,6 +166,7 @@ interface ImageInterface extends IteratorAggregate, Countable
     /**
      * Return image resolution/density
      *
+     * @throws RuntimeException
      * @return ResolutionInterface
      */
     public function resolution(): ResolutionInterface;
@@ -181,6 +184,7 @@ interface ImageInterface extends IteratorAggregate, Countable
     /**
      * Get the colorspace of the image
      *
+     * @throws RuntimeException
      * @return ColorspaceInterface
      */
     public function colorspace(): ColorspaceInterface;
@@ -200,6 +204,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $x
      * @param int $y
      * @param int $frame_key
+     * @throws RuntimeException
      * @return ColorInterface
      */
     public function pickColor(int $x, int $y, int $frame_key = 0): ColorInterface;
@@ -209,6 +214,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param int $x
      * @param int $y
+     * @throws RuntimeException
      * @return CollectionInterface
      */
     public function pickColors(int $x, int $y): CollectionInterface;
@@ -243,6 +249,7 @@ interface ImageInterface extends IteratorAggregate, Countable
     /**
      * Retrieve ICC color profile of image
      *
+     * @throws RuntimeException
      * @return ProfileInterface
      */
     public function profile(): ProfileInterface;
@@ -665,7 +672,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * will be encoded to the format of the originally read image.
      *
      * @param null|string $type
-     * @throws EncoderException
+     * @throws RuntimeException
      * @return EncodedImageInterface
      */
     public function encodeByMediaType(?string $type = null, ...$options): EncodedImageInterface;
@@ -676,7 +683,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * originally read image.
      *
      * @param null|string $extension
-     * @throws EncoderException
+     * @throws RuntimeException
      * @return EncodedImageInterface
      */
     public function encodeByExtension(?string $extension = null, mixed ...$options): EncodedImageInterface;
@@ -687,7 +694,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * the format of the originally read image.
      *
      * @param null|string $path
-     * @throws EncoderException
+     * @throws RuntimeException
      * @return EncodedImageInterface
      */
     public function encodeByPath(?string $path = null, mixed ...$options): EncodedImageInterface;
@@ -696,7 +703,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Encode image to JPEG format
      *
      * @param mixed $options
-     * @throws EncoderException
+     * @throws RuntimeException
      * @return EncodedImageInterface
      */
 
@@ -706,7 +713,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Encode image to Jpeg2000 format
      *
      * @param mixed $options
-     * @throws EncoderException
+     * @throws RuntimeException
      * @return EncodedImageInterface
      */
     public function toJpeg2000(mixed ...$options): EncodedImageInterface;
@@ -715,7 +722,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Encode image to Webp format
      *
      * @param mixed $options
-     * @throws EncoderException
+     * @throws RuntimeException
      * @return EncodedImageInterface
      */
     public function toWebp(mixed ...$options): EncodedImageInterface;
@@ -724,7 +731,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Encode image to PNG format
      *
      * @param mixed $options
-     * @throws EncoderException
+     * @throws RuntimeException
      * @return EncodedImageInterface
      */
     public function toPng(mixed ...$options): EncodedImageInterface;
@@ -733,7 +740,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Encode image to GIF format
      *
      * @param mixed $options
-     * @throws EncoderException
+     * @throws RuntimeException
      * @return EncodedImageInterface
      */
     public function toGif(mixed ...$options): EncodedImageInterface;
@@ -742,7 +749,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Encode image to Bitmap format
      *
      * @param mixed $options
-     * @throws EncoderException
+     * @throws RuntimeException
      * @return EncodedImageInterface
      */
     public function toBitmap(mixed ...$options): EncodedImageInterface;
@@ -751,7 +758,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Encode image to AVIF format
      *
      * @param mixed $options
-     * @throws EncoderException
+     * @throws RuntimeException
      * @return EncodedImageInterface
      */
     public function toAvif(mixed ...$options): EncodedImageInterface;
@@ -760,7 +767,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Encode image to TIFF format
      *
      * @param mixed $options
-     * @throws EncoderException
+     * @throws RuntimeException
      * @return EncodedImageInterface
      */
     public function toTiff(mixed ...$options): EncodedImageInterface;
@@ -769,7 +776,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Encode image to HEIC format
      *
      * @param mixed $options
-     * @throws EncoderException
+     * @throws RuntimeException
      * @return EncodedImageInterface
      */
     public function toHeic(mixed ...$options): EncodedImageInterface;

--- a/src/Interfaces/ImageInterface.php
+++ b/src/Interfaces/ImageInterface.php
@@ -8,6 +8,7 @@ use Countable;
 use Intervention\Image\Encoders\AutoEncoder;
 use Intervention\Image\Exceptions\DecoderException;
 use Intervention\Image\Exceptions\EncoderException;
+use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Origin;
 use IteratorAggregate;
 
@@ -77,7 +78,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * given, the image will be saved at its original location.
      *
      * @param null|string $path
-     * @throws EncoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function save(?string $path = null, ...$options): self;
@@ -86,7 +87,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Apply given modifier to current image
      *
      * @param ModifierInterface $modifier
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function modify(ModifierInterface $modifier): self;
@@ -115,7 +116,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * and the respective frame position is only determined approximately.
      *
      * @param int|string $position
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function removeAnimation(int|string $position = 0): self;
@@ -125,7 +126,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param int $offset
      * @param null|int $length
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function sliceAnimation(int $offset = 0, ?int $length = null): self;
@@ -172,7 +173,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param float $x
      * @param float $y
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function setResolution(float $x, float $y): self;
@@ -188,7 +189,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Transform image to given colorspace
      *
      * @param string|ColorspaceInterface $colorspace
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function setColorspace(string|ColorspaceInterface $colorspace): self;
@@ -225,7 +226,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * which does not support transparency.
      *
      * @param mixed $color
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function setBlendingColor(mixed $color): self;
@@ -234,7 +235,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Replace transparent areas of the image with given color
      *
      * @param mixed $color
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function blendTransparency(mixed $color = null): self;
@@ -250,7 +251,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Set given icc color profile to image
      *
      * @param ProfileInterface $profile
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function setProfile(ProfileInterface $profile): self;
@@ -258,7 +259,7 @@ interface ImageInterface extends IteratorAggregate, Countable
     /**
      * Remove ICC color profile from the current image
      *
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function removeProfile(): self;
@@ -268,7 +269,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param int $limit
      * @param mixed $background
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function reduceColors(int $limit, mixed $background = 'transparent'): self;
@@ -277,7 +278,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Sharpen the current image with given strength
      *
      * @param int $amount
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function sharpen(int $amount = 10): self;
@@ -285,7 +286,7 @@ interface ImageInterface extends IteratorAggregate, Countable
     /**
      * Turn image into a greyscale version
      *
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function greyscale(): self;
@@ -294,7 +295,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Adjust brightness of the current image
      *
      * @param int $level
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function brightness(int $level): self;
@@ -303,7 +304,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Adjust color contrast of the current image
      *
      * @param int $level
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function contrast(int $level): self;
@@ -312,7 +313,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Apply gamma correction on the current image
      *
      * @param float $gamma
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function gamma(float $gamma): self;
@@ -323,7 +324,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $red
      * @param int $green
      * @param int $blue
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function colorize(int $red = 0, int $green = 0, int $blue = 0): self;
@@ -331,7 +332,7 @@ interface ImageInterface extends IteratorAggregate, Countable
     /**
      * Mirror the current image horizontally
      *
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function flip(): self;
@@ -339,7 +340,7 @@ interface ImageInterface extends IteratorAggregate, Countable
     /**
      * Mirror the current image vertically
      *
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function flop(): self;
@@ -348,7 +349,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Blur current image by given strength
      *
      * @param int $amount
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function blur(int $amount = 5): self;
@@ -356,7 +357,7 @@ interface ImageInterface extends IteratorAggregate, Countable
     /**
      * Invert the colors of the current image
      *
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function invert(): self;
@@ -365,7 +366,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Apply pixelation filter effect on current image
      *
      * @param int $size
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function pixelate(int $size): self;
@@ -375,7 +376,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param float $angle
      * @param string $background
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function rotate(float $angle, mixed $background = 'ffffff'): self;
@@ -387,7 +388,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $x
      * @param int $y
      * @param callable|FontInterface $font
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function text(string $text, int $x, int $y, callable|FontInterface $font): self;
@@ -397,7 +398,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param null|int $width
      * @param null|int $height
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function resize(?int $width = null, ?int $height = null): self;
@@ -407,7 +408,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param null|int $width
      * @param null|int $height
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function resizeDown(?int $width = null, ?int $height = null): self;
@@ -417,7 +418,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param null|int $width
      * @param null|int $height
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function scale(?int $width = null, ?int $height = null): self;
@@ -428,7 +429,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      *
      * @param null|int $width
      * @param null|int $height
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function scaleDown(?int $width = null, ?int $height = null): self;
@@ -441,7 +442,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $width
      * @param int $height
      * @param string $position
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function cover(int $width, int $height, string $position = 'center'): self;
@@ -452,7 +453,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $width
      * @param int $height
      * @param string $position
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function coverDown(int $width, int $height, string $position = 'center'): self;
@@ -467,7 +468,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param null|int $height
      * @param string $position
      * @param mixed $background
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function resizeCanvas(
@@ -486,7 +487,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param null|int $height
      * @param string $position
      * @param mixed $background
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function resizeCanvasRelative(
@@ -509,7 +510,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $height
      * @param string $background
      * @param string $position
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function pad(
@@ -527,7 +528,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $height
      * @param string $background
      * @param string $position
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function contain(
@@ -548,7 +549,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $offset_y
      * @param mixed $background
      * @param string $position
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function crop(
@@ -568,7 +569,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $offset_x
      * @param int $offset_y
      * @param int $opacity
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function place(
@@ -592,7 +593,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param mixed $color
      * @param null|int $x
      * @param null|int $y
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function fill(mixed $color, ?int $x = null, ?int $y = null): self;
@@ -603,7 +604,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $x
      * @param int $y
      * @param mixed $color
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function drawPixel(int $x, int $y, mixed $color): self;
@@ -614,7 +615,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $x
      * @param int $y
      * @param callable $init
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function drawRectangle(int $x, int $y, callable $init): self;
@@ -625,7 +626,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $x
      * @param int $y
      * @param callable $init
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function drawEllipse(int $x, int $y, callable $init): self;
@@ -636,7 +637,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * @param int $x
      * @param int $y
      * @param callable $init
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function drawCircle(int $x, int $y, callable $init): self;
@@ -645,7 +646,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Draw a polygon on the current image
      *
      * @param callable $init
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function drawPolygon(callable $init): self;
@@ -654,7 +655,7 @@ interface ImageInterface extends IteratorAggregate, Countable
      * Draw a line on the current image
      *
      * @param callable $init
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function drawLine(callable $init): self;

--- a/src/Interfaces/InputHandlerInterface.php
+++ b/src/Interfaces/InputHandlerInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Intervention\Image\Interfaces;
 
 use Intervention\Image\Exceptions\DecoderException;
+use Intervention\Image\Exceptions\RuntimeException;
 
 interface InputHandlerInterface
 {
@@ -12,7 +13,7 @@ interface InputHandlerInterface
      * Try to decode the given input with each decoder of the the handler chain
      *
      * @param mixed $input
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface|ColorInterface
      */
     public function handle($input): ImageInterface|ColorInterface;

--- a/src/Interfaces/ModifierInterface.php
+++ b/src/Interfaces/ModifierInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Interfaces;
 
-use Intervention\Image\Exceptions\DecoderException;
+use Intervention\Image\Exceptions\RuntimeException;
 
 interface ModifierInterface
 {
@@ -12,7 +12,7 @@ interface ModifierInterface
      * Apply modifications of the current modifier to the given image
      *
      * @param ImageInterface $image
-     * @throws DecoderException
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function apply(ImageInterface $image): ImageInterface;

--- a/src/Interfaces/SizeInterface.php
+++ b/src/Interfaces/SizeInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Interfaces;
 
+use Intervention\Image\Exceptions\GeometryException;
+
 interface SizeInterface
 {
     /**
@@ -110,33 +112,48 @@ interface SizeInterface
 
     /**
      * @see ImageInterface::resize()
+     *
+     * @throws GeometryException
      */
     public function resize(?int $width = null, ?int $height = null): self;
 
     /**
      * @see ImageInterface::resizeDown()
+     *
+     * @throws GeometryException
      */
     public function resizeDown(?int $width = null, ?int $height = null): self;
 
     /**
      * @see ImageInterface::scale()
+     *
+     * @throws GeometryException
      */
     public function scale(?int $width = null, ?int $height = null): self;
 
     /**
      * @see ImageInterface::scaleDown()
+     *
+     * @throws GeometryException
      */
     public function scaleDown(?int $width = null, ?int $height = null): self;
 
     /**
      * @see ImageInterface::cover()
+     *
+     * @throws GeometryException
      */
     public function cover(int $width, int $height): self;
 
     /**
      * @see ImageInterface::contain()
+     *
+     * @throws GeometryException
      */
     public function contain(int $width, int $height): self;
 
+    /**
+     * @throws GeometryException
+     */
     public function containMax(int $width, int $height): self;
 }

--- a/src/Modifiers/ContainModifier.php
+++ b/src/Modifiers/ContainModifier.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Modifiers;
 
+use Intervention\Image\Exceptions\GeometryException;
+use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Geometry\Rectangle;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SizeInterface;
@@ -18,6 +20,9 @@ class ContainModifier extends SpecializableModifier
     ) {
     }
 
+    /**
+     * @throws RuntimeException
+     */
     public function getCropSize(ImageInterface $image): SizeInterface
     {
         return $image->size()

--- a/src/Modifiers/CoverModifier.php
+++ b/src/Modifiers/CoverModifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Modifiers;
 
+use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Geometry\Rectangle;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SizeInterface;
@@ -17,6 +18,9 @@ class CoverModifier extends SpecializableModifier
     ) {
     }
 
+    /**
+     * @throws RuntimeException
+     */
     public function getCropSize(ImageInterface $image): SizeInterface
     {
         $imagesize = $image->size();
@@ -30,6 +34,9 @@ class CoverModifier extends SpecializableModifier
         return $crop;
     }
 
+    /**
+     * @throws RuntimeException
+     */
     public function getResizeSize(SizeInterface $size): SizeInterface
     {
         return $size->scale($this->width, $this->height);

--- a/src/Modifiers/CropModifier.php
+++ b/src/Modifiers/CropModifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Modifiers;
 
+use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Geometry\Rectangle;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SizeInterface;
@@ -20,6 +21,9 @@ class CropModifier extends SpecializableModifier
     ) {
     }
 
+    /**
+     * @throws RuntimeException
+     */
     public function crop(ImageInterface $image): SizeInterface
     {
         $crop = new Rectangle($this->width, $this->height);

--- a/src/Modifiers/PlaceModifier.php
+++ b/src/Modifiers/PlaceModifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Modifiers;
 
+use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\PointInterface;
 
@@ -18,6 +19,9 @@ class PlaceModifier extends SpecializableModifier
     ) {
     }
 
+    /**
+     * @throws RuntimeException
+     */
     public function getPosition(ImageInterface $image, ImageInterface $watermark): PointInterface
     {
         $image_size = $image->size()->movePivot(

--- a/src/Modifiers/RemoveAnimationModifier.php
+++ b/src/Modifiers/RemoveAnimationModifier.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Intervention\Image\Modifiers;
 
 use Intervention\Image\Exceptions\InputException;
+use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Interfaces\FrameInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 
@@ -15,6 +16,9 @@ class RemoveAnimationModifier extends SpecializableModifier
         //
     }
 
+    /**
+     * @throws RuntimeException
+     */
     public function chosenFrame(ImageInterface $image, int|string $position): FrameInterface
     {
         if (is_int($position)) {

--- a/src/Modifiers/ResizeCanvasModifier.php
+++ b/src/Modifiers/ResizeCanvasModifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Modifiers;
 
+use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Geometry\Rectangle;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SizeInterface;
@@ -18,6 +19,9 @@ class ResizeCanvasModifier extends SpecializableModifier
     ) {
     }
 
+    /**
+     * @throws RuntimeException
+     */
     public function cropSize(ImageInterface $image): SizeInterface
     {
         $width = is_null($this->width) ? $image->width() : $this->width;


### PR DESCRIPTION
Hi @olivervogel, as promise, this is a follow up of https://github.com/Intervention/image/pull/1303.

I just uncommented the exception from phpstan config and followed the errors. It seems that a lot of methods are possibly throwing exception, and the `@throws RuntimeException` spread from method to method.

I stop so far because I'd like to know if you will be interested by such PR. I think it's debatable.
- Unlike Encoder/Decoder exceptions, most of the others exceptions (like colorexception, inputexception, geometryexception, ...) are kinda user-input related exception and shouldn't occurs when the user is using the right parameters. So we might consider they are not meant to be caught and doesn't need to be fully documented.
- On the otherside you might prefer to have all the exception documented without questions.

Your choice.