### PR TITLE
Avoid warning on getimage call

### DIFF
--- a/src/Drivers/Gd/Decoders/AbstractDecoder.php
+++ b/src/Drivers/Gd/Decoders/AbstractDecoder.php
@@ -18,7 +18,7 @@ abstract class AbstractDecoder extends GenericAbstractDecoder
      */
     protected function getMediaTypeByFilePath(string $filepath): string
     {
-        $info = getimagesize($filepath);
+        $info = @getimagesize($filepath);
 
         if (!is_array($info)) {
             throw new DecoderException('Unable to decode input');
@@ -40,7 +40,7 @@ abstract class AbstractDecoder extends GenericAbstractDecoder
      */
     protected function getMediaTypeByBinary(string $data): string
     {
-        $info = getimagesizefromstring($data);
+        $info = @getimagesizefromstring($data);
 
         if (!is_array($info)) {
             throw new DecoderException('Unable to decode input');


### PR DESCRIPTION
Hi @olivervogel 

I'm getting some 
```
Warning: getimagesize(): PNG file corrupted by ASCII conversion
```
from this code.

Since, a `!in_array` check is thrown with an exception. The warning should be muted.