### PR TITLE
Improve decoder exception messages with specific error descriptions

### DIFF
--- a/src/Colors/Cmyk/Decoders/StringColorDecoder.php
+++ b/src/Colors/Cmyk/Decoders/StringColorDecoder.php
@@ -19,12 +19,12 @@ class StringColorDecoder extends AbstractDecoder implements DecoderInterface
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!is_string($input)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected a string.');
         }
 
         $pattern = '/^cmyk\((?P<c>[0-9\.]+%?), ?(?P<m>[0-9\.]+%?), ?(?P<y>[0-9\.]+%?), ?(?P<k>[0-9\.]+%?)\)$/i';
         if (preg_match($pattern, $input, $matches) != 1) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. The given string is not a valid CMYK color string.');
         }
 
         $values = array_map(function (string $value): int {

--- a/src/Colors/Hsl/Decoders/StringColorDecoder.php
+++ b/src/Colors/Hsl/Decoders/StringColorDecoder.php
@@ -19,12 +19,12 @@ class StringColorDecoder extends AbstractDecoder implements DecoderInterface
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!is_string($input)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected a string.');
         }
 
         $pattern = '/^hsl\((?P<h>[0-9\.]+), ?(?P<s>[0-9\.]+%?), ?(?P<l>[0-9\.]+%?)\)$/i';
         if (preg_match($pattern, $input, $matches) != 1) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. The given string is not a valid HSL color string.');
         }
 
         $values = array_map(function (string $value): int {

--- a/src/Colors/Hsv/Decoders/StringColorDecoder.php
+++ b/src/Colors/Hsv/Decoders/StringColorDecoder.php
@@ -19,12 +19,12 @@ class StringColorDecoder extends AbstractDecoder implements DecoderInterface
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!is_string($input)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected a string.');
         }
 
         $pattern = '/^hs(v|b)\((?P<h>[0-9\.]+), ?(?P<s>[0-9\.]+%?), ?(?P<v>[0-9\.]+%?)\)$/i';
         if (preg_match($pattern, $input, $matches) != 1) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. The given string is not a valid HSV/HSB color string.');
         }
 
         $values = array_map(function (string $value): int {

--- a/src/Colors/Rgb/Decoders/HexColorDecoder.php
+++ b/src/Colors/Rgb/Decoders/HexColorDecoder.php
@@ -19,25 +19,25 @@ class HexColorDecoder extends AbstractDecoder implements DecoderInterface
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!is_string($input)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected a string.');
         }
 
         $pattern = '/^#?(?P<hex>[a-f\d]{3}(?:[a-f\d]?|(?:[a-f\d]{3}(?:[a-f\d]{2})?)?)\b)$/i';
         if (preg_match($pattern, $input, $matches) != 1) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. The given string is not a valid hex color code.');
         }
 
         $values = match (strlen($matches['hex'])) {
             3, 4 => str_split($matches['hex']),
             6, 8 => str_split($matches['hex'], 2),
-            default => throw new DecoderException('Unable to decode input'),
+            default => throw new DecoderException('Unable to decode input. Unexpected hex color code length.'),
         };
 
         $values = array_map(function (string $value): float|int {
             return match (strlen($value)) {
                 1 => hexdec($value . $value),
                 2 => hexdec($value),
-                default => throw new DecoderException('Unable to decode input'),
+                default => throw new DecoderException('Unable to decode input. Invalid hex color segment length.'),
             };
         }, $values);
 

--- a/src/Colors/Rgb/Decoders/HtmlColornameDecoder.php
+++ b/src/Colors/Rgb/Decoders/HtmlColornameDecoder.php
@@ -164,11 +164,11 @@ class HtmlColornameDecoder extends HexColorDecoder implements DecoderInterface
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!is_string($input)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected a string.');
         }
 
         if (!array_key_exists(strtolower($input), static::$names)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. The given string is not a recognized HTML color name.');
         }
 
         return parent::decode(static::$names[strtolower($input)]);

