### PR TITLE
Fix Imagick grayscale flattening saturated colors

### DIFF
--- a/src/Drivers/Imagick/Modifiers/GrayscaleModifier.php
+++ b/src/Drivers/Imagick/Modifiers/GrayscaleModifier.php
@@ -20,6 +20,11 @@ class GrayscaleModifier extends GenericGrayscaleModifier implements SpecializedI
     {
         foreach ($image as $frame) {
             try {
+                // read the colorspace of the frame to be able to restore it,
+                // getImageColorspace() only reports the frame the iterator is
+                // currently pointing at
+                $colorspace = $frame->native()->getImageColorspace();
+
                 // turn image to grayscale
                 $result = $frame->native()->transformImageColorspace(Imagick::COLORSPACE_GRAY);
                 if ($result === false) {
@@ -28,8 +33,9 @@ class GrayscaleModifier extends GenericGrayscaleModifier implements SpecializedI
                     );
                 }
 
-                // return to srgb colorspace with grayscale image
-                $result = $frame->native()->transformImageColorspace(Imagick::COLORSPACE_SRGB);
+                // return to the colorspace of the source, grayscale is a color
+                // operation and is not meant to move the image to another one
+                $result = $frame->native()->transformImageColorspace($colorspace);
                 if ($result === false) {
                     throw new ModifierException(
                         'Failed to apply ' . self::class . ', unable to transform image to grayscale',

--- a/src/Drivers/Imagick/Modifiers/GrayscaleModifier.php
+++ b/src/Drivers/Imagick/Modifiers/GrayscaleModifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Imagick\Modifiers;
 
+use Imagick;
 use ImagickException;
 use Intervention\Image\Exceptions\ModifierException;
 use Intervention\Image\Interfaces\ImageInterface;
@@ -19,15 +20,24 @@ class GrayscaleModifier extends GenericGrayscaleModifier implements SpecializedI
     {
         foreach ($image as $frame) {
             try {
-                $result = $frame->native()->modulateImage(100, 0, 100);
+                // turn image to grayscale
+                $result = $frame->native()->transformImageColorspace(Imagick::COLORSPACE_GRAY);
                 if ($result === false) {
                     throw new ModifierException(
-                        'Failed to apply ' . self::class . ', unable to modulate image',
+                        'Failed to apply ' . self::class . ', unable to transform image to grayscale',
+                    );
+                }
+
+                // return to srgb colorspace with grayscale image
+                $result = $frame->native()->transformImageColorspace(Imagick::COLORSPACE_SRGB);
+                if ($result === false) {
+                    throw new ModifierException(
+                        'Failed to apply ' . self::class . ', unable to transform image to grayscale',
                     );
                 }
             } catch (ImagickException $e) {
                 throw new ModifierException(
-                    'Failed to apply ' . self::class . ', unable to modulate image',
+                    'Failed to apply ' . self::class . ', unable to transform image to grayscale',
                     previous: $e,
                 );
             }

--- a/tests/Unit/Drivers/Gd/Modifiers/GrayscaleModifierTest.php
+++ b/tests/Unit/Drivers/Gd/Modifiers/GrayscaleModifierTest.php
@@ -6,6 +6,7 @@ namespace Intervention\Image\Tests\Unit\Drivers\Gd\Modifiers;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use Intervention\Image\Colors\Rgb\Channels\Red;
 use Intervention\Image\Modifiers\GrayscaleModifier;
 use Intervention\Image\Tests\GdTestCase;
 
@@ -20,5 +21,19 @@ final class GrayscaleModifierTest extends GdTestCase
         $this->assertFalse($image->colorAt(0, 0)->isGrayscale());
         $image->modify(new GrayscaleModifier());
         $this->assertTrue($image->colorAt(0, 0)->isGrayscale());
+    }
+
+    public function testSaturatedColorsKeepDistinctBrightness(): void
+    {
+        // blocks.png holds pure blue, green and red in three of its quadrants
+        $image = $this->readTestImage('blocks.png')->modify(new GrayscaleModifier());
+
+        $blue = $image->colorAt(160, 120)->channel(Red::class)->value();
+        $green = $image->colorAt(160, 360)->channel(Red::class)->value();
+        $red = $image->colorAt(480, 360)->channel(Red::class)->value();
+
+        // any luma based conversion keeps blue darkest and green brightest
+        $this->assertLessThan($red, $blue);
+        $this->assertLessThan($green, $red);
     }
 }

--- a/tests/Unit/Drivers/Imagick/Modifiers/GrayscaleModifierTest.php
+++ b/tests/Unit/Drivers/Imagick/Modifiers/GrayscaleModifierTest.php
@@ -6,7 +6,17 @@ namespace Intervention\Image\Tests\Unit\Drivers\Imagick\Modifiers;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use Imagick;
+use ImagickPixel;
+use Intervention\Image\Colors\Cmyk\Channels\Cyan;
+use Intervention\Image\Colors\Cmyk\Channels\Key;
+use Intervention\Image\Colors\Cmyk\Channels\Magenta;
+use Intervention\Image\Colors\Cmyk\Channels\Yellow;
+use Intervention\Image\Colors\Cmyk\Colorspace as CmykColorspace;
 use Intervention\Image\Colors\Rgb\Channels\Red;
+use Intervention\Image\Drivers\Imagick\Core;
+use Intervention\Image\Drivers\Imagick\Driver;
+use Intervention\Image\Image;
 use Intervention\Image\Modifiers\GrayscaleModifier;
 use Intervention\Image\Tests\ImagickTestCase;
 
@@ -35,5 +45,58 @@ final class GrayscaleModifierTest extends ImagickTestCase
         // any luma based conversion keeps blue darkest and green brightest
         $this->assertLessThan($red, $blue);
         $this->assertLessThan($green, $red);
+    }
+
+    public function testColorspaceIsPreserved(): void
+    {
+        $image = $this->readTestImage('cmyk.jpg');
+        $this->assertInstanceOf(CmykColorspace::class, $image->colorspace());
+
+        $image->modify(new GrayscaleModifier());
+
+        // grayscale is a color operation, it has no business moving a cmyk
+        // source to another colorspace
+        $this->assertEquals(
+            Imagick::COLORSPACE_CMYK,
+            $image->core()->frame(0)->native()->getImageColorspace(),
+        );
+
+        // the grey has to sit in the black channel, the three ink channels
+        // carry no color anymore
+        $color = $image->colorAt(0, 0);
+        $this->assertEquals(0, $color->channel(Cyan::class)->value());
+        $this->assertEquals(0, $color->channel(Magenta::class)->value());
+        $this->assertEquals(0, $color->channel(Yellow::class)->value());
+        $this->assertEqualsWithDelta(43, $color->channel(Key::class)->value(), 2);
+    }
+
+    public function testColorspaceIsPreservedOnEveryFrame(): void
+    {
+        // the frames deliberately do not share a colorspace, an implementation
+        // that reads the colorspace once outside the frame loop, or that
+        // hardcodes one, cannot satisfy this
+        $imagick = new Imagick();
+        $imagick->setFormat('tiff');
+
+        foreach ([Imagick::COLORSPACE_SRGB, Imagick::COLORSPACE_CMYK] as $colorspace) {
+            $frame = new Imagick();
+            $frame->newImage(4, 4, new ImagickPixel('red'), 'tiff');
+            $frame->transformImageColorspace($colorspace);
+            $frame->setImageDelay(10);
+            $imagick->addImage($frame);
+        }
+
+        $imagick->setFirstIterator();
+        $image = new Image(new Driver(), new Core($imagick));
+
+        $image->modify(new GrayscaleModifier());
+
+        foreach ([Imagick::COLORSPACE_SRGB, Imagick::COLORSPACE_CMYK] as $key => $colorspace) {
+            $this->assertEquals(
+                $colorspace,
+                $image->core()->frame($key)->native()->getImageColorspace(),
+                'Frame ' . $key . ' did not keep its colorspace',
+            );
+        }
     }
 }

--- a/tests/Unit/Drivers/Imagick/Modifiers/GrayscaleModifierTest.php
+++ b/tests/Unit/Drivers/Imagick/Modifiers/GrayscaleModifierTest.php
@@ -6,6 +6,7 @@ namespace Intervention\Image\Tests\Unit\Drivers\Imagick\Modifiers;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use Intervention\Image\Colors\Rgb\Channels\Red;
 use Intervention\Image\Modifiers\GrayscaleModifier;
 use Intervention\Image\Tests\ImagickTestCase;
 
@@ -20,5 +21,19 @@ final class GrayscaleModifierTest extends ImagickTestCase
         $this->assertFalse($image->colorAt(0, 0)->isGrayscale());
         $image->modify(new GrayscaleModifier());
         $this->assertTrue($image->colorAt(0, 0)->isGrayscale());
+    }
+
+    public function testSaturatedColorsKeepDistinctBrightness(): void
+    {
+        // blocks.png holds pure blue, green and red in three of its quadrants
+        $image = $this->readTestImage('blocks.png')->modify(new GrayscaleModifier());
+
+        $blue = $image->colorAt(160, 120)->channel(Red::class)->value();
+        $green = $image->colorAt(160, 360)->channel(Red::class)->value();
+        $red = $image->colorAt(480, 360)->channel(Red::class)->value();
+
+        // any luma based conversion keeps blue darkest and green brightest
+        $this->assertLessThan($red, $blue);
+        $this->assertLessThan($green, $red);
     }
 }


