### PR TITLE
Implement __debugInfo()

### DIFF
--- a/src/Colors/AbstractColor.php
+++ b/src/Colors/AbstractColor.php
@@ -8,6 +8,7 @@ use Intervention\Image\Exceptions\ColorException;
 use Intervention\Image\Interfaces\ColorChannelInterface;
 use Intervention\Image\Interfaces\ColorInterface;
 use Intervention\Image\Interfaces\ColorspaceInterface;
+use ReflectionClass;
 
 abstract class AbstractColor implements ColorInterface
 {
@@ -83,6 +84,20 @@ abstract class AbstractColor implements ColorInterface
         };
 
         return $colorspace->importColor($this);
+    }
+
+    /**
+     * Show debug info for the current color
+     *
+     * @return array<string, int>
+     */
+    public function __debugInfo(): array
+    {
+        return array_reduce($this->channels(), function (array $result, ColorChannelInterface $item) {
+            $key = strtolower((new ReflectionClass($item))->getShortName());
+            $result[$key] = $item->value();
+            return $result;
+        }, []);
     }
 
     /**

--- a/src/Drivers/AbstractFrame.php
+++ b/src/Drivers/AbstractFrame.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intervention\Image\Drivers;
+
+use Intervention\Image\Interfaces\FrameInterface;
+
+abstract class AbstractFrame implements FrameInterface
+{
+    /**
+     * Show debug info for the current image
+     *
+     * @return array<string, mixed>
+     */
+    public function __debugInfo(): array
+    {
+        return [
+            'delay' => $this->delay(),
+            'left' => $this->offsetLeft(),
+            'top' => $this->offsetTop(),
+            'dispose' => $this->dispose(),
+        ];
+    }
+}

--- a/src/Drivers/Gd/Frame.php
+++ b/src/Drivers/Gd/Frame.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Intervention\Image\Drivers\Gd;
 
 use GdImage;
+use Intervention\Image\Drivers\AbstractFrame;
 use Intervention\Image\Exceptions\ColorException;
 use Intervention\Image\Exceptions\InputException;
 use Intervention\Image\Geometry\Rectangle;
@@ -14,7 +15,7 @@ use Intervention\Image\Interfaces\FrameInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SizeInterface;
 
-class Frame implements FrameInterface
+class Frame extends AbstractFrame implements FrameInterface
 {
     /**
      * Create new frame instance

--- a/src/Drivers/Imagick/Frame.php
+++ b/src/Drivers/Imagick/Frame.php
@@ -7,6 +7,7 @@ namespace Intervention\Image\Drivers\Imagick;
 use Imagick;
 use ImagickException;
 use ImagickPixel;
+use Intervention\Image\Drivers\AbstractFrame;
 use Intervention\Image\Exceptions\InputException;
 use Intervention\Image\Geometry\Rectangle;
 use Intervention\Image\Image;
@@ -15,7 +16,7 @@ use Intervention\Image\Interfaces\FrameInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SizeInterface;
 
-class Frame implements FrameInterface
+class Frame extends AbstractFrame implements FrameInterface
 {
     /**
      * Create new frame object

--- a/src/EncodedImage.php
+++ b/src/EncodedImage.php
@@ -50,4 +50,17 @@ class EncodedImage extends File implements EncodedImageInterface
     {
         return sprintf('data:%s;base64,%s', $this->mediaType(), base64_encode((string) $this));
     }
+
+    /**
+     * Show debug info for the current image
+     *
+     * @return array<string, mixed>
+     */
+    public function __debugInfo(): array
+    {
+        return [
+            'mimetype' => $this->mimetype(),
+            'size' => $this->size(),
+        ];
+    }
 }

--- a/src/Geometry/Rectangle.php
+++ b/src/Geometry/Rectangle.php
@@ -364,4 +364,17 @@ class Rectangle extends Polygon implements SizeInterface
     {
         return new RectangleResizer($width, $height);
     }
