### PR TITLE
Avoid unnecessary exif_read_data calls

### DIFF
--- a/src/Drivers/Gd/Decoders/BinaryImageDecoder.php
+++ b/src/Drivers/Gd/Decoders/BinaryImageDecoder.php
@@ -9,6 +9,7 @@ use Intervention\Image\Interfaces\ColorInterface;
 use Intervention\Image\Interfaces\DecoderInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Exceptions\DecoderException;
+use Intervention\Image\Format;
 use Intervention\Image\Modifiers\AlignRotationModifier;
 
 class BinaryImageDecoder extends NativeObjectDecoder implements DecoderInterface
@@ -48,16 +49,16 @@ class BinaryImageDecoder extends NativeObjectDecoder implements DecoderInterface
         // create image instance
         $image = parent::decode($gd);
 
-        // extract & set exif data
-        $image->setExif($this->extractExifData($input));
+        // get media type
+        $mediaType = $this->getMediaTypeByBinary($input);
 
-        try {
-            // set mediaType on origin
-            $image->origin()->setMediaType(
-                $this->getMediaTypeByBinary($input)
-            );
-        } catch (DecoderException) {
+        // extract & set exif data for appropriate formats
+        if (in_array($mediaType->format(), [Format::JPEG, Format::TIFF])) {
+            $image->setExif($this->extractExifData($input));
         }
+
+        // set mediaType on origin
+        $image->origin()->setMediaType($mediaType);
 
         // adjust image orientation
         if ($this->driver()->config()->autoOrientation) {

--- a/src/Drivers/Gd/Decoders/FilePathImageDecoder.php
+++ b/src/Drivers/Gd/Decoders/FilePathImageDecoder.php
@@ -40,8 +40,10 @@ class FilePathImageDecoder extends NativeObjectDecoder implements DecoderInterfa
         $image->origin()->setFilePath($input);
         $image->origin()->setMediaType($mediaType);
 
-        // extract exif
-        $image->setExif($this->extractExifData($input));
+        // extract exif for the appropriate formats
+        if ($mediaType->format() === Format::JPEG) {
+            $image->setExif($this->extractExifData($input));
+        }
 
         // adjust image orientation
         if ($this->driver()->config()->autoOrientation) {

--- a/src/Drivers/Imagick/Decoders/BinaryImageDecoder.php
+++ b/src/Drivers/Imagick/Decoders/BinaryImageDecoder.php
@@ -7,8 +7,10 @@ namespace Intervention\Image\Drivers\Imagick\Decoders;
 use Imagick;
 use ImagickException;
 use Intervention\Image\Exceptions\DecoderException;
+use Intervention\Image\Format;
 use Intervention\Image\Interfaces\ColorInterface;
 use Intervention\Image\Interfaces\ImageInterface;
+use Intervention\Image\MediaType;
 
 class BinaryImageDecoder extends NativeObjectDecoder
 {
@@ -28,8 +30,13 @@ class BinaryImageDecoder extends NativeObjectDecoder
         // decode image
         $image = parent::decode($imagick);
 
-        // extract exif data
-        $image->setExif($this->extractExifData($input));
+        // get media type enum from string media type
+        $mediaType = MediaType::from($image->origin()->mediaType());
+
+        // extract exif data for appropriate formats
+        if (in_array($mediaType->format(), [Format::JPEG, Format::TIFF])) {
+            $image->setExif($this->extractExifData($input));
+        }
 
         return $image;
     }

--- a/src/Drivers/Imagick/Decoders/FilePathImageDecoder.php
+++ b/src/Drivers/Imagick/Decoders/FilePathImageDecoder.php
@@ -31,8 +31,10 @@ class FilePathImageDecoder extends NativeObjectDecoder
         // set file path on origin
         $image->origin()->setFilePath($input);
 
-        // extract exif data
-        $image->setExif($this->extractExifData($input));
+        // extract exif data for the appropriate formats
+        if (in_array($imagick->getImageFormat(), ['JPEG', 'TIFF', 'TIF'])) {
+            $image->setExif($this->extractExifData($input));
+        }
 
         return $image;
     }


### PR DESCRIPTION
EXIF data extraction makes only sense for JPEG and TIFF format. This patch checks the format and calls exif_read_data only for appropriate formats.

Previously, the function was also called with formats that can not contain EXIF data. This resulted in warnings.

See #1370 