### PR TITLE
Stop GD insert filling watermark bbox with black (optimized)

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -44,7 +44,7 @@ class Config
      * array instead of named parameters.
      *
      * @param array<mixed> $options
-     * @return array<string, mixed>
+     * @return array<mixed>
      */
     private function prepareOptions(array $options): array
     {

--- a/src/Drivers/Gd/Modifiers/InsertModifier.php
+++ b/src/Drivers/Gd/Modifiers/InsertModifier.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Gd\Modifiers;
 
+use Intervention\Image\Exceptions\ImageException;
 use Intervention\Image\Exceptions\ModifierException;
 use Intervention\Image\Exceptions\StateException;
-use Intervention\Image\Interfaces\FrameInterface;
 use Intervention\Image\Interfaces\ImageInterface;
-use Intervention\Image\Interfaces\PointInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
 use Intervention\Image\Modifiers\InsertModifier as GenericInsertModifier;
 
@@ -24,61 +23,51 @@ class InsertModifier extends GenericInsertModifier implements SpecializedInterfa
      */
     public function apply(ImageInterface $image): ImageInterface
     {
-        $watermark = $this->driver()->decodeImage($this->image);
+        $watermark = $this->watermark();
         $position = $this->position($image, $watermark);
+        $watermarkSize = $watermark->size();
 
         foreach ($image as $frame) {
             imagealphablending($frame->native(), true);
-
-            if ($this->transparency === 1.0) {
-                $this->insertOpaque($frame, $watermark, $position);
-            } else {
-                $this->insertTransparent($frame, $watermark, $position);
-            }
+            imagecopy(
+                $frame->native(),
+                $watermark->core()->native(),
+                $position->x(),
+                $position->y(),
+                0,
+                0,
+                $watermarkSize->width(),
+                $watermarkSize->height(),
+            );
         }
 
         return $image;
     }
 
     /**
-     * Insert watermark with 100% opacity
+     * Build watermark image.
      *
      * @throws ModifierException
      */
-    private function insertOpaque(FrameInterface $frame, ImageInterface $watermark, PointInterface $position): void
+    private function watermark(): ImageInterface
     {
-        imagecopy(
-            $frame->native(),
-            $watermark->core()->native(),
-            $position->x(),
-            $position->y(),
-            0,
-            0,
-            $watermark->width(),
-            $watermark->height()
-        );
+        try {
+            $watermark = $this->driver()->decodeImage($this->image);
+
+            return $this->transparency === 1.0 ? $watermark : $this->buildFadedWatermark($watermark);
+        } catch (ImageException $e) {
+            throw new ModifierException('Failed to build watermark', previous: $e);
+        }
     }
 
     /**
-     * Insert watermark with the given partial transparency.
-     *
-     * The previous implementation copied the base region into an opaque black
-     * scratch canvas and then used imagecopymerge() to blend the watermark
-     * back. That worked for opaque base images but had two known failures:
-     * imagecopymerge() does not preserve source alpha, and any transparent
-     * pixel in the base region was overwritten with opaque black before the
-     * merge ran, so the watermark's bounding box ended up filled with black
-     * wherever the base used to be transparent.
-     *
-     * Instead, build a faded copy of the watermark by scaling each pixel's
-     * alpha by the requested transparency factor, then composite that copy
-     * with imagecopy() relying on the destination's alpha blending. The base
-     * image's transparent regions stay transparent and partial alpha in the
-     * watermark is preserved.
+     * Build a faded copy of the watermark by scaling each pixel's alpha
+     * by the requested transparency factor. Created once and reused for
+     * every frame.
      *
      * @throws ModifierException
      */
-    private function insertTransparent(FrameInterface $frame, ImageInterface $watermark, PointInterface $position): void
+    private function buildFadedWatermark(ImageInterface $watermark): ImageInterface
     {
         $width = $watermark->width();
         $height = $watermark->height();
@@ -86,7 +75,7 @@ class InsertModifier extends GenericInsertModifier implements SpecializedInterfa
         $faded = imagecreatetruecolor($width, $height);
 
         if ($faded === false) {
-            throw new ModifierException('Failed to insert image');
+            throw new ModifierException('Failed to build watermark image');
         }
 
         imagealphablending($faded, false);
@@ -105,15 +94,10 @@ class InsertModifier extends GenericInsertModifier implements SpecializedInterfa
             }
         }
 
