### PR TITLE
Remove JsonSerializable from EncodedImage

### DIFF
--- a/src/EncodedImage.php
+++ b/src/EncodedImage.php
@@ -8,10 +8,9 @@ use Intervention\Image\Exceptions\InvalidArgumentException;
 use Intervention\Image\Exceptions\StreamException;
 use Intervention\Image\Interfaces\DataUriInterface;
 use Intervention\Image\Interfaces\EncodedImageInterface;
-use JsonSerializable;
 use Throwable;
 
-class EncodedImage extends File implements EncodedImageInterface, JsonSerializable
+class EncodedImage extends File implements EncodedImageInterface
 {
     /**
      * Create new instance.
@@ -72,18 +71,6 @@ class EncodedImage extends File implements EncodedImageInterface, JsonSerializab
     public function toBase64(): string
     {
         return base64_encode((string) $this);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @see JsonSerializable::jsonSerialize()
-     *
-     * @throws StreamException
-     */
-    public function jsonSerialize(): mixed
-    {
-        return $this->toDataUri();
     }
 
     /**

--- a/tests/Unit/EncodedImageTest.php
+++ b/tests/Unit/EncodedImageTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Tests\Unit;
 
+use JsonSerializable;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Intervention\Image\EncodedImage;
 use Intervention\Image\Tests\BaseTestCase;
@@ -54,11 +55,9 @@ final class EncodedImageTest extends BaseTestCase
 
     public function testNotJsonSerializable(): void
     {
-        // EncodedImage must not implement JsonSerializable, since frameworks
-        // like Laravel treat that as a signal to encode HTTP responses as
-        // JSON, overriding the correct image content type.
+        // Frameworks like Laravel force application/json responses for JsonSerializable content.
         $image = new EncodedImage('foo');
-        $this->assertNotInstanceOf(\JsonSerializable::class, $image);
+        $this->assertNotInstanceOf(JsonSerializable::class, $image);
     }
 
     public function testMediaType(): void

--- a/tests/Unit/EncodedImageTest.php
+++ b/tests/Unit/EncodedImageTest.php
@@ -52,10 +52,13 @@ final class EncodedImageTest extends BaseTestCase
         $this->assertEquals('foo', (string) $image);
     }
 
-    public function testJsonSerialze(): void
+    public function testNotJsonSerializable(): void
     {
+        // EncodedImage must not implement JsonSerializable, since frameworks
+        // like Laravel treat that as a signal to encode HTTP responses as
+        // JSON, overriding the correct image content type.
         $image = new EncodedImage('foo');
-        $this->assertEquals('["data:application\/octet-stream;base64,Zm9v"]', json_encode([$image]));
+        $this->assertNotInstanceOf(\JsonSerializable::class, $image);
     }
 
     public function testMediaType(): void


### PR DESCRIPTION
JsonSerializable on EncodedImage (added in #1513) makes Laravel's response layer treat any encoded image as JSON content and rewrite the response Content-Type to application/json, breaking `return response($image->encode())`, the most common way this library is used in HTTP contexts (also affects mewebstudio/captcha).

Color, DataUri, and Resolution keep JsonSerializable since they aren't normally returned as raw HTTP bodies. EncodedImage is the one that regularly is, so this just drops the interface there.

Fixes #1521