--- a/src/Colors/Rgb/Decoders/StringColorDecoder.php
+++ b/src/Colors/Rgb/Decoders/StringColorDecoder.php
@@ -19,13 +19,13 @@ class StringColorDecoder extends AbstractDecoder implements DecoderInterface
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!is_string($input)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected a string.');
         }
 
         $pattern = '/^s?rgba?\((?P<r>[0-9\.]+%?), ?(?P<g>[0-9\.]+%?), ?(?P<b>[0-9\.]+%?)' .
             '(?:, ?(?P<a>(?:1)|(?:1\.0*)|(?:0)|(?:0?\.\d+%?)|(?:\d{1,3}%)))?\)$/i';
         if (preg_match($pattern, $input, $matches) != 1) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. The given string is not a valid RGB color string.');
         }
 
         // rgb values

--- a/src/Colors/Rgb/Decoders/TransparentColorDecoder.php
+++ b/src/Colors/Rgb/Decoders/TransparentColorDecoder.php
@@ -18,11 +18,11 @@ class TransparentColorDecoder extends HexColorDecoder
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!is_string($input)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected a string.');
         }
 
         if (strtolower($input) !== 'transparent') {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected the string "transparent".');
         }
 
         return parent::decode('#ffffff00');

--- a/src/Decoders/ColorObjectDecoder.php
+++ b/src/Decoders/ColorObjectDecoder.php
@@ -19,7 +19,7 @@ class ColorObjectDecoder extends AbstractDecoder
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!is_a($input, ColorInterface::class)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected a ColorInterface instance.');
         }
 
         return $input;

--- a/src/Decoders/ImageObjectDecoder.php
+++ b/src/Decoders/ImageObjectDecoder.php
@@ -19,7 +19,7 @@ class ImageObjectDecoder extends AbstractDecoder
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!is_a($input, ImageInterface::class)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected an ImageInterface instance.');
         }
 
         return $input;

--- a/src/Drivers/Gd/Decoders/Base64ImageDecoder.php
+++ b/src/Drivers/Gd/Decoders/Base64ImageDecoder.php
@@ -19,7 +19,7 @@ class Base64ImageDecoder extends BinaryImageDecoder implements DecoderInterface
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!$this->isValidBase64($input)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected a valid base64 encoded string.');
         }
 
         return parent::decode(base64_decode((string) $input));

--- a/src/Drivers/Gd/Decoders/BinaryImageDecoder.php
+++ b/src/Drivers/Gd/Decoders/BinaryImageDecoder.php
@@ -22,7 +22,7 @@ class BinaryImageDecoder extends NativeObjectDecoder implements DecoderInterface
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!is_string($input)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected a binary string.');
         }
 
         return match ($this->isGifFormat($input)) {
@@ -41,7 +41,7 @@ class BinaryImageDecoder extends NativeObjectDecoder implements DecoderInterface
         $gd = @imagecreatefromstring($input);
 
         if ($gd === false) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. The binary data could not be read as an image.');
         }
 
         // create image instance

--- a/src/Drivers/Gd/Decoders/DataUriImageDecoder.php
+++ b/src/Drivers/Gd/Decoders/DataUriImageDecoder.php
@@ -19,13 +19,13 @@ class DataUriImageDecoder extends BinaryImageDecoder implements DecoderInterface
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!is_string($input)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected a string.');
         }
 
         $uri = $this->parseDataUri($input);
 
         if (!$uri->isValid()) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. The given string is not a valid data URI.');
         }
 
         if ($uri->isBase64Encoded()) {

--- a/src/Drivers/Gd/Decoders/EncodedImageObjectDecoder.php
+++ b/src/Drivers/Gd/Decoders/EncodedImageObjectDecoder.php
@@ -19,7 +19,7 @@ class EncodedImageObjectDecoder extends BinaryImageDecoder
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!is_a($input, EncodedImage::class)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected an EncodedImage object.');
         }
 
         return parent::decode($input->toString());

