### PR TITLE
Add ability to read Imagick or GDImage directly with ImageManager

### DIFF
--- a/src/Decoders/NativeObjectDecoder.php
+++ b/src/Decoders/NativeObjectDecoder.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intervention\Image\Decoders;
+
+use Intervention\Image\Drivers\SpecializableDecoder;
+
+class NativeObjectDecoder extends SpecializableDecoder
+{
+}

--- a/src/Drivers/Gd/Decoders/BinaryImageDecoder.php
+++ b/src/Drivers/Gd/Decoders/BinaryImageDecoder.php
@@ -12,7 +12,7 @@ use Intervention\Image\Drivers\Gd\Decoders\Traits\CanDecodeGif;
 use Intervention\Image\Exceptions\DecoderException;
 use Intervention\Image\Modifiers\AlignRotationModifier;
 
-class BinaryImageDecoder extends GdImageDecoder implements DecoderInterface
+class BinaryImageDecoder extends NativeObjectDecoder implements DecoderInterface
 {
     use CanDecodeGif;
 

--- a/src/Drivers/Gd/Decoders/FilePathImageDecoder.php
+++ b/src/Drivers/Gd/Decoders/FilePathImageDecoder.php
@@ -11,7 +11,7 @@ use Intervention\Image\Interfaces\DecoderInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Modifiers\AlignRotationModifier;
 
-class FilePathImageDecoder extends GdImageDecoder implements DecoderInterface
+class FilePathImageDecoder extends NativeObjectDecoder implements DecoderInterface
 {
     use CanDecodeGif;
 

--- a/src/Drivers/Gd/Decoders/NativeObjectDecoder.php
+++ b/src/Drivers/Gd/Decoders/NativeObjectDecoder.php
@@ -13,8 +13,13 @@ use Intervention\Image\Image;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\ColorInterface;
 
-class GdImageDecoder extends AbstractDecoder
+class NativeObjectDecoder extends AbstractDecoder
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @see DecoderInterface::decode()
+     */
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!is_object($input)) {

--- a/src/Drivers/Gd/InputHandler.php
+++ b/src/Drivers/Gd/InputHandler.php
@@ -19,11 +19,13 @@ use Intervention\Image\Drivers\Gd\Decoders\FilePathImageDecoder;
 use Intervention\Image\Drivers\Gd\Decoders\BinaryImageDecoder;
 use Intervention\Image\Drivers\Gd\Decoders\DataUriImageDecoder;
 use Intervention\Image\Drivers\Gd\Decoders\Base64ImageDecoder;
+use Intervention\Image\Drivers\Gd\Decoders\NativeObjectDecoder;
 use Intervention\Image\Drivers\Gd\Decoders\SplFileInfoImageDecoder;
 
 class InputHandler extends AbstractInputHandler
 {
     protected array $decoders = [
+        NativeObjectDecoder::class,
         ImageObjectDecoder::class,
         ColorObjectDecoder::class,
         RgbHexColorDecoder::class,

--- a/src/Drivers/Imagick/Decoders/BinaryImageDecoder.php
+++ b/src/Drivers/Imagick/Decoders/BinaryImageDecoder.php
@@ -10,7 +10,7 @@ use Intervention\Image\Exceptions\DecoderException;
 use Intervention\Image\Interfaces\ColorInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 
-class BinaryImageDecoder extends ImagickImageDecoder
+class BinaryImageDecoder extends NativeObjectDecoder
 {
     public function decode(mixed $input): ImageInterface|ColorInterface
     {

--- a/src/Drivers/Imagick/Decoders/FilePathImageDecoder.php
+++ b/src/Drivers/Imagick/Decoders/FilePathImageDecoder.php
@@ -10,7 +10,7 @@ use Intervention\Image\Exceptions\DecoderException;
 use Intervention\Image\Interfaces\ColorInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 
-class FilePathImageDecoder extends ImagickImageDecoder
+class FilePathImageDecoder extends NativeObjectDecoder
 {
     public function decode(mixed $input): ImageInterface|ColorInterface
     {

--- a/src/Drivers/Imagick/Decoders/NativeObjectDecoder.php
+++ b/src/Drivers/Imagick/Decoders/NativeObjectDecoder.php
@@ -14,7 +14,7 @@ use Intervention\Image\Interfaces\ColorInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Modifiers\AlignRotationModifier;
 
-class ImagickImageDecoder extends SpecializableDecoder
+class NativeObjectDecoder extends SpecializableDecoder
 {
     public function decode(mixed $input): ImageInterface|ColorInterface
     {

--- a/src/Drivers/Imagick/InputHandler.php
+++ b/src/Drivers/Imagick/InputHandler.php
@@ -19,11 +19,13 @@ use Intervention\Image\Drivers\Imagick\Decoders\FilePathImageDecoder;
 use Intervention\Image\Drivers\Imagick\Decoders\BinaryImageDecoder;
 use Intervention\Image\Drivers\Imagick\Decoders\DataUriImageDecoder;
 use Intervention\Image\Drivers\Imagick\Decoders\Base64ImageDecoder;
+use Intervention\Image\Drivers\Imagick\Decoders\NativeObjectDecoder;
 use Intervention\Image\Drivers\Imagick\Decoders\SplFileInfoImageDecoder;
 
 class InputHandler extends AbstractInputHandler
 {
     protected array $decoders = [
+        NativeObjectDecoder::class,
         ImageObjectDecoder::class,
         ColorObjectDecoder::class,
         RgbHexColorDecoder::class,

--- a/tests/Unit/Drivers/Gd/InputHandlerTest.php
+++ b/tests/Unit/Drivers/Gd/InputHandlerTest.php
@@ -34,6 +34,13 @@ final class InputHandlerTest extends BaseTestCase
         $this->assertInstanceOf(Image::class, $result);
     }
 
+    public function testHandleGdImage(): void
+    {
+        $handler = new InputHandler();
+        $result = $handler->handle(imagecreatetruecolor(3, 2));
+        $this->assertInstanceOf(Image::class, $result);
+    }
+
     public function testHandleSplFileInfo(): void
     {
         $handler = new InputHandler();

--- a/tests/Unit/Drivers/Imagick/InputHandlerTest.php
+++ b/tests/Unit/Drivers/Imagick/InputHandlerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Tests\Unit\Drivers\Imagick;
 
+use Imagick;
+use ImagickPixel;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Intervention\Image\Colors\Cmyk\Color as CmykColor;
@@ -31,6 +33,15 @@ final class InputHandlerTest extends BaseTestCase
         $handler = new InputHandler();
         $input = file_get_contents($this->getTestResourcePath('animation.gif'));
         $result = $handler->handle($input);
+        $this->assertInstanceOf(Image::class, $result);
+    }
+
+    public function testHandleImagick(): void
+    {
+        $imagick = new Imagick();
+        $imagick->newImage(3, 2, new ImagickPixel('rgba(255, 255, 255, 255)'), 'png');
+        $handler = new InputHandler();
+        $result = $handler->handle($imagick);
         $this->assertInstanceOf(Image::class, $result);
     }
 


### PR DESCRIPTION
```php
use Intervention\Image\ImageManager;
use Intervention\Image\Drivers\Gd\Driver;

// create image manager with desired driver
$manager = new ImageManager(new Driver());

// read GDImage
$image = $manager->read(imagecreatetruecolor(300, 200));
```