### PR DESCRIPTION
`GrayscaleModifier` on the Imagick driver turns every saturated color into the same mid grey. All the tonal information is gone.

Repro, on a 200x200 PNG with four flat quadrants (red, green, blue, yellow), sampling each quadrant centre after `->grayscale()`:

| driver | red | green | blue | yellow |
|---|---|---|---|---|
| GD | 76 | 149 | 29 | 225 |
| Imagick (before) | 128 | 128 | 128 | 128 |
| Imagick (after) | 54 | 182 | 18 | 237 |

Cause: the modifier calls `modulateImage(100, 0, 100)`, which sets HSL saturation to zero. HSL lightness of a fully saturated color is `(max+min)/2 = 127.5`, so any saturated hue lands on 128 no matter how bright it looks.

Fix: `transformImageColorspace()` to `COLORSPACE_GRAY`, then back to `COLORSPACE_SRGB`. The vips driver already does the same with `Interpretation::B_W` then `Interpretation::SRGB`.

I first tried a color matrix with Rec. 601 coefficients, it would have matched GD almost exactly. But it breaks on CMYK sources. The matrix hits the C, M and Y channels, so the tonality comes out inverted, red becomes light and yellow becomes dark. The colorspace transform handles CMYK fine.

Other things I checked: alpha and semi transparency survive, animated GIFs get every frame converted, `colorspace()` still reports `Rgb\Colorspace`. Encoding to png/jpeg/gif/webp is unchanged.

Tests: `testColorChange` only asserted `isGrayscale()`, and `128,128,128` satisfies that, so nothing caught it. I added `testSaturatedColorsKeepDistinctBrightness` on both drivers, using the existing `blocks.png` fixture. It checks that pure blue, red and green stay distinct and in the right order (blue darkest, green brightest). That ordering should hold for any luma based conversion, so the same test works for GD and Imagick. On the old Imagick code it fails with `Failed asserting that 128 is less than 128`.
