### PR TITLE
Silence php warning when throwing decoder exceptions

### DIFF
--- a/src/Drivers/Gd/Decoders/FilePathImageDecoder.php
+++ b/src/Drivers/Gd/Decoders/FilePathImageDecoder.php
@@ -29,10 +29,10 @@ class FilePathImageDecoder extends NativeObjectDecoder implements DecoderInterfa
             // be handled by the standard GD decoder.
             'image/gif' => $this->decodeGif($input),
             default => parent::decode(match ($mediaType) {
-                'image/jpeg', 'image/jpg', 'image/pjpeg' => imagecreatefromjpeg($input),
-                'image/webp', 'image/x-webp' => imagecreatefromwebp($input),
-                'image/png', 'image/x-png' => imagecreatefrompng($input),
-                'image/avif', 'image/x-avif' => imagecreatefromavif($input),
+                'image/jpeg', 'image/jpg', 'image/pjpeg' => @imagecreatefromjpeg($input),
+                'image/webp', 'image/x-webp' => @imagecreatefromwebp($input),
+                'image/png', 'image/x-png' => @imagecreatefrompng($input),
+                'image/avif', 'image/x-avif' => @imagecreatefromavif($input),
                 'image/bmp',
                 'image/ms-bmp',
                 'image/x-bitmap',
@@ -40,7 +40,7 @@ class FilePathImageDecoder extends NativeObjectDecoder implements DecoderInterfa
                 'image/x-ms-bmp',
                 'image/x-win-bitmap',
                 'image/x-windows-bmp',
-                'image/x-xbitmap' => imagecreatefrombmp($input),
+                'image/x-xbitmap' => @imagecreatefrombmp($input),
                 default => throw new DecoderException('Unable to decode input'),
             }),
         };

--- a/src/Interfaces/DriverInterface.php
+++ b/src/Interfaces/DriverInterface.php
@@ -35,6 +35,7 @@ interface DriverInterface
      * Resolve array of classnames or objects into their specialized version for the current driver
      *
      * @param array<string|object> $objects
+     * @throws NotSupportedException
      * @return array<object>
      */
     public function specializeMultiple(array $objects): array;
@@ -53,6 +54,7 @@ interface DriverInterface
      * Create new animated image
      *
      * @param callable $init
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function createAnimation(callable $init): ImageInterface;

--- a/src/Interfaces/ImageManagerInterface.php
+++ b/src/Interfaces/ImageManagerInterface.php
@@ -55,6 +55,7 @@ interface ImageManagerInterface
      *
      * @link https://image.intervention.io/v3/basics/instantiation#creating-animations
      * @param callable $init
+     * @throws RuntimeException
      * @return ImageInterface
      */
     public function animate(callable $init): ImageInterface;


### PR DESCRIPTION
Hi @olivervogel, 

I'm getting multiple warnings:
```
Warning: imagecreatefromjpeg(): gd-jpeg error: cannot allocate gdImage struct
```
or similar message when decoding bad inputs.

Since parent::decode call is already throwing an exception
```
throw new DecoderException('Unable to decode input')
```
there is no need to keep such warning which cannot be easily silenced.