### PR TITLE
Convert YCbCr images to sRGB when decoding with Imagick

### DIFF
--- a/src/Drivers/Imagick/Analyzers/ColorspaceAnalyzer.php
+++ b/src/Drivers/Imagick/Analyzers/ColorspaceAnalyzer.php
@@ -25,13 +25,22 @@ class ColorspaceAnalyzer extends GenericColorspaceAnalyzer implements Specialize
     public function analyze(ImageInterface $image): mixed
     {
         try {
-            return match ($image->core()->native()->getImageColorspace()) {
-                Imagick::COLORSPACE_CMYK => new Cmyk(),
-                Imagick::COLORSPACE_SRGB, Imagick::COLORSPACE_RGB => new Rgb(),
-                Imagick::COLORSPACE_HSL => new Hsl(),
-                Imagick::COLORSPACE_HSB => new Hsv(),
-                constant(Imagick::class . '::COLORSPACE_OKLAB') => new Oklab(),
-                constant(Imagick::class . '::COLORSPACE_OKLCH') => new Oklch(),
+            $colorspace = $image->core()->native()->getImageColorspace();
+
+            // OKLAB/OKLCH only exist on recent ImageMagick builds, so the
+            // constants are resolved through defined()/constant() (mirroring the
+            // ColorspaceModifier) to avoid referencing them where they are
+            // undefined. Any unexpected resolution error is normalized below.
+            return match (true) {
+                $colorspace === Imagick::COLORSPACE_CMYK => new Cmyk(),
+                $colorspace === Imagick::COLORSPACE_SRGB,
+                $colorspace === Imagick::COLORSPACE_RGB => new Rgb(),
+                $colorspace === Imagick::COLORSPACE_HSL => new Hsl(),
+                $colorspace === Imagick::COLORSPACE_HSB => new Hsv(),
+                defined(Imagick::class . '::COLORSPACE_OKLAB')
+                    && $colorspace === constant(Imagick::class . '::COLORSPACE_OKLAB') => new Oklab(),
+                defined(Imagick::class . '::COLORSPACE_OKLCH')
+                    && $colorspace === constant(Imagick::class . '::COLORSPACE_OKLCH') => new Oklch(),
                 default => throw new AnalyzerException('Failed to analyze unknown colorspace'),
             };
         } catch (Error $e) {

--- a/src/Drivers/Imagick/Decoders/NativeObjectDecoder.php
+++ b/src/Drivers/Imagick/Decoders/NativeObjectDecoder.php
@@ -64,6 +64,15 @@ class NativeObjectDecoder extends SpecializableDecoder implements SpecializedInt
             if ($input->getImageColorspace() === Imagick::COLORSPACE_GRAY) {
                 $input->setImageColorspace(Imagick::COLORSPACE_SRGB);
             }
+
+            // AVIF/HEIF store their pixels in a luma/chroma (YCbCr) colorspace.
+            // Recent ImageMagick normalizes this to sRGB on decode, but older
+            // releases report the image as YCbCr, which leaves every later color
+            // operation (colorspace analysis, pixel reads) working on raw
+            // luma/chroma values. Convert it to sRGB so colors are correct.
+            if ($input->getImageColorspace() === Imagick::COLORSPACE_YCBCR) {
+                $input->transformImageColorspace(Imagick::COLORSPACE_SRGB);
+            }
         } catch (ImagickException $e) {
             throw new DriverException('Failed to convert image to sRGB', previous: $e);
         }

--- a/tests/Unit/Drivers/Imagick/Decoders/NativeObjectDecoderTest.php
+++ b/tests/Unit/Drivers/Imagick/Decoders/NativeObjectDecoderTest.php
@@ -8,6 +8,7 @@ use Imagick;
 use ImagickPixel;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use Intervention\Image\Colors\Rgb\Colorspace as RgbColorspace;
 use Intervention\Image\Drivers\Imagick\Decoders\NativeObjectDecoder;
 use Intervention\Image\Drivers\Imagick\Driver;
 use Intervention\Image\Image;
@@ -32,5 +33,22 @@ final class NativeObjectDecoderTest extends BaseTestCase
         $result = $this->decoder->decode($native);
 
         $this->assertInstanceOf(Image::class, $result);
+    }
+
+    public function testDecodeNormalizesYcbcrColorspaceToSrgb(): void
+    {
+        // Older ImageMagick reports decoded AVIF/HEIF images in a YCbCr
+        // colorspace and does not normalize it. The decoder must convert it to
+        // sRGB, otherwise colorspace analysis and pixel reads operate on raw
+        // luma/chroma values (here the color would come back roughly as
+        // rgb(254, 128, 128) instead of the original).
+        $native = new Imagick();
+        $native->newImage(3, 2, new ImagickPixel('rgb(80, 160, 240)'), 'png');
+        $native->transformImageColorspace(Imagick::COLORSPACE_YCBCR);
+
+        $result = $this->decoder->decode($native);
+
+        $this->assertInstanceOf(RgbColorspace::class, $result->colorspace());
+        $this->assertColor(80, 160, 240, 255, $result->colorAt(0, 0), tolerance: 2);
     }
 }


### PR DESCRIPTION
Reading pixels from an AVIF (or HEIF) fails with the Imagick driver on older ImageMagick. Decoding is fine, the first `colorAt()` throws.

Older ImageMagick decodes AVIF/HEIF into the YCbCr colorspace and doesn't normalize it. The Imagick `ColorspaceAnalyzer` has no YCbCr branch, so the `match` falls through to the OKLAB/OKLCH arms. Those reference `Imagick::COLORSPACE_OKLAB`, which doesn't exist before the ImageMagick release that added OKLAB, so analysis fails with "Undefined constant Imagick::COLORSPACE_OKLAB". Newer ImageMagick returns sRGB for the same image, so it only shows up on older builds.

Repro: decode an AVIF with the Imagick driver on an ImageMagick without OKLAB, then call `colorAt()` or `colorspace()`.

Measured inside the failing environment:

| ImageMagick | OKLAB defined | decoded AVIF colorspace |
| --- | --- | --- |
| 6.9.11-60 | no | 7 (`COLORSPACE_YCBCR`) |
| 6.9.13-40 | no | 7 (`COLORSPACE_YCBCR`) |
| 7.1.2 | no | sRGB |

Every decoded AVIF reported YCbCr regardless of the encoder (aom/libavif, vips). The colorspace enum values differ between ImageMagick majors (YCbCr is 7 on IM6, 27 on IM7), so the fix uses the `Imagick::COLORSPACE_YCBCR` constant, not a literal.

Fix:

1. `NativeObjectDecoder` converts YCbCr to sRGB on decode, next to the existing GRAY handling. It uses `transformImageColorspace()` (a real conversion), not `setImageColorspace()`, otherwise pixels come back as raw luma/chroma values. This is a no-op on newer ImageMagick where the image is already sRGB.

2. `ColorspaceAnalyzer` guards the OKLAB/OKLCH constants with `defined()` before using them, the same way `ColorspaceModifier` already does. Unknown colorspaces now reach the `default` arm instead of throwing on the missing constant.

Tests: added a regression test in `NativeObjectDecoderTest` that forces an image to YCbCr, decodes it, and checks the result is sRGB and `colorAt()` returns the original color (small tolerance, so it also catches a relabel-instead-of-convert mistake). It forces YCbCr explicitly so it runs the same on ImageMagick 6 and 7.
