### PR TITLE
Bugfix: Filter out parameter that do not match target encoder

### DIFF
--- a/src/Format.php
+++ b/src/Format.php
@@ -89,7 +89,7 @@ enum Format
     }
 
     /**
-     * Create an encoder instance that matches the format
+     * Create an encoder instance with given options that matches the format
      *
      * @param mixed $options
      * @return EncoderInterface

--- a/src/Format.php
+++ b/src/Format.php
@@ -112,9 +112,10 @@ enum Format
         $parameters = [];
         $reflectionClass = new ReflectionClass($classname);
         if ($constructor = $reflectionClass->getConstructor()) {
-            foreach ($constructor->getParameters() as $parameter) {
-                $parameters[] = $parameter->getName();
-            }
+            $parameters = array_map(
+                fn ($parameter) => $parameter->getName(),
+                $constructor->getParameters(),
+            );
         }
 
         // filter only allowed options

--- a/src/Format.php
+++ b/src/Format.php
@@ -96,6 +96,7 @@ enum Format
      */
     public function encoder(mixed ...$options): EncoderInterface
     {
+        // get classname of target encoder from current format
         $classname = match ($this) {
             self::AVIF => AvifEncoder::class,
             self::BMP => BmpEncoder::class,
@@ -118,7 +119,7 @@ enum Format
             );
         }
 
-        // filter out unavailable options for target encoder
+        // filter out unavailable options of target encoder
         $options = array_filter(
             $options,
             fn ($key) => in_array($key, $parameters),

--- a/src/Format.php
+++ b/src/Format.php
@@ -108,7 +108,7 @@ enum Format
             self::WEBP => WebpEncoder::class,
         };
 
-        // get allowed parameters of target encoder
+        // get parameters of target encoder
         $parameters = [];
         $reflectionClass = new ReflectionClass($classname);
         if ($constructor = $reflectionClass->getConstructor()) {
@@ -118,7 +118,7 @@ enum Format
             );
         }
 
-        // filter only allowed options
+        // filter out unavailable options for target encoder
         $options = array_filter(
             $options,
             fn ($key) => in_array($key, $parameters),

--- a/src/Format.php
+++ b/src/Format.php
@@ -119,7 +119,11 @@ enum Format
         }
 
         // filter only allowed options
-        $options = array_filter($options, fn ($key) => in_array($key, $parameters), ARRAY_FILTER_USE_KEY);
+        $options = array_filter(
+            $options,
+            fn ($key) => in_array($key, $parameters),
+            ARRAY_FILTER_USE_KEY,
+        );
 
         return new $classname(...$options);
     }

--- a/src/Format.php
+++ b/src/Format.php
@@ -119,9 +119,7 @@ enum Format
         }
 
         // filter only allowed options
-        $options = array_filter($options, function ($key) use ($parameters) {
-            return in_array($key, $parameters);
-        }, ARRAY_FILTER_USE_KEY);
+        $options = array_filter($options, fn ($key) => in_array($key, $parameters), ARRAY_FILTER_USE_KEY);
 
         return new $classname(...$options);
     }

--- a/tests/Unit/Encoders/MediaTypeEncoderTest.php
+++ b/tests/Unit/Encoders/MediaTypeEncoderTest.php
@@ -42,7 +42,7 @@ final class MediaTypeEncoderTest extends BaseTestCase
 
     #[DataProvider('targetEncoderProvider')]
     public function testEncoderByMediaType(
-        string $mediaType,
+        string|MediaType $mediaType,
         string $targetEncoderClassname,
     ): void {
         $this->assertInstanceOf(
@@ -64,6 +64,16 @@ final class MediaTypeEncoderTest extends BaseTestCase
             ['image/tiff', TiffEncoder::class],
             ['image/jp2', Jpeg2000Encoder::class],
             ['image/heic', HeicEncoder::class],
+            [MediaType::IMAGE_WEBP, WebpEncoder::class],
+            [MediaType::IMAGE_AVIF, AvifEncoder::class],
+            [MediaType::IMAGE_JPEG, JpegEncoder::class],
+            [MediaType::IMAGE_BMP, BmpEncoder::class],
+            [MediaType::IMAGE_GIF, GifEncoder::class],
+            [MediaType::IMAGE_PNG, PngEncoder::class],
+            [MediaType::IMAGE_TIFF, TiffEncoder::class],
+            [MediaType::IMAGE_JP2, Jpeg2000Encoder::class],
+            [MediaType::IMAGE_HEIC, HeicEncoder::class],
+            [MediaType::IMAGE_HEIF, HeicEncoder::class],
         ];
     }
 

