### PR TITLE
Detach Imagick frame when converting to image

### DIFF
--- a/src/Drivers/Imagick/Frame.php
+++ b/src/Drivers/Imagick/Frame.php
@@ -41,10 +41,21 @@ class Frame extends AbstractFrame implements FrameInterface
      * {@inheritdoc}
      *
      * @see DriverInterface::toImage()
+     *
+     * @throws DriverException
      */
     public function toImage(DriverInterface $driver): ImageInterface
     {
-        return new Image($driver, new Core($this->native()));
+        try {
+            // Imagick::current() returns the wand itself, so the native of a
+            // frame taken from an animation still holds the whole sequence.
+            // Copy the current frame out, otherwise the resulting image would
+            // report every frame and read whichever one the shared wand is
+            // seeked to.
+            return new Image($driver, new Core($this->native->getImage()));
+        } catch (ImagickException $e) {
+            throw new DriverException('Failed to transform frame into image', previous: $e);
+        }
     }
 
     /**

--- a/src/Drivers/Imagick/Frame.php
+++ b/src/Drivers/Imagick/Frame.php
@@ -22,6 +22,12 @@ use Intervention\Image\Size;
 class Frame extends AbstractFrame implements FrameInterface
 {
     /**
+     * Position this frame was taken from, or null if it is not bound to a
+     * position in a sequence.
+     */
+    protected ?int $position = null;
+
+    /**
      * Create new frame.
      *
      * @throws DriverException
@@ -29,6 +35,11 @@ class Frame extends AbstractFrame implements FrameInterface
     public function __construct(protected Imagick $native)
     {
         try {
+            // Imagick::current() returns the wand itself, so a frame taken
+            // from an animation shares the whole sequence with its core. Keep
+            // the position it was taken from to be able to seek back to it.
+            $this->position = $this->native->getIteratorIndex();
+
             $background = new ImagickPixel('rgba(255, 255, 255, 0)');
             $this->native->setImageBackgroundColor($background);
             $this->native->setBackgroundColor($background);
@@ -47,11 +58,15 @@ class Frame extends AbstractFrame implements FrameInterface
     public function toImage(DriverInterface $driver): ImageInterface
     {
         try {
-            // Imagick::current() returns the wand itself, so the native of a
-            // frame taken from an animation still holds the whole sequence.
-            // Copy the current frame out, otherwise the resulting image would
-            // report every frame and read whichever one the shared wand is
-            // seeked to.
+            // The native of a frame taken from an animation still holds the
+            // whole sequence, and any other frame access in the meantime has
+            // moved its pointer. Seek back before copying the frame out,
+            // otherwise the resulting image would report every frame and hold
+            // whichever one the shared wand was left on.
+            if ($this->position !== null) {
+                $this->native->setIteratorIndex($this->position);
+            }
+
             return new Image($driver, new Core($this->native->getImage()));
         } catch (ImagickException $e) {
             throw new DriverException('Failed to transform frame into image', previous: $e);
@@ -74,6 +89,10 @@ class Frame extends AbstractFrame implements FrameInterface
         }
 
         $this->native = $native;
+
+        // the replacement carries its own sequence, so the position this
+        // frame was taken from does not apply to it anymore
+        $this->position = null;
 
         return $this;
     }

--- a/tests/Unit/Drivers/Imagick/FrameTest.php
+++ b/tests/Unit/Drivers/Imagick/FrameTest.php
@@ -11,7 +11,9 @@ use ImagickPixel;
 use Intervention\Image\Drivers\Imagick\Core;
 use Intervention\Image\Drivers\Imagick\Driver;
 use Intervention\Image\Drivers\Imagick\Frame;
+use Intervention\Image\Direction;
 use Intervention\Image\Image;
+use Intervention\Image\Modifiers\FlipModifier;
 use Intervention\Image\Size;
 use Intervention\Image\Tests\BaseTestCase;
 
@@ -138,6 +140,22 @@ final class FrameTest extends BaseTestCase
         // the resulting image must not share the sequence of the core, which
         // still holds all frames and gets seeked around by every frame access
         $this->assertNotSame($core->native(), $image->core()->native());
+
+        // mirroring the result must not reach back into the animation
+        $image->modify(new FlipModifier(Direction::HORIZONTAL));
+        $this->assertEquals('ff0000', $core->frame(0)->toImage(new Driver())->colorAt(0, 0)->toHex());
+    }
+
+    public function testToImageOfAnimationFrameAfterFurtherFrameAccess(): void
+    {
+        $core = new Core($this->getTestAnimation());
+
+        // taking another frame moves the shared iterator away, the frame that
+        // was taken first still has to convert to its own position
+        $frame = $core->frame(1);
+        $core->frame(0);
+
+        $this->assertEquals('0000ff', $frame->toImage(new Driver())->colorAt(0, 0)->toHex());
     }
 
     public function testSetGetNative(): void

--- a/tests/Unit/Drivers/Imagick/FrameTest.php
+++ b/tests/Unit/Drivers/Imagick/FrameTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Imagick;
 use ImagickPixel;
+use Intervention\Image\Drivers\Imagick\Core;
 use Intervention\Image\Drivers\Imagick\Driver;
 use Intervention\Image\Drivers\Imagick\Frame;
 use Intervention\Image\Image;
@@ -27,6 +28,24 @@ final class FrameTest extends BaseTestCase
         $imagick->setImagePage(3, 2, 8, 9);
 
         return new Frame($imagick);
+    }
+
+    /**
+     * Create a two frame animation, the first frame red and the second blue.
+     */
+    protected function getTestAnimation(): Imagick
+    {
+        $imagick = new Imagick();
+        $imagick->setFormat('gif');
+
+        foreach (['red', 'blue'] as $color) {
+            $frame = new Imagick();
+            $frame->newImage(3, 2, new ImagickPixel($color), 'gif');
+            $frame->setImageDelay(10);
+            $imagick->addImage($frame);
+        }
+
+        return $imagick;
     }
 
     public function testConstructor(): void
