### PR TITLE
Add 'image/bmp' case to BMP image processing switch

### DIFF
--- a/src/Intervention/Image/AbstractEncoder.php
+++ b/src/Intervention/Image/AbstractEncoder.php
@@ -157,6 +157,7 @@ abstract class AbstractEncoder
             case 'x-win-bitmap':
             case 'x-windows-bmp':
             case 'x-xbitmap':
+            case 'image/bmp':
             case 'image/ms-bmp':
             case 'image/x-bitmap':
             case 'image/x-bmp':


### PR DESCRIPTION
Add 'image/bmp' case to BMP image processing switch
    
    The `processBmp()` handler already supported various BMP MIME types (like
    `image/ms-bmp` and `image/x-bitmap`), but was missing the standard
    `image/bmp` identifier. Added the missing case condition.