-        imagecopy(
-            $frame->native(),
-            $faded,
-            $position->x(),
-            $position->y(),
-            0,
-            0,
-            $width,
-            $height,
-        );
+        try {
+            return $this->driver()->decodeImage($faded);
+        } catch (StateException $e) {
+            throw new ModifierException('Failed to build watermark', previous: $e);
+        }
     }
 }

--- a/src/Drivers/Gd/Modifiers/InsertModifier.php
+++ b/src/Drivers/Gd/Modifiers/InsertModifier.php
@@ -54,7 +54,7 @@ class InsertModifier extends GenericInsertModifier implements SpecializedInterfa
         try {
             $watermark = $this->driver()->decodeImage($this->image);
 
-            return $this->transparency === 1.0 ? $watermark : $this->buildFadedWatermark($watermark);
+            return $this->transparency === 1.0 ? $watermark : $this->fadeWatermark($watermark);
         } catch (ImageException $e) {
             throw new ModifierException('Failed to build watermark', previous: $e);
         }
@@ -62,12 +62,12 @@ class InsertModifier extends GenericInsertModifier implements SpecializedInterfa
 
     /**
      * Build a faded copy of the watermark by scaling each pixel's alpha
-     * by the requested transparency factor. Created once and reused for
-     * every frame.
+     * by the requested transparency factor of the modifier. Created once
+     * and reused for every frame.
      *
      * @throws ModifierException
      */
