### PR TITLE
Apply Imagick colorspace change to every frame

### DIFF
--- a/src/Drivers/Imagick/Modifiers/ColorspaceModifier.php
+++ b/src/Drivers/Imagick/Modifiers/ColorspaceModifier.php
@@ -28,24 +28,27 @@ class ColorspaceModifier extends GenericColorspaceModifier implements Specialize
      */
     public function apply(ImageInterface $image): ImageInterface
     {
-        $colorspace = $this->targetColorspace();
-        $imagick = $image->core()->native();
+        $target = $this->imagickColorspaceOrFail($this->targetColorspace());
 
-        try {
-            $result = $imagick->transformImageColorspace(
-                $this->imagickColorspaceOrFail($colorspace),
-            );
+        // Imagick::transformImageColorspace() only affects the frame the
+        // iterator is currently pointing at, so every frame has to be
+        // transformed individually. Otherwise all frames but one would keep
+        // their original colorspace on animated images.
+        foreach ($image as $frame) {
+            try {
+                $result = $frame->native()->transformImageColorspace($target);
 
-            if ($result === false) {
+                if ($result === false) {
+                    throw new ModifierException(
+                        'Failed to apply ' . self::class . ', unable to transform image colorspace',
+                    );
+                }
+            } catch (ImagickException $e) {
                 throw new ModifierException(
                     'Failed to apply ' . self::class . ', unable to transform image colorspace',
+                    previous: $e,
                 );
             }
-        } catch (ImagickException $e) {
-            throw new ModifierException(
-                'Failed to apply ' . self::class . ', unable to transform image colorspace',
-                previous: $e,
-            );
         }
 
         return $image;

--- a/src/Drivers/Imagick/Modifiers/ProfileModifier.php
+++ b/src/Drivers/Imagick/Modifiers/ProfileModifier.php
@@ -17,20 +17,25 @@ class ProfileModifier extends GenericProfileModifier implements SpecializedInter
      */
     public function apply(ImageInterface $image): ImageInterface
     {
-        $imagick = $image->core()->native();
+        // read the profile once, casting it rewinds and drains its stream
+        $profile = (string) $this->profile;
 
-        try {
-            $result = $imagick->profileImage('icc', (string) $this->profile);
-            if ($result === false) {
+        // profileImage() only acts on the frame the iterator is currently
+        // pointing at, so every frame has to be profiled individually.
+        foreach ($image as $frame) {
+            try {
+                $result = $frame->native()->profileImage('icc', $profile);
+                if ($result === false) {
+                    throw new ModifierException(
+                        'Failed to apply ' . self::class . ', unable to set ICC color profile',
+                    );
+                }
+            } catch (ImagickException $e) {
                 throw new ModifierException(
                     'Failed to apply ' . self::class . ', unable to set ICC color profile',
+                    previous: $e,
                 );
             }
-        } catch (ImagickException $e) {
-            throw new ModifierException(
-                'Failed to apply ' . self::class . ', unable to set ICC color profile',
-                previous: $e,
-            );
         }
 
         return $image;

--- a/src/Drivers/Imagick/Modifiers/RemoveProfileModifier.php
+++ b/src/Drivers/Imagick/Modifiers/RemoveProfileModifier.php
@@ -17,20 +17,22 @@ class RemoveProfileModifier extends GenericRemoveProfileModifier implements Spec
      */
     public function apply(ImageInterface $image): ImageInterface
     {
-        $imagick = $image->core()->native();
-
-        try {
-            $result = $imagick->profileImage('icc', null);
-            if ($result === false) {
+        // profileImage() only acts on the frame the iterator is currently
+        // pointing at, so every frame has to be cleared individually.
+        foreach ($image as $frame) {
+            try {
+                $result = $frame->native()->profileImage('icc', null);
+                if ($result === false) {
+                    throw new ModifierException(
+                        'Failed to apply ' . self::class . ', unable to remove ICC color profile',
+                    );
+                }
+            } catch (ImagickException $e) {
                 throw new ModifierException(
                     'Failed to apply ' . self::class . ', unable to remove ICC color profile',
+                    previous: $e,
                 );
             }
-        } catch (ImagickException $e) {
-            throw new ModifierException(
-                'Failed to apply ' . self::class . ', unable to remove ICC color profile',
-                previous: $e,
-            );
         }
 
         return $image;

--- a/src/Drivers/Imagick/Modifiers/ResolutionModifier.php
+++ b/src/Drivers/Imagick/Modifiers/ResolutionModifier.php
@@ -17,20 +17,22 @@ class ResolutionModifier extends GenericResolutionModifier implements Specialize
      */
     public function apply(ImageInterface $image): ImageInterface
     {
-        $imagick = $image->core()->native();
-
-        try {
-            $result = $imagick->setImageResolution($this->x, $this->y);
-            if ($result === false) {
+        // setImageResolution() only acts on the frame the iterator is
+        // currently pointing at, so every frame has to be set individually.
+        foreach ($image as $frame) {
+            try {
+                $result = $frame->native()->setImageResolution($this->x, $this->y);
+                if ($result === false) {
+                    throw new ModifierException(
+                        'Failed to apply ' . self::class . ', unable to set image resolution',
+                    );
+                }
+            } catch (ImagickException $e) {
                 throw new ModifierException(
                     'Failed to apply ' . self::class . ', unable to set image resolution',
+                    previous: $e,
                 );
             }
-        } catch (ImagickException $e) {
-            throw new ModifierException(
-                'Failed to apply ' . self::class . ', unable to set image resolution',
-                previous: $e,
-            );
         }
 
         return $image;

--- a/src/Drivers/Imagick/Modifiers/StripMetaModifier.php
+++ b/src/Drivers/Imagick/Modifiers/StripMetaModifier.php
@@ -22,49 +22,56 @@ class StripMetaModifier implements ModifierInterface, SpecializedInterface
      */
     public function apply(ImageInterface $image): ImageInterface
     {
-        // preserve icc profiles
-        try {
-            $profiles = $image->core()->native()->getImageProfiles('icc');
-        } catch (ImagickException $e) {
-            throw new ModifierException(
-                'Failed to apply ' . self::class . ', unable to preserve icc profiles',
-                previous: $e,
-            );
-        }
-
-        // remove meta data
-        try {
-            $result = $image->core()->native()->stripImage();
-            if ($result === false) {
+        // getImageProfiles(), stripImage() and profileImage() all act on the
+        // frame the iterator is currently pointing at, so every frame has to
+        // be stripped individually. Otherwise the meta data of an animated
+        // image survives on every frame but one.
+        foreach ($image as $frame) {
+            // preserve icc profiles
+            try {
+                $profiles = $frame->native()->getImageProfiles('icc');
+            } catch (ImagickException $e) {
                 throw new ModifierException(
-                    'Failed to apply ' . self::class . ', unable to strip meta data',
+                    'Failed to apply ' . self::class . ', unable to preserve icc profiles',
+                    previous: $e,
                 );
             }
-        } catch (ImagickException $e) {
-            throw new ModifierException(
-                'Failed to apply ' . self::class . ', unable to strip meta data',
-                previous: $e,
-            );
-        }
 
-        $image->setExif(new Collection());
-
-        if ($profiles !== []) {
-            // re-apply icc profiles
+            // remove meta data
             try {
-                $result = $image->core()->native()->profileImage("icc", $profiles['icc']);
+                $result = $frame->native()->stripImage();
                 if ($result === false) {
                     throw new ModifierException(
-                        'Failed to apply ' . self::class . ', unable to re-apply icc profile',
+                        'Failed to apply ' . self::class . ', unable to strip meta data',
                     );
                 }
             } catch (ImagickException $e) {
                 throw new ModifierException(
-                    'Failed to apply ' . self::class . ', unable to re-apply icc profile',
+                    'Failed to apply ' . self::class . ', unable to strip meta data',
                     previous: $e,
                 );
             }
+
+            if ($profiles !== []) {
+                // re-apply icc profiles
+                try {
+                    $result = $frame->native()->profileImage("icc", $profiles['icc']);
+                    if ($result === false) {
+                        throw new ModifierException(
+                            'Failed to apply ' . self::class . ', unable to re-apply icc profile',
+                        );
+                    }
+                } catch (ImagickException $e) {
+                    throw new ModifierException(
+                        'Failed to apply ' . self::class . ', unable to re-apply icc profile',
+                        previous: $e,
+                    );
+                }
+            }
         }
+
+        $image->setExif(new Collection());
+
         return $image;
     }
 }

--- a/tests/Unit/Drivers/Imagick/Modifiers/ColorspaceModifierTest.php
+++ b/tests/Unit/Drivers/Imagick/Modifiers/ColorspaceModifierTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intervention\Image\Tests\Unit\Drivers\Imagick\Modifiers;
+
+use Imagick;
+use Intervention\Image\Colors\Cmyk\Colorspace as Cmyk;
+use Intervention\Image\Colors\Rgb\Colorspace as Rgb;
+use Intervention\Image\Drivers\Imagick\Modifiers\ColorspaceModifier as ImagickColorspaceModifier;
+use Intervention\Image\Exceptions\NotSupportedException;
+use Intervention\Image\Modifiers\ColorspaceModifier;
+use Intervention\Image\Tests\ImagickTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+
+#[RequiresPhpExtension('imagick')]
+#[CoversClass(ColorspaceModifier::class)]
+#[CoversClass(ImagickColorspaceModifier::class)]
+final class ColorspaceModifierTest extends ImagickTestCase
+{
+    public function testApply(): void
+    {
+        $image = $this->readTestImage('test.jpg');
+        $this->assertInstanceOf(Rgb::class, $image->colorspace());
+        $image->modify(new ColorspaceModifier(Cmyk::class));
+        $this->assertInstanceOf(Cmyk::class, $image->colorspace());
+    }
+
+    public function testApplyAnimated(): void
+    {
+        $image = $this->createTestAnimation();
+        $image->modify(new ColorspaceModifier(Cmyk::class));
+
+        foreach ($image as $key => $frame) {
+            $this->assertEquals(
+                Imagick::COLORSPACE_CMYK,
+                $frame->native()->getImageColorspace(),
+                'Frame ' . $key . ' was not transformed to the target colorspace.',
+            );
+        }
+    }
+
+    public function testApplyUnsupportedColorspace(): void
+    {
+        $image = $this->readTestImage('test.jpg');
+        $this->expectException(NotSupportedException::class);
+        $image->modify(new ColorspaceModifier('not_existing'));
+    }
+}

--- a/tests/Unit/Drivers/Imagick/Modifiers/ColorspaceModifierTest.php
+++ b/tests/Unit/Drivers/Imagick/Modifiers/ColorspaceModifierTest.php
@@ -9,6 +9,8 @@ use Intervention\Image\Colors\Cmyk\Colorspace as Cmyk;
 use Intervention\Image\Colors\Rgb\Colorspace as Rgb;
 use Intervention\Image\Drivers\Imagick\Modifiers\ColorspaceModifier as ImagickColorspaceModifier;
 use Intervention\Image\Exceptions\NotSupportedException;
+use Intervention\Image\Interfaces\ColorInterface;
+use Intervention\Image\Interfaces\ColorspaceInterface;
 use Intervention\Image\Modifiers\ColorspaceModifier;
 use Intervention\Image\Tests\ImagickTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -30,6 +32,16 @@ final class ColorspaceModifierTest extends ImagickTestCase
     public function testApplyAnimated(): void
     {
         $image = $this->createTestAnimation();
+        $this->assertEquals(3, count($image));
+
+        foreach ($image as $key => $frame) {
+            $this->assertEquals(
+                Imagick::COLORSPACE_SRGB,
+                $frame->native()->getImageColorspace(),
+                'Frame ' . $key . ' does not start in the source colorspace.',
+            );
+        }
+
         $image->modify(new ColorspaceModifier(Cmyk::class));
 
         foreach ($image as $key => $frame) {
@@ -41,10 +53,37 @@ final class ColorspaceModifierTest extends ImagickTestCase
         }
     }
 
-    public function testApplyUnsupportedColorspace(): void
+    public function testApplyColorspaceUnsupportedByDriver(): void
     {
+        $colorspace = new class () implements ColorspaceInterface {
+            /**
+             * @return array<string>
+             */
+            public static function channels(): array
+            {
+                return [];
+            }
+
+            /**
+             * @param array<float> $normalized
+             */
+            public static function colorFromNormalized(array $normalized): ColorInterface
+            {
+                throw new NotSupportedException('Not implemented');
+            }
+
+            public function importColor(ColorInterface $color): ColorInterface
+            {
+                throw new NotSupportedException('Not implemented');
+            }
+        };
+
         $image = $this->readTestImage('test.jpg');
         $this->expectException(NotSupportedException::class);
-        $image->modify(new ColorspaceModifier('not_existing'));
+
+        // the generic modifier passes a colorspace instance straight through,
+        // so this has to come from the driver rather than from target parsing
+        $this->expectExceptionMessageMatches('/^Colorspace .+@anonymous.* is not supported by driver$/');
+        $image->modify(new ColorspaceModifier($colorspace));
     }
 }

--- a/tests/Unit/Drivers/Imagick/Modifiers/ProfileModifierTest.php
+++ b/tests/Unit/Drivers/Imagick/Modifiers/ProfileModifierTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intervention\Image\Tests\Unit\Drivers\Imagick\Modifiers;
+
+use Intervention\Image\Colors\Profile;
+use Intervention\Image\Drivers\Imagick\Modifiers\ProfileModifier as ImagickProfileModifier;
+use Intervention\Image\Modifiers\ProfileModifier;
+use Intervention\Image\Tests\ImagickTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+
+#[RequiresPhpExtension('imagick')]
+#[CoversClass(ProfileModifier::class)]
+#[CoversClass(ImagickProfileModifier::class)]
+final class ProfileModifierTest extends ImagickTestCase
+{
+    /**
+     * Read the icc profile embedded in one of the test resources.
+     */
+    private function getTestProfile(): Profile
+    {
+        return new Profile(
+            $this->readTestImage('test.jpg')->core()->native()->getImageProfiles('icc')['icc'],
+        );
+    }
+
+    public function testApply(): void
+    {
+        $image = $this->readTestImage('tile.png');
+        $this->assertEmpty($image->core()->native()->getImageProfiles('icc'));
+
+        $image->modify(new ProfileModifier($this->getTestProfile()));
+
+        $this->assertNotEmpty($image->core()->native()->getImageProfiles('icc'));
+    }
+
+    public function testApplyAnimated(): void
+    {
+        $image = $this->createTestAnimation();
+        $image->modify(new ProfileModifier($this->getTestProfile()));
+
+        foreach ($image as $key => $frame) {
+            $this->assertNotEmpty(
+                $frame->native()->getImageProfiles('icc'),
+                'Frame ' . $key . ' did not get the profile',
+            );
+        }
+    }
+}

--- a/tests/Unit/Drivers/Imagick/Modifiers/RemoveProfileModifierTest.php
+++ b/tests/Unit/Drivers/Imagick/Modifiers/RemoveProfileModifierTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intervention\Image\Tests\Unit\Drivers\Imagick\Modifiers;
+
+use Intervention\Image\Colors\Profile;
+use Intervention\Image\Drivers\Imagick\Modifiers\RemoveProfileModifier as ImagickRemoveProfileModifier;
+use Intervention\Image\Modifiers\RemoveProfileModifier;
+use Intervention\Image\Tests\ImagickTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+
+#[RequiresPhpExtension('imagick')]
+#[CoversClass(RemoveProfileModifier::class)]
+#[CoversClass(ImagickRemoveProfileModifier::class)]
+final class RemoveProfileModifierTest extends ImagickTestCase
+{
+    /**
+     * Read the icc profile embedded in one of the test resources.
+     */
+    private function getTestProfile(): Profile
+    {
+        return new Profile(
+            $this->readTestImage('test.jpg')->core()->native()->getImageProfiles('icc')['icc'],
+        );
+    }
+
+    public function testApply(): void
+    {
+        $image = $this->readTestImage('test.jpg');
+        $this->assertNotEmpty($image->core()->native()->getImageProfiles('icc'));
+
+        $image->modify(new RemoveProfileModifier());
+
+        $this->assertEmpty($image->core()->native()->getImageProfiles('icc'));
+    }
+
+    public function testApplyAnimated(): void
+    {
+        $image = $this->createTestAnimation();
+
+        // set the profile on every frame through the native api, going
+        // through ProfileModifier would only cover the frames that one
+        // reaches and could hide a partial removal here
+        $profile = (string) $this->getTestProfile();
+        foreach ($image as $frame) {
+            $frame->native()->profileImage('icc', $profile);
+        }
+
+        $image->modify(new RemoveProfileModifier());
+
+        foreach ($image as $key => $frame) {
+            $this->assertEmpty(
+                $frame->native()->getImageProfiles('icc'),
+                'Frame ' . $key . ' kept its profile',
+            );
+        }
+    }
+}

--- a/tests/Unit/Drivers/Imagick/Modifiers/ResolutionModifierTest.php
+++ b/tests/Unit/Drivers/Imagick/Modifiers/ResolutionModifierTest.php
@@ -23,4 +23,16 @@ final class ResolutionModifierTest extends ImagickTestCase
         $this->assertEquals(1.0, $image->resolution()->x());
         $this->assertEquals(2.0, $image->resolution()->y());
     }
+
+    public function testResolutionChangeAnimated(): void
+    {
+        $image = $this->createTestAnimation();
+        $image->modify(new ResolutionModifier(300, 150));
+
+        foreach ($image as $key => $frame) {
+            $resolution = $frame->native()->getImageResolution();
+            $this->assertEquals(300.0, $resolution['x'], 'Frame ' . $key . ' kept its resolution');
+            $this->assertEquals(150.0, $resolution['y'], 'Frame ' . $key . ' kept its resolution');
+        }
+    }
 }

--- a/tests/Unit/Drivers/Imagick/Modifiers/StripMetaModifierTest.php
+++ b/tests/Unit/Drivers/Imagick/Modifiers/StripMetaModifierTest.php
@@ -23,4 +23,51 @@ final class StripMetaModifierTest extends ImagickTestCase
         $result = $image->encodeUsingFormat(Format::JPEG);
         $this->assertEmpty(exif_read_data($result->toStream())['IFD0.Artist'] ?? null);
     }
+
+    public function testApplyAnimated(): void
+    {
+        $image = $this->createTestAnimation();
+
+        foreach ($image as $key => $frame) {
+            $frame->native()->setImageProperty('comment', 'frame ' . $key);
+        }
+
+        $image->modify(new StripMetaModifier());
+
+        $this->assertEquals(3, count($image));
+
+        foreach ($image as $key => $frame) {
+            $this->assertEmpty(
+                $frame->native()->getImageProperty('comment'),
+                'Frame ' . $key . ' kept its meta data',
+            );
+        }
+    }
+
+    public function testApplyAnimatedKeepsIccProfiles(): void
+    {
+        $profile = $this->readTestImage('test.jpg')->core()->native()->getImageProfiles('icc')['icc'];
+
+        $image = $this->createTestAnimation();
+        foreach ($image as $frame) {
+            $frame->native()->setImageProperty('comment', 'strip me');
+            $frame->native()->profileImage('icc', $profile);
+        }
+
+        $image->modify(new StripMetaModifier());
+
+        // stripImage() drops the profile along with the rest, so the modifier
+        // reads it back per frame and re-applies it afterwards
+        foreach ($image as $key => $frame) {
+            $this->assertEmpty(
+                $frame->native()->getImageProperty('comment'),
+                'Frame ' . $key . ' kept its meta data',
+            );
+            $this->assertEquals(
+                $profile,
+                $frame->native()->getImageProfiles('icc')['icc'] ?? null,
+                'Frame ' . $key . ' lost its icc profile',
+            );
+        }
+    }
 }


### PR DESCRIPTION
`Imagick::transformImageColorspace()` only mutates the frame the iterator is parked on, so `setColorspace()` on an animated image leaves the other frames alone.

Repro, a 2 frame TIFF where both frames are CMYK:

```
decoded by Intervention:   f0=CMYK f1=CMYK
after setColorspace(Rgb):  f0=sRGB f1=CMYK
```

Which frame gets converted depends on where the iterator sits, not on the image. Call `colorsAt()` first and you get `f0=CMYK f1=sRGB` instead.

It gets worse downstream, `InsertModifier` does iterate every frame, so a half converted base composites an sRGB watermark into CMYK bands on the frames the change missed.

The fix iterates, same shape `GrayscaleModifier` already uses for the identical call. GD is a no-op in this path.

Four other modifiers had the same shape, so they are in here too. Measured on the 8 frame `animation.gif`:

| modifier | call | before |
| --- | --- | --- |
| `ResolutionModifier` | `setImageResolution()` | x-resolution `300,0,0,0,0,0,0,0` |
| `ProfileModifier` | `profileImage()` | profile on `yes,no,no,no,no,no,no,no` |
| `RemoveProfileModifier` | `profileImage(null)` | cleared on one frame only |
| `StripMetaModifier` | `stripImage()` | comment survives on every frame but one |

`StripMetaModifier` is the one I would worry about. Every encoder runs it when strip is enabled, and an animated TIFF written with `strip: true` kept the meta data of all its frames but one. Webp and avif are not affected, those writers do not round-trip per frame metadata at all. Its `setExif()` reset stays outside the loop, that one is a property of the image and not of a frame.

`TrimModifier` has the same shape but refuses animated images already, and the rest delegate to modifiers that iterate.

Every fix has an animated test, all of them fail on `develop`. There was no Imagick specific test for `ColorspaceModifier`, `ProfileModifier` or `RemoveProfileModifier` at all before this.

Two other places have the same fault and are not in here, `NativeObjectDecoder` and `ReduceColorsModifier`. Details in the comments.

Note if you write your own repro: building the fixture with `addImage()` twice and then one `transformImageColorspace(CMYK)` gives you `f0=CMYK f1=sRGB`, for the same reason. Each frame has to be converted before it is added.