+
+    /**
+     * Show debug info for the current rectangle
+     *
+     * @return array<string, int>
+     */
+    public function __debugInfo(): array
+    {
+        return [
+            'width' => $this->width(),
+            'height' => $this->height(),
+        ];
+    }
 }

--- a/src/Image.php
+++ b/src/Image.php
@@ -882,7 +882,7 @@ final class Image implements ImageInterface
         );
     }
 
-     /**
+    /**
      * {@inheritdoc}
      *
      * @see ImageInterface::drawBezier()
@@ -1063,6 +1063,23 @@ final class Image implements ImageInterface
     public function toHeic(mixed ...$options): EncodedImageInterface
     {
         return $this->encode(new HeicEncoder(...$options));
+    }
+
+    /**
+     * Show debug info for the current image
+     *
+     * @return array<string, int>
+     */
+    public function __debugInfo(): array
+    {
+        try {
+            return [
+                'width' => $this->width(),
+                'height' => $this->height(),
+            ];
+        } catch (RuntimeException) {
+            return [];
+        }
     }
 
     /**

--- a/tests/Unit/Colors/Cmyk/ColorTest.php
+++ b/tests/Unit/Colors/Cmyk/ColorTest.php
@@ -115,4 +115,13 @@ final class ColorTest extends BaseTestCase
         $color = new Color(0, 0, 0, 0);
         $this->assertFalse($color->isClear());
     }
+
+    public function testDebugInfo(): void
+    {
+        $info = (new Color(10, 20, 30, 40))->__debugInfo();
+        $this->assertEquals(10, $info['cyan']);
+        $this->assertEquals(20, $info['magenta']);
+        $this->assertEquals(30, $info['yellow']);
+        $this->assertEquals(40, $info['key']);
+    }
 }

--- a/tests/Unit/Colors/Hsl/ColorTest.php
+++ b/tests/Unit/Colors/Hsl/ColorTest.php
@@ -114,4 +114,12 @@ final class ColorTest extends BaseTestCase
         $color = new Color(0, 1, 0);
         $this->assertFalse($color->isClear());
     }
+
+    public function testDebugInfo(): void
+    {
+        $info = (new Color(10, 20, 30))->__debugInfo();
+        $this->assertEquals(10, $info['hue']);
+        $this->assertEquals(20, $info['saturation']);
+        $this->assertEquals(30, $info['luminance']);
+    }
 }

--- a/tests/Unit/Colors/Hsv/ColorTest.php
+++ b/tests/Unit/Colors/Hsv/ColorTest.php
@@ -114,4 +114,12 @@ final class ColorTest extends BaseTestCase
         $color = new Color(0, 1, 0);
         $this->assertFalse($color->isClear());
     }
+
+    public function testDebugInfo(): void
+    {
+        $info = (new Color(10, 20, 30))->__debugInfo();
+        $this->assertEquals(10, $info['hue']);
+        $this->assertEquals(20, $info['saturation']);
+        $this->assertEquals(30, $info['value']);
+    }
 }

--- a/tests/Unit/Colors/Rgb/ColorTest.php
+++ b/tests/Unit/Colors/Rgb/ColorTest.php
@@ -176,4 +176,13 @@ final class ColorTest extends BaseTestCase
         $color = new Color(255, 255, 255, 0);
         $this->assertTrue($color->isClear());
     }
+
+    public function testDebugInfo(): void
+    {
+        $info = (new Color(10, 20, 30, 40))->__debugInfo();
+        $this->assertEquals(10, $info['red']);
+        $this->assertEquals(20, $info['green']);
+        $this->assertEquals(30, $info['blue']);
+        $this->assertEquals(40, $info['alpha']);
+    }
 }

--- a/tests/Unit/Drivers/Gd/FrameTest.php
+++ b/tests/Unit/Drivers/Gd/FrameTest.php
@@ -108,4 +108,13 @@ final class FrameTest extends BaseTestCase
         $frame = $this->getTestFrame();
         $this->assertInstanceOf(Image::class, $frame->toImage(new Driver()));
     }
+
+    public function testDebugInfo(): void
+    {
+        $info = $this->getTestFrame()->__debugInfo();
+        $this->assertEquals(0, $info['delay']);
+        $this->assertEquals(0, $info['left']);
+        $this->assertEquals(0, $info['top']);
+        $this->assertEquals(1, $info['dispose']);
+    }
 }

--- a/tests/Unit/Drivers/Gd/ImageTest.php
+++ b/tests/Unit/Drivers/Gd/ImageTest.php
@@ -390,4 +390,11 @@ final class ImageTest extends GdTestCase
         $this->assertInstanceOf(ImageInterface::class, $result);
         $this->assertEquals('4cfaff', $image->pickColor(14, 14)->toHex());
     }
+
+    public function testDebugInfo(): void
+    {
+        $info = $this->readTestImage('trim.png')->__debugInfo();
+        $this->assertArrayHasKey('width', $info);
+        $this->assertArrayHasKey('height', $info);
+    }
 }

--- a/tests/Unit/Drivers/Imagick/ImageTest.php
+++ b/tests/Unit/Drivers/Imagick/ImageTest.php
@@ -392,4 +392,11 @@ final class ImageTest extends ImagickTestCase
         $this->assertInstanceOf(ImageInterface::class, $result);
         $this->assertEquals('39c9ff', $image->pickColor(14, 14)->toHex());
     }
+
+    public function testDebugInfo(): void
+    {
+        $info = $this->readTestImage('trim.png')->__debugInfo();
+        $this->assertArrayHasKey('width', $info);
+        $this->assertArrayHasKey('height', $info);
+    }
 }

--- a/tests/Unit/EncodedImageTest.php
+++ b/tests/Unit/EncodedImageTest.php
@@ -57,4 +57,11 @@ final class EncodedImageTest extends BaseTestCase
         $image = new EncodedImage($this->getTestResourceData(), 'image/jpeg');
         $this->assertEquals('image/jpeg', $image->mimetype());
     }
+
+    public function testDebugInfo(): void
+    {
+        $info = (new EncodedImage('foo', 'image/png'))->__debugInfo();
+        $this->assertEquals('image/png', $info['mimetype']);
+        $this->assertEquals(3, $info['size']);
+    }
 }

--- a/tests/Unit/Geometry/RectangleTest.php
+++ b/tests/Unit/Geometry/RectangleTest.php
@@ -325,4 +325,11 @@ final class RectangleTest extends BaseTestCase
         $this->assertEquals(800, $result->width());
         $this->assertEquals(600, $result->height());
     }
+
+    public function testDebugInfo(): void
+    {
+        $info = (new Rectangle(800, 600))->__debugInfo();
+        $this->assertEquals(800, $info['width']);
+        $this->assertEquals(600, $info['height']);
+    }
 }


### PR DESCRIPTION
Implement __debugInfo() on the following classes:

- `Intervention\Image\Image`
- `Intervention\Image\EncodedImage`
- `Intervention\Image\Drivers\Gd\Frame`
- `Intervention\Image\Drivers\Imagick\Frame`
- `Intervention\Image\Geometry\Rectangle`
- `Intervention\Image\Colors\Rgb\Color`
- `Intervention\Image\Colors\Cmyk\Color`
- `Intervention\Image\Colors\Hsl\Color`
- `Intervention\Image\Colors\Hsv\Color`

The result is more informative debug information when objects of the classes are output via `var_dump()`.

For example the following code:

```php
$color = ImageManager::gd()
    ->read($path)
    ->pickColor(0, 0);

var_dump($color);
```

results in:

```
object(Intervention\Image\Colors\Rgb\Color)#9 (4) {
  ["red"]=>
  int(104)
  ["green"]=>
  int(128)
  ["blue"]=>
  int(132)
  ["alpha"]=>
  int(255)
}
```