--- a/tests/Unit/Encoders/MediaTypeEncoderTest.php
+++ b/tests/Unit/Encoders/MediaTypeEncoderTest.php
@@ -18,13 +18,19 @@ use Intervention\Image\Exceptions\EncoderException;
 use Intervention\Image\Interfaces\EncoderInterface;
 use Intervention\Image\MediaType;
 use Intervention\Image\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class MediaTypeEncoderTest extends BaseTestCase
 {
-    private function testEncoder(string|MediaType $mediaType): EncoderInterface
+    private function testEncoder(string|MediaType $mediaType, array $options = []): EncoderInterface
     {
-        $encoder = new class () extends MediaTypeEncoder
+        $encoder = new class ($mediaType, ...$options) extends MediaTypeEncoder
         {
+            public function __construct($mediaType, ...$options)
+            {
+                parent::__construct($mediaType, ...$options);
+            }
+
             public function test($mediaType)
             {
                 return $this->encoderByMediaType($mediaType);
@@ -34,101 +40,34 @@ final class MediaTypeEncoderTest extends BaseTestCase
         return $encoder->test($mediaType);
     }
 
-    public function testEncoderByFileExtensionString(): void
-    {
+    #[DataProvider('targetEncoderProvider')]
+    public function testEncoderByFileExtensionString(
+        string $mediaType,
+        string $targetEncoderClassname,
+        array $options,
+    ): void {
         $this->assertInstanceOf(
-            WebpEncoder::class,
-            $this->testEncoder('image/webp')
-        );
-
-        $this->assertInstanceOf(
-            AvifEncoder::class,
-            $this->testEncoder('image/avif')
-        );
-
-        $this->assertInstanceOf(
-            JpegEncoder::class,
-            $this->testEncoder('image/jpeg')
-        );
-
-        $this->assertInstanceOf(
-            BmpEncoder::class,
-            $this->testEncoder('image/bmp')
-        );
-
-        $this->assertInstanceOf(
-            GifEncoder::class,
-            $this->testEncoder('image/gif')
-        );
-
-        $this->assertInstanceOf(
-            PngEncoder::class,
-            $this->testEncoder('image/png')
-        );
-
-        $this->assertInstanceOf(
-            TiffEncoder::class,
-            $this->testEncoder('image/tiff')
-        );
-
-        $this->assertInstanceOf(
-            Jpeg2000Encoder::class,
-            $this->testEncoder('image/jp2')
-        );
-
-        $this->assertInstanceOf(
-            HeicEncoder::class,
-            $this->testEncoder('image/heic')
+            $targetEncoderClassname,
+            $this->testEncoder($mediaType, $options)
         );
     }
 
-    public function testEncoderByFileExtensionEnumMember(): void
+    public static function targetEncoderProvider(): array
     {
-        $this->assertInstanceOf(
-            WebpEncoder::class,
-            $this->testEncoder(MediaType::IMAGE_WEBP)
-        );
-
-        $this->assertInstanceOf(
-            AvifEncoder::class,
-            $this->testEncoder(MediaType::IMAGE_AVIF)
-        );
-
-        $this->assertInstanceOf(
-            JpegEncoder::class,
-            $this->testEncoder(MediaType::IMAGE_JPG)
-        );
-
-        $this->assertInstanceOf(
-            BmpEncoder::class,
-            $this->testEncoder(MediaType::IMAGE_BMP)
-        );
-
-        $this->assertInstanceOf(
-            GifEncoder::class,
-            $this->testEncoder(MediaType::IMAGE_GIF)
-        );
-
-        $this->assertInstanceOf(
-            PngEncoder::class,
-            $this->testEncoder(MediaType::IMAGE_PNG)
-        );
-
-        $this->assertInstanceOf(
-            TiffEncoder::class,
-            $this->testEncoder(MediaType::IMAGE_TIFF)
-        );
-
-        $this->assertInstanceOf(
-            Jpeg2000Encoder::class,
-            $this->testEncoder(MediaType::IMAGE_JP2)
-        );
-
-        $this->assertInstanceOf(
-            HeicEncoder::class,
-            $this->testEncoder(MediaType::IMAGE_HEIC)
-        );
+        return [
+            ['image/webp', WebpEncoder::class, []],
+            ['image/avif', AvifEncoder::class, []],
+            ['image/jpeg', JpegEncoder::class, []],
+            ['image/bmp', BmpEncoder::class, []],
+            ['image/gif', GifEncoder::class, []],
+            ['image/png', PngEncoder::class, []],
+            ['image/png', PngEncoder::class, ['quality' => 10]],
+            ['image/tiff', TiffEncoder::class, []],
+            ['image/jp2', Jpeg2000Encoder::class, []],
+            ['image/heic', HeicEncoder::class, []],
+        ];
     }
+
 
     public function testEncoderByFileExtensionUnknown(): void
     {

--- a/tests/Unit/Encoders/MediaTypeEncoderTest.php
+++ b/tests/Unit/Encoders/MediaTypeEncoderTest.php
@@ -44,30 +44,42 @@ final class MediaTypeEncoderTest extends BaseTestCase
     public function testEncoderByFileExtensionString(
         string $mediaType,
         string $targetEncoderClassname,
-        array $options,
     ): void {
         $this->assertInstanceOf(
             $targetEncoderClassname,
-            $this->testEncoder($mediaType, $options)
+            $this->testEncoder($mediaType)
         );
     }
 
     public static function targetEncoderProvider(): array
     {
         return [
-            ['image/webp', WebpEncoder::class, []],
-            ['image/avif', AvifEncoder::class, []],
-            ['image/jpeg', JpegEncoder::class, []],
-            ['image/bmp', BmpEncoder::class, []],
-            ['image/gif', GifEncoder::class, []],
-            ['image/png', PngEncoder::class, []],
-            ['image/png', PngEncoder::class, ['quality' => 10]],
-            ['image/tiff', TiffEncoder::class, []],
-            ['image/jp2', Jpeg2000Encoder::class, []],
-            ['image/heic', HeicEncoder::class, []],
+            ['image/webp', WebpEncoder::class],
+            ['image/avif', AvifEncoder::class],
+            ['image/jpeg', JpegEncoder::class],
+            ['image/bmp', BmpEncoder::class],
+            ['image/gif', GifEncoder::class],
+            ['image/png', PngEncoder::class],
+            ['image/png', PngEncoder::class],
+            ['image/tiff', TiffEncoder::class],
+            ['image/jp2', Jpeg2000Encoder::class],
+            ['image/heic', HeicEncoder::class],
         ];
     }
 
+    public function testArgumentsNotSupportedByTargetEncoder(): void
+    {
+        $encoder = $this->testEncoder(
+            'image/png',
+            [
+                'interlaced' => true, // is not ignored
+                'quality' => 10, // is ignored because png encoder has no quality argument
+            ],
+        );
+
+        $this->assertInstanceOf(PngEncoder::class, $encoder);
+        $this->assertTrue($encoder->interlaced);
+    }
 
     public function testEncoderByFileExtensionUnknown(): void
     {

--- a/tests/Unit/Encoders/MediaTypeEncoderTest.php
+++ b/tests/Unit/Encoders/MediaTypeEncoderTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intervention\Image\Tests\Unit\Encoders;
+
+use Intervention\Image\Encoders\AvifEncoder;
+use Intervention\Image\Encoders\BmpEncoder;
+use Intervention\Image\Encoders\GifEncoder;
+use Intervention\Image\Encoders\HeicEncoder;
+use Intervention\Image\Encoders\Jpeg2000Encoder;
+use Intervention\Image\Encoders\JpegEncoder;
+use Intervention\Image\Encoders\MediaTypeEncoder;
+use Intervention\Image\Encoders\PngEncoder;
+use Intervention\Image\Encoders\TiffEncoder;
+use Intervention\Image\Encoders\WebpEncoder;
+use Intervention\Image\Exceptions\EncoderException;
+use Intervention\Image\Interfaces\EncoderInterface;
+use Intervention\Image\MediaType;
+use Intervention\Image\Tests\BaseTestCase;
+
+final class MediaTypeEncoderTest extends BaseTestCase
+{
+    private function testEncoder(string|MediaType $mediaType): EncoderInterface
+    {
+        $encoder = new class () extends MediaTypeEncoder
+        {
+            public function test($mediaType)
+            {
+                return $this->encoderByMediaType($mediaType);
+            }
+        };
+
+        return $encoder->test($mediaType);
+    }
+
+    public function testEncoderByFileExtensionString(): void
+    {
+        $this->assertInstanceOf(
+            WebpEncoder::class,
+            $this->testEncoder('image/webp')
+        );
+
+        $this->assertInstanceOf(
+            AvifEncoder::class,
+            $this->testEncoder('image/avif')
+        );
+
+        $this->assertInstanceOf(
+            JpegEncoder::class,
+            $this->testEncoder('image/jpeg')
+        );
+
+        $this->assertInstanceOf(
+            BmpEncoder::class,
+            $this->testEncoder('image/bmp')
+        );
+
+        $this->assertInstanceOf(
+            GifEncoder::class,
+            $this->testEncoder('image/gif')
+        );
+
+        $this->assertInstanceOf(
+            PngEncoder::class,
+            $this->testEncoder('image/png')
+        );
+
+        $this->assertInstanceOf(
+            TiffEncoder::class,
+            $this->testEncoder('image/tiff')
+        );
+
+        $this->assertInstanceOf(
+            Jpeg2000Encoder::class,
+            $this->testEncoder('image/jp2')
+        );
+
+        $this->assertInstanceOf(
+            HeicEncoder::class,
+            $this->testEncoder('image/heic')
+        );
+    }
+
+    public function testEncoderByFileExtensionEnumMember(): void
+    {
+        $this->assertInstanceOf(
+            WebpEncoder::class,
+            $this->testEncoder(MediaType::IMAGE_WEBP)
+        );
+
+        $this->assertInstanceOf(
+            AvifEncoder::class,
+            $this->testEncoder(MediaType::IMAGE_AVIF)
+        );
+
+        $this->assertInstanceOf(
+            JpegEncoder::class,
+            $this->testEncoder(MediaType::IMAGE_JPG)
+        );
+
+        $this->assertInstanceOf(
+            BmpEncoder::class,
+            $this->testEncoder(MediaType::IMAGE_BMP)
+        );
+
+        $this->assertInstanceOf(
+            GifEncoder::class,
+            $this->testEncoder(MediaType::IMAGE_GIF)
+        );
+
+        $this->assertInstanceOf(
+            PngEncoder::class,
+            $this->testEncoder(MediaType::IMAGE_PNG)
+        );
+
+        $this->assertInstanceOf(
+            TiffEncoder::class,
+            $this->testEncoder(MediaType::IMAGE_TIFF)
+        );
+
+        $this->assertInstanceOf(
+            Jpeg2000Encoder::class,
+            $this->testEncoder(MediaType::IMAGE_JP2)
+        );
+
+        $this->assertInstanceOf(
+            HeicEncoder::class,
+            $this->testEncoder(MediaType::IMAGE_HEIC)
+        );
+    }
+
+    public function testEncoderByFileExtensionUnknown(): void
+    {
+        $this->expectException(EncoderException::class);
+        $this->testEncoder('test');
+    }
+}

--- a/tests/Unit/Encoders/MediaTypeEncoderTest.php
+++ b/tests/Unit/Encoders/MediaTypeEncoderTest.php
@@ -41,7 +41,7 @@ final class MediaTypeEncoderTest extends BaseTestCase
     }
 
     #[DataProvider('targetEncoderProvider')]
-    public function testEncoderByFileExtensionString(
+    public function testEncoderByMediaType(
         string $mediaType,
         string $targetEncoderClassname,
     ): void {


### PR DESCRIPTION
This deals with the problem that arises when format-unspecific encoders are provided with parameters that are not present in the final target encoder.

For example, the following call can take place with the `quality` argument.

```php
// works if $image was created from jpeg, errors if image source is png for example
$encoded = $image->encode(new AutoEncoder(quality: 5));
```

If the source image and thus the target encoder supports `quality` (e.g. Jpeg), everything works fine. However, if the input format does not contain `quality` in the target encoder (e.g. PNG), an error occurs.

> Unknown named parameter $quality  

The logic has only been adapted since version 3.6, so this does not affect previous versions.

See #1332 