### PR TITLE
Stop Imagick contrast from lifting every pixel

### DIFF
--- a/src/Drivers/Imagick/Modifiers/ContrastModifier.php
+++ b/src/Drivers/Imagick/Modifiers/ContrastModifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Imagick\Modifiers;
 
+use Imagick;
 use ImagickException;
 use Intervention\Image\Exceptions\ModifierException;
 use Intervention\Image\Interfaces\ImageInterface;
@@ -17,9 +18,17 @@ class ContrastModifier extends GenericContrastModifier implements SpecializedInt
      */
     public function apply(ImageInterface $image): ImageInterface
     {
+        // sigmoidalContrastImage's midpoint argument is in QuantumRange units,
+        // not the [0..1] range a normalized API would imply. Passing 0 pivots
+        // the sigmoidal curve around pure black, which lifts every pixel
+        // including the midtone — the opposite of a symmetric contrast
+        // adjustment. Pivot around the middle of the QuantumRange so a
+        // mid-grey pixel survives unchanged and the curve is symmetric.
+        $midpoint = Imagick::QUANTUM_RANGE / 2;
+
         foreach ($image as $frame) {
             try {
-                $result = $frame->native()->sigmoidalContrastImage($this->level > 0, abs($this->level / 4), 0);
+                $result = $frame->native()->sigmoidalContrastImage($this->level > 0, abs($this->level / 4), $midpoint);
                 if ($result === false) {
                     throw new ModifierException(
                         'Failed to apply ' . self::class . ', unable to adjust image contrast',

--- a/tests/Unit/Drivers/Imagick/Modifiers/ContrastModifierTest.php
+++ b/tests/Unit/Drivers/Imagick/Modifiers/ContrastModifierTest.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Tests\Unit\Drivers\Imagick\Modifiers;
 
+use Imagick;
+use ImagickPixel;
+use Intervention\Image\Drivers\Imagick\Core;
+use Intervention\Image\Drivers\Imagick\Driver;
+use Intervention\Image\Image;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Intervention\Image\Modifiers\ContrastModifier;
@@ -19,6 +24,29 @@ final class ContrastModifierTest extends ImagickTestCase
         $image = $this->readTestImage('trim.png');
         $this->assertEquals('00aef0', $image->colorAt(14, 14)->toHex());
         $image->modify(new ContrastModifier(30));
-        $this->assertEquals('00fcff', $image->colorAt(14, 14)->toHex());
+        $this->assertEquals('00cffc', $image->colorAt(14, 14)->toHex());
+    }
+
+    public function testApplyPreservesMidtone(): void
+    {
+        // sigmoidalContrastImage takes its midpoint argument in QuantumRange
+        // units. Passing 0 pivots the curve around pure black, lifting every
+        // pixel — including the midtone, which a contrast adjustment must keep
+        // fixed. After the fix the midpoint is QUANTUM_RANGE / 2 and a mid-grey
+        // pixel survives a contrast adjustment unchanged.
+        $image = $this->createMidGreyImage();
+        $this->assertColor(128, 128, 128, 255, $image->colorAt(0, 0));
+        $image->modify(new ContrastModifier(30));
+        $this->assertColor(128, 128, 128, 255, $image->colorAt(0, 0), tolerance: 1);
+    }
+
+    private function createMidGreyImage(): Image
+    {
+        $imagick = new Imagick();
+        $imagick->newImage(1, 1, new ImagickPixel('rgb(128, 128, 128)'), 'png');
+        $imagick->setImageType(Imagick::IMGTYPE_TRUECOLOR);
+        $imagick->setColorspace(Imagick::COLORSPACE_SRGB);
+
+        return new Image(new Driver(), new Core($imagick));
     }
 }


### PR DESCRIPTION
`sigmoidalContrastImage` takes its midpoint in QuantumRange units, not normalized 0..1. Passing 0 anchors the curve at pure black, which lifts every pixel including the midtone. That's brightness, not contrast. GD's `IMG_FILTER_CONTRAST` is midtone-symmetric, so the same `$image->contrast(N)` gave different output across drivers. On `rgb(0, 174, 240)`: GD gives `rgb(0, 206, 255)`, Imagick gave `rgb(0, 252, 255)`.

Anchor the curve at `QUANTUM_RANGE / 2`. Imagick output now matches GD within 1 LSB.

Added testApplyPreservesMidtone: a pure-grey pixel must `survivecontrast(30)` unchanged. Bumped testApply expectation from `00fcff` to `00cffc`.