### PR TITLE
GIF detection: Only check the first 6 bytes of the input

### DIFF
--- a/src/Drivers/AbstractDecoder.php
+++ b/src/Drivers/AbstractDecoder.php
@@ -22,9 +22,11 @@ abstract class AbstractDecoder implements DecoderInterface
      */
     protected function isGifFormat(string $input): bool
     {
+        $head = substr($input, 0, 6);
+
         return 1 === preg_match(
             "/^47494638(37|39)61/",
-            strtoupper(substr(bin2hex($input), 0, 32))
+            strtoupper(substr(bin2hex($head), 0, 32))
         );
     }
 

--- a/src/Drivers/AbstractDecoder.php
+++ b/src/Drivers/AbstractDecoder.php
@@ -26,7 +26,7 @@ abstract class AbstractDecoder implements DecoderInterface
 
         return 1 === preg_match(
             "/^47494638(37|39)61/",
-            strtoupper(substr(bin2hex($head), 0, 32))
+            strtoupper(bin2hex($head))
         );
     }
 


### PR DESCRIPTION
 This reduces memory usage and speeds up the detection.