### PR TITLE
Update doctype ImageManagerInterface

### DIFF
--- a/src/Interfaces/ImageManagerInterface.php
+++ b/src/Interfaces/ImageManagerInterface.php
@@ -44,7 +44,7 @@ interface ImageManagerInterface
      *
      * @link https://image.intervention.io/v3/basics/instantiation#reading-images
      * @param mixed $input
-     * @param string|array<DecoderInterface>|DecoderInterface $decoders
+     * @param string|array<string|DecoderInterface>|DecoderInterface $decoders
      * @throws RuntimeException
      * @return ImageInterface
      */


### PR DESCRIPTION
The [example](https://image.intervention.io/v3/basics/instantiation#examples) uses an array of strings.
It seems to be fine either way when you look at it.

https://github.com/Intervention/image/blob/267d588eb100d5cf36c91fffa3642087aa4c1028/src/Drivers/AbstractDriver.php#L69-L79