### PR TITLE
Add ImageManager interface

### DIFF
--- a/src/ImageManager.php
+++ b/src/ImageManager.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Intervention\Image;
 
-use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Interfaces\DriverInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Drivers\Gd\Driver as GdDriver;
 use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
 use Intervention\Image\Interfaces\DecoderInterface;
+use Intervention\Image\Interfaces\ImageManagerInterface;
 
-final class ImageManager
+final class ImageManager implements ImageManagerInterface
 {
     protected DriverInterface $driver;
 
@@ -59,13 +59,9 @@ final class ImageManager
     }
 
     /**
-     * Create new image instance with given width & height
+     * {@inheritdoc}
      *
-     * @link https://image.intervention.io/v3/basics/instantiation#creating-new-images
-     * @param int $width
-     * @param int $height
-     * @throws RuntimeException
-     * @return ImageInterface
+     * @see ImageManagerInterface::create()
      */
     public function create(int $width, int $height): ImageInterface
     {
@@ -73,33 +69,9 @@ final class ImageManager
     }
 
     /**
-     * Create new image instance from given input which can be one of the following
+     * {@inheritdoc}
      *
-     * - Path in filesystem
-     * - File Pointer resource
-     * - SplFileInfo object
-     * - Raw binary image data
-     * - Base64 encoded image data
-     * - Data Uri
-     * - Intervention\Image\Image Instance
-     *
-     * To decode the raw input data, you can optionally specify a decoding strategy
-     * with the second parameter. This can be an array of class names or objects
-     * of decoders to be processed in sequence. In this case, the input must be
-     * decodedable with one of the decoders passed. It is also possible to pass
-     * a single object or class name of a decoder.
-     *
-     * All decoders that implement the `DecoderInterface::class` can be passed. Usually
-     * a selection of classes of the namespace `Intervention\Image\Decoders`
-     *
-     * If the second parameter is not set, an attempt to decode the input is made
-     * with all available decoders of the driver.
-     *
-     * @link https://image.intervention.io/v3/basics/instantiation#reading-images
-     * @param mixed $input
-     * @param string|array|DecoderInterface $decoders
-     * @throws RuntimeException
-     * @return ImageInterface
+     * @see ImageManagerInterface::read()
      */
     public function read(mixed $input, string|array|DecoderInterface $decoders = []): ImageInterface
     {
@@ -113,11 +85,9 @@ final class ImageManager
     }
 
     /**
-     * Create new animated image by given callback
+     * {@inheritdoc}
      *
-     * @link https://image.intervention.io/v3/basics/instantiation#creating-animations
-     * @param callable $init
-     * @return ImageInterface
+     * @see ImageManagerInterface::animate()
      */
     public function animate(callable $init): ImageInterface
     {
@@ -125,9 +95,9 @@ final class ImageManager
     }
 
     /**
-     * Return currently used driver
+     * {@inheritdoc}
      *
-     * @return DriverInterface
+     * @see ImageManagerInterface::driver()
      */
     public function driver(): DriverInterface
     {

--- a/src/Interfaces/ImageManagerInterface.php
+++ b/src/Interfaces/ImageManagerInterface.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intervention\Image\Interfaces;
+
+use Intervention\Image\Exceptions\RuntimeException;
+
+interface ImageManagerInterface
+{
+    /**
+     * Create new image instance with given width & height
+     *
+     * @link https://image.intervention.io/v3/basics/instantiation#creating-new-images
+     * @param int $width
+     * @param int $height
+     * @throws RuntimeException
+     * @return ImageInterface
+     */
+    public function create(int $width, int $height): ImageInterface;
+
+    /**
+     * Create new image instance from given input which can be one of the following
+     *
+     * - Path in filesystem
+     * - File Pointer resource
+     * - SplFileInfo object
+     * - Raw binary image data
+     * - Base64 encoded image data
+     * - Data Uri
+     * - Intervention\Image\Image Instance
+     *
+     * To decode the raw input data, you can optionally specify a decoding strategy
+     * with the second parameter. This can be an array of class names or objects
+     * of decoders to be processed in sequence. In this case, the input must be
+     * decodedable with one of the decoders passed. It is also possible to pass
+     * a single object or class name of a decoder.
+     *
+     * All decoders that implement the `DecoderInterface::class` can be passed. Usually
+     * a selection of classes of the namespace `Intervention\Image\Decoders`
+     *
+     * If the second parameter is not set, an attempt to decode the input is made
+     * with all available decoders of the driver.
+     *
+     * @link https://image.intervention.io/v3/basics/instantiation#reading-images
+     * @param mixed $input
+     * @param string|array|DecoderInterface $decoders
+     * @throws RuntimeException
+     * @return ImageInterface
+     */
+    public function read(mixed $input, string|array|DecoderInterface $decoders = []): ImageInterface;
+
+    /**
+     * Create new animated image by given callback
+     *
+     * @link https://image.intervention.io/v3/basics/instantiation#creating-animations
+     * @param callable $init
+     * @return ImageInterface
+     */
+    public function animate(callable $init): ImageInterface;
+
+    /**
+     * Return currently used driver
+     *
+     * @return DriverInterface
+     */
+    public function driver(): DriverInterface;
+}


### PR DESCRIPTION
In v3 the ImageManager class is now final making it impossible to mock out in tests, and while most other classes in this library have corresponding interfaces enabling mocking this class does not.

This PR adds a new ImageManagerInterface interface with the 4 public instance methods from ImageManager. I've based it off how the Image & ImageInterface pair is set up, so the docblock contents for those methods have also been moved to the interface.

Addresses #1324.