### PR TITLE
Add JPEG XL (JXL) encoder

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   run:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -35,15 +35,15 @@ jobs:
           sudo apt remove -y imagemagick imagemagick-6-common libmagic-dev
           sudo apt update --allow-releaseinfo-change
           sudo apt update
-          sudo apt install -y libjpeg-dev libgif-dev libtiff-dev libpng-dev libwebp-dev libavif-dev libheif-dev libraqm-dev libmagickwand-dev
+          sudo apt install -y libjpeg-dev libgif-dev libtiff-dev libpng-dev libwebp-dev libavif-dev libheif-dev libheif-plugin-x265 libheif-plugin-aomenc libheif-plugin-aomdec libheif-plugin-libde265 libjxl-dev libraqm-dev libmagickwand-dev
 
       - name: Cache ImageMagick
         uses: actions/cache@v6
         id: cache-imagemagick
         with:
           path: /home/runner/im/imagemagick-${{ matrix.imagemagick }}
-          key: ${{ runner.os }}-ImageMagick-${{ matrix.imagemagick }}-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-ImageMagick-${{ matrix.imagemagick }}-
+          key: ${{ runner.os }}-ImageMagick-jxl1-${{ matrix.imagemagick }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-ImageMagick-jxl1-${{ matrix.imagemagick }}-
 
       - name: Check ImageMagick cache exists
         uses: andstor/file-existence-action@v3

--- a/src/Drivers/Imagick/Encoders/JxlEncoder.php
+++ b/src/Drivers/Imagick/Encoders/JxlEncoder.php
@@ -34,15 +34,12 @@ class JxlEncoder extends GenericJxlEncoder implements SpecializedInterface
             $image->modify(new StripMetaModifier());
         }
 
