### PR TITLE
Fix GD driver resolution in ImageManager - Class "gd" not found

### DIFF
--- a/src/ImageManager.php
+++ b/src/ImageManager.php
@@ -120,7 +120,11 @@ final class ImageManager implements ImageManagerInterface
      */
     private static function resolveDriver(string|DriverInterface $driver, mixed ...$options): DriverInterface
     {
-        $driver = is_string($driver) ? new $driver() : $driver;
+        if ($driver === 'gd') {
+            $driver = new \Intervention\Image\Drivers\Gd\Driver();
+        } else {
+            $driver = is_string($driver) ? new $driver() : $driver;
+        }
         $driver->config()->setOptions(...$options);
 
         return $driver;


### PR DESCRIPTION
**Problem**
When using Intervention Image 3.x with the GD driver, the following error occurs:
`Class "gd" not found on line vendor/intervention/image/src/ImageManager.php (line 123)`

This issue arises because the library attempts to resolve the gd driver by treating it as a class string. However, gd does not directly map to a valid class, causing the application to throw an error.

> Error Message: 
> Class "gd" not found

**Solution**
This patch explicitly checks if the $driver is set to gd and directly instantiates the \Intervention\Image\Drivers\Gd\Driver class. The updated code in ImageManager.php looks like this:
```
if ($driver === 'gd') {
    $driver = new \Intervention\Image\Drivers\Gd\Driver();
} else {
    $driver = is_string($driver) ? new $driver() : $driver;
}
```
This ensures the GD driver is correctly initialized without relying on implicit class resolution, which can fail in some environments.