### PR TITLE
Simplify GIF magic number detection

### DIFF
--- a/src/Drivers/AbstractDecoder.php
+++ b/src/Drivers/AbstractDecoder.php
@@ -24,10 +24,7 @@ abstract class AbstractDecoder implements DecoderInterface
     {
         $head = substr($input, 0, 6);
 
-        return 1 === preg_match(
-            "/^47494638(37|39)61/",
-            strtoupper(bin2hex($head))
-        );
+        return $head === 'GIF87a' || $head === 'GIF89a';
     }
 
     /**


### PR DESCRIPTION
Removed unnecessary `bin2hex()` conversion.

Follow-up to ac9734129478be387c1914f1c2856d623341128c and #1441.