--- a/src/Drivers/Gd/Decoders/FilePathImageDecoder.php
+++ b/src/Drivers/Gd/Decoders/FilePathImageDecoder.php
@@ -21,7 +21,7 @@ class FilePathImageDecoder extends NativeObjectDecoder implements DecoderInterfa
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!$this->isFile($input)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. The given path does not point to a readable file.');
         }
 
         // detect media (mime) type
@@ -37,7 +37,7 @@ class FilePathImageDecoder extends NativeObjectDecoder implements DecoderInterfa
                 Format::PNG => @imagecreatefrompng($input),
                 Format::AVIF => @imagecreatefromavif($input),
                 Format::BMP => @imagecreatefrombmp($input),
-                default => throw new DecoderException('Unable to decode input'),
+                default => throw new DecoderException('Unable to decode input. The image format of the file is not supported.'),
             }),
         };
 

--- a/src/Drivers/Gd/Decoders/FilePointerImageDecoder.php
+++ b/src/Drivers/Gd/Decoders/FilePointerImageDecoder.php
@@ -18,7 +18,7 @@ class FilePointerImageDecoder extends BinaryImageDecoder
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!is_resource($input) || !in_array(get_resource_type($input), ['file', 'stream'])) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected a file or stream resource.');
         }
 
         $contents = '';

--- a/src/Drivers/Gd/Decoders/NativeObjectDecoder.php
+++ b/src/Drivers/Gd/Decoders/NativeObjectDecoder.php
@@ -26,11 +26,11 @@ class NativeObjectDecoder extends AbstractDecoder
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!is_object($input)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected an object.');
         }
 
         if (!($input instanceof GdImage)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected a GdImage instance.');
         }
 
         if (!imageistruecolor($input)) {
@@ -66,7 +66,7 @@ class NativeObjectDecoder extends AbstractDecoder
             };
 
             if ($native === false) {
-                throw new DecoderException('Unable to decode input.');
+                throw new DecoderException('Unable to decode input. GIF image could not be created from the given data.');
             }
 
             $image = self::decode($native);

--- a/src/Drivers/Gd/Decoders/SplFileInfoImageDecoder.php
+++ b/src/Drivers/Gd/Decoders/SplFileInfoImageDecoder.php
@@ -20,7 +20,7 @@ class SplFileInfoImageDecoder extends FilePathImageDecoder implements DecoderInt
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!is_a($input, SplFileInfo::class)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected an SplFileInfo object.');
         }
 
         return parent::decode($input->getRealPath());

--- a/src/Drivers/Imagick/Decoders/Base64ImageDecoder.php
+++ b/src/Drivers/Imagick/Decoders/Base64ImageDecoder.php
@@ -18,7 +18,7 @@ class Base64ImageDecoder extends BinaryImageDecoder
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!$this->isValidBase64($input)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected a valid base64 encoded string.');
         }
 
         return parent::decode(base64_decode((string) $input));

--- a/src/Drivers/Imagick/Decoders/BinaryImageDecoder.php
+++ b/src/Drivers/Imagick/Decoders/BinaryImageDecoder.php
@@ -21,14 +21,14 @@ class BinaryImageDecoder extends NativeObjectDecoder
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!is_string($input)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected a binary string.');
         }
 
         try {
             $imagick = new Imagick();
             $imagick->readImageBlob($input);
         } catch (ImagickException) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. The binary data could not be read as an image.');
         }
 
         // decode image

