### PR TITLE
Orient every frame of an animated Imagick image

### DIFF
--- a/src/Drivers/Imagick/Modifiers/OrientModifier.php
+++ b/src/Drivers/Imagick/Modifiers/OrientModifier.php
@@ -23,45 +23,51 @@ class OrientModifier extends GenericOrientModifier implements SpecializedInterfa
             ? $image->core()->meta()->get('originalImageOrientation', 0)
             : $orientation;
 
-        try {
-            $result = match ($orientation) {
-                Imagick::ORIENTATION_TOPRIGHT
-                => $image->core()->native()->flopImage(), // 2
+        // rotateImage() and flopImage() only act on the frame the iterator is
+        // currently pointing at, so every frame has to be transformed
+        // individually. Otherwise an animated source comes back with only one
+        // frame turned and a mixed geometry sequence.
+        foreach ($image as $frame) {
+            try {
+                $result = match ($orientation) {
+                    Imagick::ORIENTATION_TOPRIGHT
+                    => $frame->native()->flopImage(), // 2
 
-                Imagick::ORIENTATION_BOTTOMRIGHT
-                => $image->core()->native()->rotateImage('#000', 180), // 3
+                    Imagick::ORIENTATION_BOTTOMRIGHT
+                    => $frame->native()->rotateImage('#000', 180), // 3
 
-                Imagick::ORIENTATION_BOTTOMLEFT
-                => $image->core()->native()->rotateImage('#000', 180) && $image->core()->native()->flopImage(), // 4
+                    Imagick::ORIENTATION_BOTTOMLEFT
+                    => $frame->native()->rotateImage('#000', 180) && $frame->native()->flopImage(), // 4
 
-                Imagick::ORIENTATION_LEFTTOP
-                => $image->core()->native()->rotateImage('#000', 90) && $image->core()->native()->flopImage(), // 5
+                    Imagick::ORIENTATION_LEFTTOP
+                    => $frame->native()->rotateImage('#000', 90) && $frame->native()->flopImage(), // 5
 
-                Imagick::ORIENTATION_RIGHTTOP
-                => $image->core()->native()->rotateImage('#000', 90), // 6
+                    Imagick::ORIENTATION_RIGHTTOP
+                    => $frame->native()->rotateImage('#000', 90), // 6
 
-                Imagick::ORIENTATION_RIGHTBOTTOM
-                => $image->core()->native()->rotateImage('#000', 270) && $image->core()->native()->flopImage(), // 7
+                    Imagick::ORIENTATION_RIGHTBOTTOM
+                    => $frame->native()->rotateImage('#000', 270) && $frame->native()->flopImage(), // 7
 
-                Imagick::ORIENTATION_LEFTBOTTOM
-                => $image->core()->native()->rotateImage('#000', 270), // 8
+                    Imagick::ORIENTATION_LEFTBOTTOM
+                    => $frame->native()->rotateImage('#000', 270), // 8
 
-                default => 'value',
-            };
+                    default => true,
+                };
 
-            // set new orientation in image
-            $result = $result && $image->core()->native()->setImageOrientation(Imagick::ORIENTATION_TOPLEFT);
+                // set new orientation in frame
+                $result = $result && $frame->native()->setImageOrientation(Imagick::ORIENTATION_TOPLEFT);
 
-            if ($result === false) {
+                if ($result === false) {
+                    throw new ModifierException(
+                        'Failed to apply ' . self::class . ', unable to process rotation of image',
+                    );
+                }
+            } catch (ImagickException $e) {
                 throw new ModifierException(
-                    'Failed to apply ' . self::class . ', unable to process rotation of image',
+                    'Failed to apply ' . self::class . ', unable to process rotation',
+                    previous: $e,
                 );
             }
-        } catch (ImagickException $e) {
-            throw new ModifierException(
-                'Failed to apply ' . self::class . ', unable to process rotation',
-                previous: $e,
-            );
         }
 
         return $image;

--- a/src/Drivers/Imagick/Modifiers/OrientModifier.php
+++ b/src/Drivers/Imagick/Modifiers/OrientModifier.php
@@ -18,6 +18,11 @@ class OrientModifier extends GenericOrientModifier implements SpecializedInterfa
      */
     public function apply(ImageInterface $image): ImageInterface
     {
+        // getImageOrientation() reads the frame the iterator is pointing at as
+        // well, so read it off the first frame rather than off whichever one
+        // the last operation happened to leave it on
+        $image->core()->native()->setFirstIterator();
+
         $orientation = $image->core()->native()->getImageOrientation();
         $orientation = $orientation === Imagick::ORIENTATION_UNDEFINED
             ? $image->core()->meta()->get('originalImageOrientation', 0)

--- a/tests/Unit/Drivers/Imagick/Modifiers/OrientModifierTest.php
+++ b/tests/Unit/Drivers/Imagick/Modifiers/OrientModifierTest.php
@@ -47,10 +47,12 @@ final class OrientModifierTest extends ImagickTestCase
         // every frame is red on the left and blue on the right, so a
         // horizontal mirror has to swap the two pixels of each of them
         for ($key = 0; $key < count($image); $key++) {
+            $this->assertEquals('0000ff', $image->colorAt(0, 0, $key)->toHex(), 'Frame ' . $key . ' left');
+            $this->assertEquals('ff0000', $image->colorAt(1, 0, $key)->toHex(), 'Frame ' . $key . ' right');
             $this->assertEquals(
-                '0000ff',
-                $image->colorAt(0, 0, $key)->toHex(),
-                'Frame ' . $key . ' was not mirrored',
+                Imagick::ORIENTATION_TOPLEFT,
+                $image->core()->frame($key)->native()->getImageOrientation(),
+                'Frame ' . $key . ' was not marked as aligned',
             );
         }
     }

--- a/tests/Unit/Drivers/Imagick/Modifiers/OrientModifierTest.php
+++ b/tests/Unit/Drivers/Imagick/Modifiers/OrientModifierTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intervention\Image\Tests\Unit\Drivers\Imagick\Modifiers;
+
+use Imagick;
+use ImagickPixel;
+use Intervention\Image\Drivers\Imagick\Core;
+use Intervention\Image\Drivers\Imagick\Driver;
+use Intervention\Image\Drivers\Imagick\Modifiers\OrientModifier as ImagickOrientModifier;
+use Intervention\Image\Image;
+use Intervention\Image\Modifiers\OrientModifier;
+use Intervention\Image\Tests\ImagickTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+
+#[RequiresPhpExtension('imagick')]
+#[CoversClass(OrientModifier::class)]
+#[CoversClass(ImagickOrientModifier::class)]
+final class OrientModifierTest extends ImagickTestCase
+{
+    public function testApplyAnimatedRotates(): void
+    {
+        $image = $this->createOrientedTestAnimation(Imagick::ORIENTATION_RIGHTTOP);
+
+        $image->modify(new OrientModifier());
+
+        for ($key = 0; $key < count($image); $key++) {
+            $frame = $image->core()->frame($key);
+            $this->assertEquals(1, $frame->size()->width(), 'Frame ' . $key . ' was not rotated');
+            $this->assertEquals(2, $frame->size()->height(), 'Frame ' . $key . ' was not rotated');
+            $this->assertEquals(
+                Imagick::ORIENTATION_TOPLEFT,
+                $frame->native()->getImageOrientation(),
+                'Frame ' . $key . ' was not marked as aligned',
+            );
+        }
+    }
+
+    public function testApplyAnimatedFlops(): void
+    {
+        $image = $this->createOrientedTestAnimation(Imagick::ORIENTATION_TOPRIGHT);
+
+        $image->modify(new OrientModifier());
+
+        // every frame is red on the left and blue on the right, so a
+        // horizontal mirror has to swap the two pixels of each of them
+        for ($key = 0; $key < count($image); $key++) {
+            $this->assertEquals(
+                '0000ff',
+                $image->colorAt(0, 0, $key)->toHex(),
+                'Frame ' . $key . ' was not mirrored',
+            );
+        }
+    }
+
+    /**
+     * Create a two frame 2x1 animation, every frame red on the left and blue
+     * on the right, carrying the given orientation.
+     */
+    private function createOrientedTestAnimation(int $orientation): Image
+    {
+        $imagick = new Imagick();
+        $imagick->setFormat('gif');
+
+        for ($i = 0; $i < 2; $i++) {
+            $frame = new Imagick();
+            $frame->newImage(2, 1, new ImagickPixel('black'), 'gif');
+            $frame->importImagePixels(0, 0, 2, 1, 'RGB', Imagick::PIXEL_CHAR, [255, 0, 0, 0, 0, 255]);
+            $frame->setImageDelay(10);
+            $frame->setImageOrientation($orientation);
+            $imagick->addImage($frame);
+        }
+
+        $imagick->resetIterator();
+
+        return new Image(new Driver(), new Core($imagick));
+    }
+}


### PR DESCRIPTION
`Drivers\Imagick\Modifiers\OrientModifier::apply()` calls `rotateImage()` and `flopImage()` straight on `$image->core()->native()` with no iteration. Those act on the frame the iterator is currently pointing at, so an animated source comes back with one frame turned and every other frame as it was.

Repro, a 2 frame 40x20 GIF with orientation 6 set on both frames:

```php
$img = $manager->decodeBinary($blob);
$native = $img->core()->native();
foreach ($native as $f) { $f->setImageOrientation(Imagick::ORIENTATION_RIGHTTOP); }
$native->resetIterator();
$img->orient();
```

```
frame 0 20x40 orientation=1
frame 1 40x20 orientation=6
```

So a mixed geometry sequence, and the frames that were skipped keep their original orientation flag because the `setImageOrientation(TOPLEFT)` at the end lands on the same single frame. Encoded back to GIF it composes wrong, frame 1 came back showing frame 0's background instead of its own color.

The fix moves the transform into the `foreach ($image as $frame)` loop the other modifiers already use, and marks each frame aligned instead of just one. After the patch both frames are 20x40 with orientation 1, and the re-encoded GIF reads blue over the whole of frame 1.

`getImageOrientation()` is a current image call too, so I made it read the first frame explicitly. It was already positional before, but it only mis-turned one frame back then. Now that the value drives the whole sequence a stale read turns everything the wrong way. Measured on a source with mixed per frame flags, `orient()` gave 4x2 or 2x4 for the same input depending on where the iterator sat, and it is stable at 2x4 after. That path is not reachable through the decoders as far as I can tell, `coalesceImages()` leaves the iterator at 0, so this is defensive.

I looked at whether this needs `RotateModifier`'s `setImagePage(0, 0, 0, 0)` and it does not. That guard is for the negative page offsets of non right angles (measured `6x6+-1+-2` at 45 degrees), and orient only ever uses 90, 180 and 270, which all come out `+0+0`. Encoding an oriented animation with and without the reset gave byte identical GIF and animated AVIF.

Worth saying that the input is awkward to build, GIF carries no EXIF so the orientation has to be set in memory on each frame. That is probably why this went unnoticed.

Two tests added, one for a rotating orientation (6) checking the geometry and the flag on every frame, one for the mirror only orientation (2) on frames that are red on the left and blue on the right. `AutoOrientationTest` covers the single frame cases for all eight orientations on both drivers and still passes.

One note on writing the second test. I first read the mirrored pixel through `$frame->toImage($driver)->colorAt(0, 0)` and it went green on `develop` with the bug in place, because on Imagick `toImage()` hands back the whole sequence and `colorAt()` then answers frame 0 (that is #1518). Reading through `colorAt($x, $y, $frame)` on the original image works, it goes through `frame($i)->native()` and reads before anything moves the wand.

Same shape as #1517, which was the colorspace modifier missing the same loop.