-    private function buildFadedWatermark(ImageInterface $watermark): ImageInterface
+    private function fadeWatermark(ImageInterface $watermark): ImageInterface
     {
         $width = $watermark->width();
         $height = $watermark->height();

--- a/src/Drivers/Gd/Modifiers/InsertModifier.php
+++ b/src/Drivers/Gd/Modifiers/InsertModifier.php
@@ -5,19 +5,15 @@ declare(strict_types=1);
 namespace Intervention\Image\Drivers\Gd\Modifiers;
 
 use Intervention\Image\Exceptions\ModifierException;
-use Intervention\Image\Exceptions\RuntimeException;
 use Intervention\Image\Exceptions\StateException;
 use Intervention\Image\Interfaces\FrameInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\PointInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
 use Intervention\Image\Modifiers\InsertModifier as GenericInsertModifier;
-use Intervention\Image\Traits\CanConvertRange;
 
 class InsertModifier extends GenericInsertModifier implements SpecializedInterface
 {
-    use CanConvertRange;
-
     /**
      * {@inheritdoc}
      *
@@ -64,66 +60,60 @@ class InsertModifier extends GenericInsertModifier implements SpecializedInterfa
     }
 
     /**
-     * Insert watermark transparent with current transparency
+     * Insert watermark with the given partial transparency.
      *
-     * Unfortunately, the original PHP function imagecopymerge does not work reliably.
-     * For example, any transparency of the image to be inserted is not applied correctly.
-     * For this reason, a new GDImage is created into which the original image is inserted
-     * in the first step and the watermark is inserted with 100% opacity in the second
-     * step. This combination is then transferred to the original image again with the
-     * respective opacity.
+     * The previous implementation copied the base region into an opaque black
+     * scratch canvas and then used imagecopymerge() to blend the watermark
+     * back. That worked for opaque base images but had two known failures:
+     * imagecopymerge() does not preserve source alpha, and any transparent
+     * pixel in the base region was overwritten with opaque black before the
+     * merge ran, so the watermark's bounding box ended up filled with black
+     * wherever the base used to be transparent.
      *
-     * Please note: Unfortunately, there is still an edge case, when a transparent image
-     * is inserted on a transparent background, the "double" transparent areas appear opaque!
+     * Instead, build a faded copy of the watermark by scaling each pixel's
+     * alpha by the requested transparency factor, then composite that copy
+     * with imagecopy() relying on the destination's alpha blending. The base
+     * image's transparent regions stay transparent and partial alpha in the
+     * watermark is preserved.
      *
      * @throws ModifierException
      */
     private function insertTransparent(FrameInterface $frame, ImageInterface $watermark, PointInterface $position): void
     {
-        $cut = imagecreatetruecolor($watermark->width(), $watermark->height());
+        $width = $watermark->width();
+        $height = $watermark->height();
 
-        if ($cut === false) {
+        $faded = imagecreatetruecolor($width, $height);
+
+        if ($faded === false) {
             throw new ModifierException('Failed to insert image');
         }
 
-        imagecopy(
-            $cut,
-            $frame->native(),
-            0,
-            0,
-            $position->x(),
-            $position->y(),
-            imagesx($cut),
-            imagesy($cut)
-        );
+        imagealphablending($faded, false);
+        imagesavealpha($faded, true);
 
-        imagecopy(
-            $cut,
-            $watermark->core()->native(),
-            0,
-            0,
-            0,
-            0,
-            imagesx($cut),
-            imagesy($cut)
-        );
+        $watermarkNative = $watermark->core()->native();
 
-        try {
-            $transparency = (int) round(self::convertRange($this->transparency, 0, 1, 0, 100));
-        } catch (RuntimeException $e) {
-            throw new ModifierException('Failed to convert transparency', previous: $e);
+        for ($y = 0; $y < $height; $y++) {
+            for ($x = 0; $x < $width; $x++) {
+                $color = imagecolorat($watermarkNative, $x, $y);
+                $alpha = ($color >> 24) & 0x7F;
+                // GD stores alpha as 0 (opaque) … 127 (transparent), so scale
+                // the opacity (127 - alpha) and flip back to GD's convention.
+                $newAlpha = 127 - (int) round((127 - $alpha) * $this->transparency);
+                imagesetpixel($faded, $x, $y, ($newAlpha << 24) | ($color & 0xFFFFFF));
+            }
         }
 
-        imagecopymerge(
+        imagecopy(
             $frame->native(),
-            $cut,
+            $faded,
             $position->x(),
             $position->y(),
             0,
             0,
-            $watermark->width(),
-            $watermark->height(),
-            $transparency,
+            $width,
+            $height,
         );
     }
 }

--- a/tests/GdTestCase.php
+++ b/tests/GdTestCase.php
@@ -32,6 +32,22 @@ abstract class GdTestCase extends BaseTestCase
         );
     }
 
+    public static function createTestImageTransparent(int $width, int $height): Image
+    {
+        $gd = imagecreatetruecolor($width, $height);
+
+        imagealphablending($gd, false);
+        imagesavealpha($gd, true);
+        imagefill($gd, 0, 0, imagecolorallocatealpha($gd, 0, 0, 0, 127));
+
+        return new Image(
+            new Driver(),
+            new Core([
+                new Frame($gd),
+            ]),
+        );
+    }
+
     public static function createTestAnimation(): Image
     {
         $gd1 = imagecreatetruecolor(3, 2);

--- a/tests/Unit/Drivers/Gd/Modifiers/InsertModifierTest.php
+++ b/tests/Unit/Drivers/Gd/Modifiers/InsertModifierTest.php
@@ -5,10 +5,6 @@ declare(strict_types=1);
 namespace Intervention\Image\Tests\Unit\Drivers\Gd\Modifiers;
 
 use Intervention\Image\Alignment;
-use Intervention\Image\Drivers\Gd\Core;
-use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\Drivers\Gd\Frame;
-use Intervention\Image\Image;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Intervention\Image\Modifiers\InsertModifier;
@@ -48,7 +44,7 @@ final class InsertModifierTest extends GdTestCase
 
     public function testInsertWithTransparencyKeepsTransparentBaseTransparent(): void
     {
-        $image = $this->createTransparentBase(50, 50);
+        $image = self::createTestImageTransparent(50, 50);
         $this->assertTransparency($image->colorAt(0, 0));
 
         $image->modify(new InsertModifier(
@@ -64,21 +60,5 @@ final class InsertModifierTest extends GdTestCase
         // watermark bbox with opaque black wherever the base was
         // transparent. The corner must still be transparent.
         $this->assertTransparency($image->colorAt(0, 0));
-    }
-
-    private function createTransparentBase(int $width, int $height): Image
-    {
-        $gd = imagecreatetruecolor($width, $height);
-        imagealphablending($gd, false);
-        imagesavealpha($gd, true);
-        $transparent = imagecolorallocatealpha($gd, 0, 0, 0, 127);
-        imagefilledrectangle($gd, 0, 0, $width - 1, $height - 1, $transparent);
-
-        return new Image(
-            new Driver(),
-            new Core([
-                new Frame($gd),
-            ]),
-        );
     }
 }

--- a/tests/Unit/Drivers/Gd/Modifiers/InsertModifierTest.php
+++ b/tests/Unit/Drivers/Gd/Modifiers/InsertModifierTest.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Intervention\Image\Tests\Unit\Drivers\Gd\Modifiers;
 
 use Intervention\Image\Alignment;
+use Intervention\Image\Drivers\Gd\Core;
+use Intervention\Image\Drivers\Gd\Driver;
+use Intervention\Image\Drivers\Gd\Frame;
+use Intervention\Image\Image;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Intervention\Image\Modifiers\InsertModifier;
@@ -40,5 +44,41 @@ final class InsertModifierTest extends GdTestCase
         $this->assertEquals('0000ff', $image->colorAt(10, 10)->toHex());
         $image->modify(new InsertModifier(Resource::create('exif.jpg')->path(), transparency: .5));
         $this->assertColor(127, 83, 127, 255, $image->colorAt(10, 10), tolerance: 1);
+    }
+
+    public function testInsertWithTransparencyKeepsTransparentBaseTransparent(): void
+    {
+        $image = $this->createTransparentBase(50, 50);
+        $this->assertTransparency($image->colorAt(0, 0));
+
+        $image->modify(new InsertModifier(
+            Resource::create('circle.png')->path(),
+            0,
+            0,
+            Alignment::TOP_LEFT,
+            .5,
+        ));
+
+        // circle.png's (0, 0) is fully transparent. The previous
+        // imagecreatetruecolor + imagecopymerge path filled the whole
+        // watermark bbox with opaque black wherever the base was
+        // transparent. The corner must still be transparent.
+        $this->assertTransparency($image->colorAt(0, 0));
+    }
+
+    private function createTransparentBase(int $width, int $height): Image
+    {
+        $gd = imagecreatetruecolor($width, $height);
+        imagealphablending($gd, false);
+        imagesavealpha($gd, true);
+        $transparent = imagecolorallocatealpha($gd, 0, 0, 0, 127);
+        imagefilledrectangle($gd, 0, 0, $width - 1, $height - 1, $transparent);
+
+        return new Image(
+            new Driver(),
+            new Core([
+                new Frame($gd),
+            ]),
+        );
     }
 }


### PR DESCRIPTION
insertTransparent() copied the base region into an opaque-black scratch canvas, layered the watermark on top, and merged it back with imagecopymerge(). Two problems: the black fill stuck wherever the base was transparent, so the watermark's bbox came out black on alpha PNGs; and imagecopymerge ignores source alpha, so partial watermark alpha was lost on the way back.

Build a faded copy of the watermark by scaling each pixel's alpha by the transparency factor, then composite with imagecopy(). GD does the blending instead of imagecopymerge, so transparent base pixels stay put and partial watermark alpha survives.

Regression test inserts circle.png on a 50x50 transparent canvas at transparency=0.5 and asserts the watermark's transparent corner is still transparent after insert.

Also drop the unused CanConvertRange trait and the trailing imagedestroy() call (no-op since PHP 8.0).