--- a/src/Drivers/Imagick/Decoders/DataUriImageDecoder.php
+++ b/src/Drivers/Imagick/Decoders/DataUriImageDecoder.php
@@ -18,13 +18,13 @@ class DataUriImageDecoder extends BinaryImageDecoder
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!is_string($input)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected a string.');
         }
 
         $uri = $this->parseDataUri($input);
 
         if (!$uri->isValid()) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. The given string is not a valid data URI.');
         }
 
         if ($uri->isBase64Encoded()) {

--- a/src/Drivers/Imagick/Decoders/EncodedImageObjectDecoder.php
+++ b/src/Drivers/Imagick/Decoders/EncodedImageObjectDecoder.php
@@ -19,7 +19,7 @@ class EncodedImageObjectDecoder extends BinaryImageDecoder
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!is_a($input, EncodedImage::class)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected an EncodedImage object.');
         }
 
         return parent::decode($input->toString());

--- a/src/Drivers/Imagick/Decoders/FilePathImageDecoder.php
+++ b/src/Drivers/Imagick/Decoders/FilePathImageDecoder.php
@@ -20,14 +20,14 @@ class FilePathImageDecoder extends NativeObjectDecoder
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!$this->isFile($input)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. The given path does not point to a readable file.');
         }
 
         try {
             $imagick = new Imagick();
             $imagick->readImage($input);
         } catch (ImagickException) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. The image format of the file is not supported.');
         }
 
         // decode image

--- a/src/Drivers/Imagick/Decoders/FilePointerImageDecoder.php
+++ b/src/Drivers/Imagick/Decoders/FilePointerImageDecoder.php
@@ -18,7 +18,7 @@ class FilePointerImageDecoder extends BinaryImageDecoder
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!is_resource($input) || !in_array(get_resource_type($input), ['file', 'stream'])) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected a file or stream resource.');
         }
 
         $contents = '';

--- a/src/Drivers/Imagick/Decoders/NativeObjectDecoder.php
+++ b/src/Drivers/Imagick/Decoders/NativeObjectDecoder.php
@@ -25,11 +25,11 @@ class NativeObjectDecoder extends SpecializableDecoder implements SpecializedInt
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!is_object($input)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected an object.');
         }
 
         if (!($input instanceof Imagick)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected an Imagick instance.');
         }
 
         // For some JPEG formats, the "coalesceImages()" call leads to an image

--- a/src/Drivers/Imagick/Decoders/SplFileInfoImageDecoder.php
+++ b/src/Drivers/Imagick/Decoders/SplFileInfoImageDecoder.php
@@ -19,7 +19,7 @@ class SplFileInfoImageDecoder extends FilePathImageDecoder
     public function decode(mixed $input): ImageInterface|ColorInterface
     {
         if (!is_a($input, SplFileInfo::class)) {
-            throw new DecoderException('Unable to decode input');
+            throw new DecoderException('Unable to decode input. Expected an SplFileInfo object.');
         }
 
         return parent::decode($input->getRealPath());


### PR DESCRIPTION
## Summary

This PR replaces all generic `Unable to decode input` error messages across all decoders with specific, descriptive messages that indicate:

- **What type of input was expected** (e.g., `Expected a GdImage instance`, `Expected an SplFileInfo object`)
- **What went wrong** (e.g., `The binary data could not be read as an image`, `The image format of the file is not supported`)

## Problem

As described in #1234, when the decoder chain fails, the last decoder's generic `Unable to decode input` message is propagated — giving no indication of what went wrong or what input type was expected. This makes debugging difficult.

## Solution

Each decoder now throws a specific error message. Examples:

| Decoder | Old Message | New Message |
|---------|------------|-------------|
| FilePathImageDecoder | `Unable to decode input` | `Unable to decode input. The given path does not point to a readable file.` |
| BinaryImageDecoder | `Unable to decode input` | `Unable to decode input. The binary data could not be read as an image.` |
| HexColorDecoder | `Unable to decode input` | `Unable to decode input. The given string is not a valid hex color code.` |
| NativeObjectDecoder (GD) | `Unable to decode input` | `Unable to decode input. Expected a GdImage instance.` |
| NativeObjectDecoder (Imagick) | `Unable to decode input` | `Unable to decode input. Expected an Imagick instance.` |

All 25 decoder files across GD, Imagick, Color, and generic decoders have been updated.

Fixes #1234