### PR TITLE
Reset page geometry after Imagick rotation

### DIFF
--- a/src/Drivers/Imagick/Modifiers/RotateModifier.php
+++ b/src/Drivers/Imagick/Modifiers/RotateModifier.php
@@ -32,6 +32,12 @@ class RotateModifier extends GenericRotateModifier implements SpecializedInterfa
                         'Failed to apply ' . self::class . ', unable to rotate image',
                     );
                 }
+
+                // Reset the virtual canvas page that rotateImage() leaves behind. A
+                // non-right angle produces a negative page offset which otherwise
+                // corrupts the animated-AVIF (libheif sequences) writer, leaving the
+                // bottom/right region transparent. Mirrors TrimModifier/CoverModifier.
+                $frame->native()->setImagePage(0, 0, 0, 0);
             } catch (ImagickException $e) {
                 throw new ModifierException(
                     'Failed to apply ' . self::class . ', unable to rotate image',

--- a/tests/Unit/Drivers/Imagick/Modifiers/RotateModifierTest.php
+++ b/tests/Unit/Drivers/Imagick/Modifiers/RotateModifierTest.php
@@ -23,4 +23,19 @@ final class RotateModifierTest extends ImagickTestCase
         $this->assertEquals(240, $image->width());
         $this->assertEquals(320, $image->height());
     }
+
+    public function testRotateResetsFramePageOffset(): void
+    {
+        // A non-right-angle rotation grows the virtual canvas; ImageMagick leaves
+        // each frame with a negative page offset. That offset mis-composes the
+        // animated-AVIF (libheif sequences) writer, leaving the bottom/right
+        // transparent, so rotate must reset every frame's page to +0+0.
+        $image = $this->readTestImage('animation.gif');
+        $image->modify(new RotateModifier(45, 'fff'));
+
+        foreach ($image as $frame) {
+            $this->assertSame(0, $frame->offsetLeft());
+            $this->assertSame(0, $frame->offsetTop());
+        }
+    }
 }


### PR DESCRIPTION
Rotating an image with the Imagick driver leaves a page offset on every frame. You don't notice it on a still image. On an animated one that then gets encoded to AVIF, it breaks: the bottom-right of every frame comes out transparent.

Where it comes from: `rotateImage()` at a non-right angle grows the canvas and sets a negative page offset. A 480x480 frame rotated 45 degrees ends up with page `680x680-100-100`. The single-frame AVIF encoder and the animated WebP encoder ignore that offset. The animated AVIF path does not, it composites every frame shifted up and to the left.

The real bug is in ImageMagick's animated AVIF writer, not in Intervention. But we can shield against it here, and the other modifiers already do this (see the fix below).

Repro with plain magick, no PHP involved:

```
magick in.gif -coalesce -background '#3b82f6' -rotate 45 bad.avif
magick 'bad.avif[0]' -alpha on -format '%[pixel:p{679,679}]' info:
# srgba(0,0,0,0)  -> transparent

magick in.gif -coalesce -background '#3b82f6' -rotate 45 +repage good.avif
magick 'good.avif[0]' -alpha on -format '%[pixel:p{678,678}]' info:
# srgba(59,130,246,1)  -> the background color, correct
```

Same thing through the library:

```php
use Intervention\Image\ImageManager;
use Intervention\Image\Drivers\Imagick\Driver;
use Intervention\Image\Encoders\AvifEncoder;

$image = ImageManager::usingDriver(Driver::class)
    ->decodePath('in.gif')
    ->rotate(45, '#3b82f6');

$image->encode(new AvifEncoder());
// every frame is 680x680, bottom-right corner is transparent
```

Fix: reset each frame's page to +0+0 right after `rotateImage()`. `TrimModifier` and `CoverModifier` already do this after they change the canvas, so the rotate modifier is just catching up with them. GD and vips don't leave an offset after a rotate, so this also lines the drivers up.

One line in `Drivers/Imagick/Modifiers/RotateModifier.php`:

```php
$frame->native()->setImagePage(0, 0, 0, 0);
```

Test: I added `testRotateResetsFramePageOffset` next to the existing rotate test. It rotates an animated fixture by 45 and checks every frame has offset 0. It fails before the change and passes after.

Corner pixel, same input, before and after:

| driver | animated AVIF, bottom-right corner |
| --- | --- |
| imagick, before | transparent (srgba 0,0,0,0) |
| imagick, after | background color (srgba 59,130,246,1) |
| gd | fine (it flattens the animation to one frame) |
| vips | fine (no page offset) |

Two things if you want to reproduce it:

It only shows with real photo-like frames. A flat color or a tiny synthetic gif compresses to trivial tiles and the corner stays fine, so use a real animated image.

You need an ImageMagick build with animated AVIF support. I saw it on 7.1.2-26, and it was also reported on a couple of earlier 7.1.2 builds. Older ImageMagick without animated AVIF is not affected.
