### PR TITLE
Preserve alpha channel in Imagick invert modifier

### DIFF
--- a/src/Drivers/Imagick/Modifiers/InvertModifier.php
+++ b/src/Drivers/Imagick/Modifiers/InvertModifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Imagick\Modifiers;
 
+use Imagick;
 use ImagickException;
 use Intervention\Image\Exceptions\ModifierException;
 use Intervention\Image\Interfaces\ImageInterface;
@@ -17,9 +18,16 @@ class InvertModifier extends GenericInvertModifier implements SpecializedInterfa
      */
     public function apply(ImageInterface $image): ImageInterface
     {
+        // Imagick::CHANNEL_DEFAULT includes the alpha channel, so a plain
+        // negateImage() call inverts transparency along with color and turns
+        // fully transparent pixels opaque. Mask the alpha bit off so the
+        // result matches the GD driver, where IMG_FILTER_NEGATE only touches
+        // the color channels.
+        $channel = Imagick::CHANNEL_ALL & ~Imagick::CHANNEL_ALPHA;
+
         foreach ($image as $frame) {
             try {
-                $result = $frame->native()->negateImage(false);
+                $result = $frame->native()->negateImage(false, $channel);
                 if ($result === false) {
                     throw new ModifierException(
                         'Failed to apply ' . self::class . ', unable to invert image colors',

--- a/tests/Unit/Drivers/Imagick/Modifiers/InvertModifierTest.php
+++ b/tests/Unit/Drivers/Imagick/Modifiers/InvertModifierTest.php
@@ -23,4 +23,14 @@ final class InvertModifierTest extends ImagickTestCase
         $this->assertEquals('ff510f', $image->colorAt(0, 0)->toHex());
         $this->assertEquals('0059fe', $image->colorAt(25, 25)->toHex());
     }
+
+    public function testApplyPreservesAlphaChannel(): void
+    {
+        $image = $this->readTestImage('circle.png');
+        $this->assertColor(0, 0, 0, 0, $image->colorAt(0, 0));
+        $this->assertColor(0, 0, 0, 204, $image->colorAt(25, 25));
+        $image->modify(new InvertModifier());
+        $this->assertColor(255, 255, 255, 0, $image->colorAt(0, 0));
+        $this->assertColor(255, 255, 255, 204, $image->colorAt(25, 25));
+    }
 }


### PR DESCRIPTION
negateImage() defaults to CHANNEL_DEFAULT, which has the alpha bit set, so invert() was turning transparent pixels opaque and flipping partial alpha (0.8 became 0.2). The GD driver uses IMG_FILTER_NEGATE and leaves alpha alone, so the same call produced different bytes on the two drivers.

Mask CHANNEL_ALPHA off so only the color channels get negated.

Test covers both a fully transparent corner and a semi-transparent body pixel from circle.png.