-        // In ImageMagick, JXL lossless encoding is triggered by a compression quality of 100.
-        $quality = $this->lossless ? 100 : $this->quality;
-
         try {
             $imagick = clone $image->core()->native();
             $imagick->setFormat($format);
             $imagick->setImageFormat($format);
-            $imagick->setCompressionQuality($quality);
-            $imagick->setImageCompressionQuality($quality);
+            $imagick->setCompressionQuality($this->quality);
+            $imagick->setImageCompressionQuality($this->quality);
 
             $result = new EncodedImage($imagick->getImagesBlob(), 'image/jxl');
             $imagick->clear();

--- a/src/Drivers/Imagick/Encoders/JxlEncoder.php
+++ b/src/Drivers/Imagick/Encoders/JxlEncoder.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intervention\Image\Drivers\Imagick\Encoders;
+
+use ImagickException;
+use Intervention\Image\Drivers\Imagick\Modifiers\StripMetaModifier;
+use Intervention\Image\EncodedImage;
+use Intervention\Image\Encoders\JxlEncoder as GenericJxlEncoder;
+use Intervention\Image\Exceptions\EncoderException;
+use Intervention\Image\Interfaces\EncodedImageInterface;
+use Intervention\Image\Interfaces\ImageInterface;
+use Intervention\Image\Interfaces\SpecializedInterface;
+use Intervention\Image\Exceptions\StreamException;
+use Intervention\Image\Exceptions\ImageException;
+use Intervention\Image\Exceptions\InvalidArgumentException;
+use Intervention\Image\Exceptions\StateException;
+
+class JxlEncoder extends GenericJxlEncoder implements SpecializedInterface
+{
+    /**
+     * @throws InvalidArgumentException
+     * @throws StreamException
+     * @throws StateException
+     * @throws EncoderException
+     */
+    public function encode(ImageInterface $image): EncodedImageInterface
+    {
+        $format = 'JXL';
+
+        // strip meta data
+        if ($this->strip || (is_null($this->strip) && $this->driver()->config()->strip)) {
+            $image->modify(new StripMetaModifier());
+        }
+
+        // In ImageMagick, JXL lossless encoding is triggered by a compression quality of 100.
+        $quality = $this->lossless ? 100 : $this->quality;
+
+        try {
+            $imagick = clone $image->core()->native();
+            $imagick->setFormat($format);
+            $imagick->setImageFormat($format);
+            $imagick->setCompressionQuality($quality);
+            $imagick->setImageCompressionQuality($quality);
+
+            $result = new EncodedImage($imagick->getImagesBlob(), 'image/jxl');
+            $imagick->clear();
+
+            return $result;
+        } catch (ImagickException | ImageException $e) {
+            throw new EncoderException('Failed to encode jxl format', previous: $e);
+        }
+    }
+}

--- a/src/Encoders/JxlEncoder.php
+++ b/src/Encoders/JxlEncoder.php
@@ -13,13 +13,11 @@ class JxlEncoder extends SpecializableEncoder
      * Create new encoder object.
      *
      * @param null|bool $strip Strip EXIF metadata
-     * @param bool $lossless Encode losslessly, ignoring the quality value
      * @throws InvalidArgumentException
      */
     public function __construct(
         public int $quality = self::DEFAULT_QUALITY,
         public ?bool $strip = null,
-        public bool $lossless = false,
     ) {
         if ($quality < 0 || $quality > 100) {
             throw new InvalidArgumentException('Quality must be in range 0 to 100');

--- a/src/Encoders/JxlEncoder.php
+++ b/src/Encoders/JxlEncoder.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intervention\Image\Encoders;
+
+use Intervention\Image\Drivers\SpecializableEncoder;
+use Intervention\Image\Exceptions\InvalidArgumentException;
+
+class JxlEncoder extends SpecializableEncoder
+{
+    /**
+     * Create new encoder object.
+     *
+     * @param null|bool $strip Strip EXIF metadata
+     * @param bool $lossless Encode losslessly, ignoring the quality value
+     * @throws InvalidArgumentException
+     */
+    public function __construct(
+        public int $quality = self::DEFAULT_QUALITY,
+        public ?bool $strip = null,
+        public bool $lossless = false,
+    ) {
+        if ($quality < 0 || $quality > 100) {
+            throw new InvalidArgumentException('Quality must be in range 0 to 100');
+        }
+    }
+}

--- a/src/FileExtension.php
+++ b/src/FileExtension.php
@@ -32,6 +32,7 @@ enum FileExtension: string
     case JPX = 'jpx';
     case HEIC = 'heic';
     case HEIF = 'heif';
+    case JXL = 'jxl';
     case ICO = 'ico';
 
     /**
@@ -120,6 +121,7 @@ enum FileExtension: string
             self::JPX => Format::JP2,
             self::HEIC,
             self::HEIF => Format::HEIC,
+            self::JXL => Format::JXL,
             self::ICO => Format::ICO,
         };
     }

--- a/src/Format.php
+++ b/src/Format.php
@@ -12,6 +12,7 @@ use Intervention\Image\Encoders\HeicEncoder;
 use Intervention\Image\Encoders\IcoEncoder;
 use Intervention\Image\Encoders\Jpeg2000Encoder;
 use Intervention\Image\Encoders\JpegEncoder;
+use Intervention\Image\Encoders\JxlEncoder;
 use Intervention\Image\Encoders\PngEncoder;
 use Intervention\Image\Encoders\TiffEncoder;
 use Intervention\Image\Encoders\WebpEncoder;
@@ -30,6 +31,7 @@ enum Format
     case ICO;
     case JP2;
     case JPEG;
+    case JXL;
     case PNG;
     case TIFF;
     case WEBP;
@@ -157,6 +159,7 @@ enum Format
             self::ICO => IcoEncoder::class,
             self::JP2 => Jpeg2000Encoder::class,
             self::JPEG => JpegEncoder::class,
+            self::JXL => JxlEncoder::class,
             self::PNG => PngEncoder::class,
             self::TIFF => TiffEncoder::class,
             self::WEBP => WebpEncoder::class,

--- a/src/MediaType.php
+++ b/src/MediaType.php
@@ -38,6 +38,8 @@ enum MediaType: string
     case IMAGE_HEIC = 'image/heic';
     case IMAGE_X_HEIC = 'image/x-heic';
     case IMAGE_HEIF = 'image/heif';
+    case IMAGE_JXL = 'image/jxl';
+    case IMAGE_X_JXL = 'image/x-jxl';
     case IMAGE_X_ICON = 'image/x-icon';
     case IMAGE_VND_MICROSOFT_ICON = 'image/vnd.microsoft.icon';
 
@@ -133,6 +135,8 @@ enum MediaType: string
             self::IMAGE_HEIF,
             self::IMAGE_HEIC,
             self::IMAGE_X_HEIC => Format::HEIC,
+            self::IMAGE_JXL,
+            self::IMAGE_X_JXL => Format::JXL,
             self::IMAGE_X_ICON,
             self::IMAGE_VND_MICROSOFT_ICON => Format::ICO,
         };

--- a/tests/Unit/Drivers/Gd/DriverTest.php
+++ b/tests/Unit/Drivers/Gd/DriverTest.php
@@ -210,6 +210,14 @@ final class DriverTest extends BaseTestCase
         yield [false, 'image/heic'];
         yield [false, 'image/heif'];
 
+        yield [false, Format::JXL];
+        yield [false, MediaType::IMAGE_JXL];
+        yield [false, MediaType::IMAGE_X_JXL];
+        yield [false, FileExtension::JXL];
+        yield [false, 'jxl'];
+        yield [false, 'image/jxl'];
+        yield [false, 'image/x-jxl'];
+
         yield [false, 'tga'];
         yield [false, 'image/tga'];
         yield [false, 'image/x-targa'];

--- a/tests/Unit/Drivers/Imagick/DriverTest.php
+++ b/tests/Unit/Drivers/Imagick/DriverTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Intervention\Image\Tests\Unit\Drivers\Imagick;
 
 use Generator;
+use Imagick;
 use Intervention\Image\Analyzers\WidthAnalyzer as GenericWidthAnalyzer;
 use Intervention\Image\Decoders\FilePathImageDecoder as GenericFilePathImageDecoder;
 use Intervention\Image\Encoders\PngEncoder as GenericPngEncoder;
@@ -104,6 +105,21 @@ final class DriverTest extends BaseTestCase
     public function testSupports(bool $result, mixed $identifier): void
     {
         $this->assertEquals($result, $this->driver->supports($identifier));
+    }
+
+    public function testSupportsJxl(): void
+    {
+        if (Imagick::queryFormats('JXL') === []) {
+            $this->markTestSkipped('ImageMagick was built without JXL (libjxl) support');
+        }
+
+        $this->assertTrue($this->driver->supports(Format::JXL));
+        $this->assertTrue($this->driver->supports(MediaType::IMAGE_JXL));
+        $this->assertTrue($this->driver->supports(MediaType::IMAGE_X_JXL));
+        $this->assertTrue($this->driver->supports(FileExtension::JXL));
+        $this->assertTrue($this->driver->supports('jxl'));
+        $this->assertTrue($this->driver->supports('image/jxl'));
+        $this->assertTrue($this->driver->supports('image/x-jxl'));
     }
 
     public static function supportsDataProvider(): Generator

--- a/tests/Unit/Drivers/Imagick/Encoders/JxlEncoderTest.php
+++ b/tests/Unit/Drivers/Imagick/Encoders/JxlEncoderTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intervention\Image\Tests\Unit\Drivers\Imagick\Encoders;
+
+use Imagick;
+use Intervention\Image\Drivers\Imagick\Driver;
+use Intervention\Image\Drivers\Imagick\Encoders\JxlEncoder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use Intervention\Image\Tests\ImagickTestCase;
+
+#[RequiresPhpExtension('imagick')]
+#[CoversClass(JxlEncoder::class)]
+final class JxlEncoderTest extends ImagickTestCase
+{
+    protected function setUp(): void
+    {
+        if (Imagick::queryFormats('JXL') === []) {
+            $this->markTestSkipped('ImageMagick was built without JXL (libjxl) support');
+        }
+    }
+
+    public function testEncode(): void
+    {
+        $image = $this->createTestImage(3, 2);
+        $encoder = new JxlEncoder(75);
+        $encoder->setDriver(new Driver());
+        $result = $encoder->encode($image);
+        $this->assertMediaType(['image/jxl', 'image/x-jxl'], $result);
+        $this->assertEquals('image/jxl', $result->mimetype());
+    }
+
+    public function testEncodeLossless(): void
+    {
+        $image = $this->createTestImage(3, 2);
+        $encoder = new JxlEncoder(lossless: true);
+        $encoder->setDriver(new Driver());
+        $result = $encoder->encode($image);
+        $this->assertMediaType(['image/jxl', 'image/x-jxl'], $result);
+        $this->assertEquals('image/jxl', $result->mimetype());
+    }
+}

--- a/tests/Unit/Drivers/Imagick/Encoders/JxlEncoderTest.php
+++ b/tests/Unit/Drivers/Imagick/Encoders/JxlEncoderTest.php
@@ -31,14 +31,4 @@ final class JxlEncoderTest extends ImagickTestCase
         $this->assertMediaType(['image/jxl', 'image/x-jxl'], $result);
         $this->assertEquals('image/jxl', $result->mimetype());
     }
-
-    public function testEncodeLossless(): void
-    {
-        $image = $this->createTestImage(3, 2);
-        $encoder = new JxlEncoder(lossless: true);
-        $encoder->setDriver(new Driver());
-        $result = $encoder->encode($image);
-        $this->assertMediaType(['image/jxl', 'image/x-jxl'], $result);
-        $this->assertEquals('image/jxl', $result->mimetype());
-    }
 }

--- a/tests/Unit/FileExtensionTest.php
+++ b/tests/Unit/FileExtensionTest.php
@@ -133,6 +133,12 @@ final class FileExtensionTest extends BaseTestCase
         $this->assertEquals(Format::HEIC, $ext->format());
     }
 
+    public function testFormatJxl(): void
+    {
+        $ext = FileExtension::JXL;
+        $this->assertEquals(Format::JXL, $ext->format());
+    }
+
     public function testFormatIco(): void
     {
         $ext = FileExtension::ICO;
@@ -168,6 +174,7 @@ final class FileExtensionTest extends BaseTestCase
         yield [FileExtension::JP2, 4, MediaType::IMAGE_JP2];
         yield [FileExtension::HEIC, 3, MediaType::IMAGE_HEIC];
         yield [FileExtension::HEIF, 3, MediaType::IMAGE_HEIC];
+        yield [FileExtension::JXL, 2, MediaType::IMAGE_JXL];
         yield [FileExtension::JPF, 4, MediaType::IMAGE_JP2];
         yield [FileExtension::JPX, 4, MediaType::IMAGE_JP2];
         yield [FileExtension::JPC, 4, MediaType::IMAGE_JP2];

--- a/tests/Unit/FormatTest.php
+++ b/tests/Unit/FormatTest.php
@@ -11,6 +11,7 @@ use Intervention\Image\Encoders\HeicEncoder;
 use Intervention\Image\Encoders\IcoEncoder;
 use Intervention\Image\Encoders\Jpeg2000Encoder;
 use Intervention\Image\Encoders\JpegEncoder;
+use Intervention\Image\Encoders\JxlEncoder;
 use Intervention\Image\Encoders\PngEncoder;
 use Intervention\Image\Encoders\TiffEncoder;
 use Intervention\Image\Encoders\WebpEncoder;
@@ -147,6 +148,16 @@ final class FormatTest extends BaseTestCase
         $this->assertEquals(MediaType::IMAGE_HEIC, $format->mediaType());
     }
 
+    public function testMediaTypesJxl(): void
+    {
+        $format = Format::JXL;
+        $mediaTypes = $format->mediaTypes();
+        $this->assertIsArray($mediaTypes);
+        $this->assertCount(2, $mediaTypes);
+
+        $this->assertEquals(MediaType::IMAGE_JXL, $format->mediaType());
+    }
+
     public function testEncoderJpeg(): void
     {
         $format = Format::JPEG;
@@ -199,6 +210,12 @@ final class FormatTest extends BaseTestCase
     {
         $format = Format::HEIC;
         $this->assertInstanceOf(HeicEncoder::class, $format->encoder());
+    }
+
+    public function testEncoderJxl(): void
+    {
+        $format = Format::JXL;
+        $this->assertInstanceOf(JxlEncoder::class, $format->encoder());
     }
 
     public function testFileExtensionsJpeg(): void
@@ -289,6 +306,16 @@ final class FormatTest extends BaseTestCase
         $this->assertCount(2, $extensions);
 
         $this->assertEquals(FileExtension::HEIC, $format->fileExtension());
+    }
+
+    public function testFileExtensionsJxl(): void
+    {
+        $format = Format::JXL;
+        $extensions = $format->fileExtensions();
+        $this->assertIsArray($extensions);
+        $this->assertCount(1, $extensions);
+
+        $this->assertEquals(FileExtension::JXL, $format->fileExtension());
     }
 
     public function testMediaTypesIco(): void

--- a/tests/Unit/MediaTypeTest.php
+++ b/tests/Unit/MediaTypeTest.php
@@ -176,6 +176,15 @@ final class MediaTypeTest extends BaseTestCase
         $this->assertEquals(Format::HEIC, $mime->format());
     }
 
+    public function testFormatJxl(): void
+    {
+        $mime = MediaType::IMAGE_JXL;
+        $this->assertEquals(Format::JXL, $mime->format());
+
+        $mime = MediaType::IMAGE_X_JXL;
+        $this->assertEquals(Format::JXL, $mime->format());
+    }
+
     #[DataProvider('fileExtensionsDataProvider')]
     public function testFileExtensions(
         MediaType $mediaType,
@@ -215,6 +224,8 @@ final class MediaTypeTest extends BaseTestCase
         yield [MediaType::IMAGE_HEIC, 2, FileExtension::HEIC];
         yield [MediaType::IMAGE_X_HEIC, 2, FileExtension::HEIC];
         yield [MediaType::IMAGE_HEIF, 2, FileExtension::HEIC];
+        yield [MediaType::IMAGE_JXL, 1, FileExtension::JXL];
+        yield [MediaType::IMAGE_X_JXL, 1, FileExtension::JXL];
         yield [MediaType::IMAGE_X_JP2_CODESTREAM, 9, FileExtension::JP2];
         yield [MediaType::IMAGE_X_ICON, 1, FileExtension::ICO];
         yield [MediaType::IMAGE_VND_MICROSOFT_ICON, 1, FileExtension::ICO];


### PR DESCRIPTION
This adds JPEG XL (JXL) as an encodable format.

It works like the HEIC encoder. Encoding goes through Imagick, and I wired JXL into the `Format`, `MediaType` and `FileExtension` enums. There's no JXL in GD, so the GD driver reports it as unsupported and throws `NotSupportedException`, same as HEIC today.

The encoder takes quality, strip and a lossless flag. For lossless I set the compression quality to 100, that's what ImageMagick's coder uses to switch libjxl to lossless mode (distance 0). See coders/jxl.c.

Putting image/jxl in the `MediaType` enum also lets the Imagick binary decoder read and round-trip .jxl input, since it gets the origin from `getImageMimeType()`. So reading works too, on any build that has libjxl.

I also added image/x-jxl next to image/jxl. It's not just an input alias. On one CI runner libmagic detected an encoded JXL blob as image/x-jxl while the others said image/jxl, so the test accepts both.

CI was the tricky part. libjxl-dev isn't packaged for ubuntu-22.04, it's only there from 24.04 on, so I moved the workflow to ubuntu-24.04. That brought out a second problem: 24.04 ships libheif 1.17, which moved its encoders into separate plugin packages, so libheif-dev on its own can't encode AVIF or HEIC anymore and those existing tests started failing with empty output. Installing the x265 and aomenc libheif plugins (plus the matching decoders) brings AVIF and HEIC back. I also bumped the ImageMagick cache key so the cached build gets rebuilt against libjxl.

One more thing on the tests. ImageMagick 6.9.13 doesn't build the JXL coder even when libjxl is there, only 7.1.2 does (you can see it in queryFormats). So the JXL encoder test and the Imagick JXL supports check skip when `Imagick::queryFormats('JXL')` is empty. They run on the 7.1.2 cells and skip on 6.9.13. I used queryFormats to stay consistent with how `Driver::supports()` already decides what's supported.

All six matrix cells are green. JXL runs for real on the three 7.1.2 cells (encode and lossless), and skips on the 6.9.13 cells.

Two things I'm not sure about, tell me what you prefer:

- image/x-jxl in the `MediaType` enum. I can drop it and keep only image/jxl, but then the media type check in the test has to tolerate whatever libmagic returns on a given runner.
- Moving CI to ubuntu-24.04. It was the simplest way to get libjxl, but it dragged in the libheif plugin change. If you'd rather stay on 22.04 I can try building libjxl another way, or just keep JXL out of CI.

Browser support is still niche for now. ~14-16%, Safari-only by default. But the [trend just turned](https://www.photoformatlab.com/blog/jpeg-xl-chrome-2026-image-format-guide): Chrome 145 (Feb 2026) re-added a Rust JXL decoder behind a flag, Firefox 152 (June 2026) put it in the release channel behind a Labs flag, and Chrome is expected to flip it on by default in H2 2026. Meaning it could jump to ~85-90% almost overnight. Having it now seems like the good time.