### PR TITLE
Allow animated WEBP's

### DIFF
--- a/src/Drivers/Imagick/Encoders/WebpEncoder.php
+++ b/src/Drivers/Imagick/Encoders/WebpEncoder.php
@@ -21,7 +21,10 @@ class WebpEncoder extends GenericWebpEncoder implements SpecializedInterface
         $imagick = $image->core()->native();
         $imagick->setImageBackgroundColor(new ImagickPixel('transparent'));
 
-        $imagick = $imagick->mergeImageLayers(Imagick::LAYERMETHOD_MERGE);
+        if(! $image->isAnimated()) {
+            $imagick = $imagick->mergeImageLayers(Imagick::LAYERMETHOD_MERGE);
+        }
+
         $imagick->setFormat($format);
         $imagick->setImageFormat($format);
         $imagick->setCompression($compression);

--- a/src/Drivers/Imagick/Encoders/WebpEncoder.php
+++ b/src/Drivers/Imagick/Encoders/WebpEncoder.php
@@ -21,7 +21,7 @@ class WebpEncoder extends GenericWebpEncoder implements SpecializedInterface
         $imagick = $image->core()->native();
         $imagick->setImageBackgroundColor(new ImagickPixel('transparent'));
 
-        if(! $image->isAnimated()) {
+        if (!$image->isAnimated()) {
             $imagick = $imagick->mergeImageLayers(Imagick::LAYERMETHOD_MERGE);
         }
 


### PR DESCRIPTION
The current logic merges all the layers when using WEBP and Imagick. In an animated image, these layers are the separate frames. Not merging the layers when we're dealing with an animation allows for the creation of animated webp files.

Note: this still does only work with Imagick, GD has no animated webp support yet.