### PR TITLE
Handle non-standard but still in use image/x-jpeg mimetype as JPEG

### DIFF
--- a/src/MediaType.php
+++ b/src/MediaType.php
@@ -9,6 +9,7 @@ enum MediaType: string
     case IMAGE_JPEG = 'image/jpeg';
     case IMAGE_JPG = 'image/jpg';
     case IMAGE_PJPEG = 'image/pjpeg';
+    case IMAGE_X_JPEG = 'image/x-jpeg';
     case IMAGE_WEBP = 'image/webp';
     case IMAGE_X_WEBP = 'image/x-webp';
     case IMAGE_GIF = 'image/gif';
@@ -41,7 +42,8 @@ enum MediaType: string
         return match ($this) {
             self::IMAGE_JPEG,
             self::IMAGE_JPG,
-            self::IMAGE_PJPEG => Format::JPEG,
+            self::IMAGE_PJPEG,
+            self::IMAGE_X_JPEG => Format::JPEG,
             self::IMAGE_WEBP,
             self::IMAGE_X_WEBP => Format::WEBP,
             self::IMAGE_GIF => Format::GIF,

--- a/tests/Unit/FormatTest.php
+++ b/tests/Unit/FormatTest.php
@@ -43,7 +43,7 @@ final class FormatTest extends BaseTestCase
         $format = Format::JPEG;
         $mediaTypes = $format->mediaTypes();
         $this->assertIsArray($mediaTypes);
-        $this->assertCount(3, $mediaTypes);
+        $this->assertCount(4, $mediaTypes);
     }
 
     public function testMediaTypesWebp(): void

--- a/tests/Unit/MediaTypeTest.php
+++ b/tests/Unit/MediaTypeTest.php
@@ -20,6 +20,9 @@ final class MediaTypeTest extends BaseTestCase
 
         $mime = MediaType::IMAGE_JPG;
         $this->assertEquals(Format::JPEG, $mime->format());
+
+        $mime = MediaType::IMAGE_X_JPEG;
+        $this->assertEquals(Format::JPEG, $mime->format());
     }
 
     public function testFormatWebp(): void


### PR DESCRIPTION
I stumbled upon this issue for the second time recently, so I decided to try to submit a PR: I sometimes have to deal with image/x-jpeg files (seems that it's a non-standard mime type, but some use it...).

Without this PR, the code breaks with
`"image/x-jpeg" is not a valid backing value for enum Intervention\Image\MediaType`