@@ -98,6 +117,27 @@ final class FrameTest extends BaseTestCase
     {
         $frame = $this->getTestFrame();
         $this->assertInstanceOf(Image::class, $frame->toImage(new Driver()));
+    }
+
+    public function testToImageOfAnimationFrame(): void
+    {
+        $core = new Core($this->getTestAnimation());
+
+        foreach (['ff0000', '0000ff'] as $position => $hex) {
+            $image = $core->frame($position)->toImage(new Driver());
+            $this->assertEquals(1, $image->count());
+            $this->assertEquals($hex, $image->colorAt(0, 0)->toHex());
+        }
+    }
+
+    public function testToImageOfAnimationFrameIsDetached(): void
+    {
+        $core = new Core($this->getTestAnimation());
+        $image = $core->frame(0)->toImage(new Driver());
+
+        // the resulting image must not share the sequence of the core, which
+        // still holds all frames and gets seeked around by every frame access
+        $this->assertNotSame($core->native(), $image->core()->native());
     }
 
     public function testSetGetNative(): void


### PR DESCRIPTION
On the Imagick driver, taking a frame off an animation and calling `toImage()` gives back an image that still holds every frame. Reading a pixel off it then answers frame 0, whatever index you asked for.

Repro on a 2 frame GIF that is red then blue (`magick -delay 50 -loop 0 -size 100x100 xc:red xc:blue animated.gif`):

```php
for ($i = 0; $i < $image->count(); $i++) {
    $sub = $image->core()->frame($i)->toImage($image->driver());
    printf("frame %d: %s (count=%d)\n", $i, $sub->colorAt(1, 1)->toHex(), $sub->count());
}
```

Imagick:

```
frame 0: ff0000 (count=2)
frame 1: ff0000 (count=2)
```

GD, same bytes:

```
frame 0: ff0000 (count=1)
frame 1: 0000ff (count=1)
```

GD matches how the file was made, so the two drivers disagree.

`Imagick::current()` returns the wand itself, not a copy, so the `Frame` that `Core::frame()` builds wraps the multi frame wand the core holds. `toImage()` then did `new Core($this->native())` on that same wand, which is where both the `count=2` and the frame 0 pixels come from.

The fix copies the current frame out with `getImage()`. Copying alone is not quite enough, it only lands on the right frame while the shared wand still points at it, and taking any other frame in between moves it:

```php
$frame = $core->frame(1);
$core->frame(0);
$frame->toImage($driver);   // was red, should be blue
```

So the frame also keeps the position it was taken from and seeks back before copying. I checked that the copy keeps the delay and the disposal method, and the page geometry too, so nothing the frame API exposes gets lost. `toImage()` has one caller in the library, the GD `GifEncoder`, and that one is untouched.

Three tests added to `FrameTest`, one on the colors and the frame count, one asserting the result is detached from the core and does not change when the derived image is modified, one on the deferred case above. About the detach test: I first wrote it as "read frame 0's image after touching frame 1" and it passed on `develop` even with the bug there, because `PixelColorAnalyzer` defaults to `$frame = 0` and seeks the shared wand back before reading. So that phrasing tests nothing, worth knowing if you write your own.

One thing I left out. Two frame handles taken from the same core still alias each other for everything other than `toImage()`:

```php
$f0 = $image->core()->frame(0);
$f1 = $image->core()->frame(1);
var_dump($f0->native() === $f1->native());   // bool(true), $f0->delay() now reads frame 1's
```

My guess is this one should stay as it is. Modifiers mutate through `foreach ($image as $frame) { $frame->native()->... }`, so `frame()` and `current()` have to hand back a live handle on the wand, a copy there would silently drop every modifier. It would also copy a frame on every `colorAt()` call. Happy to look at it separately if you disagree.
