### PR TITLE
Keep the ICC profile of a stripped Imagick image in PNG output

### DIFF
--- a/src/Drivers/Imagick/Modifiers/StripMetaModifier.php
+++ b/src/Drivers/Imagick/Modifiers/StripMetaModifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Imagick\Modifiers;
 
+use Imagick;
 use ImagickException;
 use Intervention\Image\Collection;
 use Intervention\Image\Exceptions\ModifierException;
@@ -52,6 +53,27 @@ class StripMetaModifier implements ModifierInterface, SpecializedInterface
                 );
             }
 
+            // stripImage() leaves the meta data in the property cache and
+            // instead sets a "png:exclude-chunk" artifact to keep the png
+            // encoder from writing it back. That artifact also discards the
+            // icc profile, because the png encoder skips every profile as
+            // soon as the text chunks are excluded. Drop the artifact and
+            // clear the property cache instead, so that the meta data is
+            // really gone for every encoder and the icc profile can be
+            // restored below.
+            try {
+                if ($frame->native()->getImageArtifact('png:exclude-chunk') !== null) {
+                    $frame->native()->deleteImageArtifact('png:exclude-chunk');
+                }
+
+                $this->clearProperties($frame->native());
+            } catch (ImagickException $e) {
+                throw new ModifierException(
+                    'Failed to apply ' . self::class . ', unable to clear image properties',
+                    previous: $e,
+                );
+            }
+
             if ($profiles !== []) {
                 // re-apply icc profiles
                 try {
@@ -73,5 +95,46 @@ class StripMetaModifier implements ModifierInterface, SpecializedInterface
         $image->setExif(new Collection());
 
         return $image;
+    }
+
+    /**
+     * Remove all meta data properties of the given image.
+     *
+     * @throws ImagickException
+     */
+    private function clearProperties(Imagick $imagick): void
+    {
+        foreach ($imagick->getImageProperties('*', false) as $property) {
+            $this->deleteProperty($imagick, $property);
+        }
+
+        // getImageProperties() silently skips every property whose name starts
+        // with "[", which a png text chunk is able to produce. The png encoder
+        // does not skip them, so the ones that are left are read again through
+        // the "%[*]" format. That format builds a string of every property and
+        // its value, which is why it only runs once the properties above are
+        // gone and there is almost never anything left to report.
+        foreach (explode("\n", (string) $imagick->identifyFormat('%[*]')) as $line) {
+            $position = strpos($line, '=');
+            if ($position !== false && $position > 0) {
+                $this->deleteProperty($imagick, substr($line, 0, $position));
+            }
+        }
+    }
+
+    /**
+     * Remove the given property of the given image unless it is an encoder hint.
+     *
+     * @throws ImagickException
+     */
+    private function deleteProperty(Imagick $imagick, string $property): void
+    {
+        // the png encoder skips "png:" and "jpeg:" properties, they carry
+        // encoding hints like the jpeg sampling factor instead of meta data
+        if (str_starts_with($property, 'png:') || str_starts_with($property, 'jpeg:')) {
+            return;
+        }
+
+        $imagick->deleteImageProperty($property);
     }
 }

--- a/tests/Unit/Drivers/Imagick/Modifiers/StripMetaModifierTest.php
+++ b/tests/Unit/Drivers/Imagick/Modifiers/StripMetaModifierTest.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Tests\Unit\Drivers\Imagick\Modifiers;
 
+use Imagick;
 use Intervention\Image\Drivers\Imagick\Modifiers\StripMetaModifier;
+use Intervention\Image\Encoders\JpegEncoder;
+use Intervention\Image\Encoders\PngEncoder;
 use Intervention\Image\Format;
+use Intervention\Image\Interfaces\EncodedImageInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Intervention\Image\Tests\ImagickTestCase;
@@ -14,6 +18,18 @@ use Intervention\Image\Tests\ImagickTestCase;
 #[CoversClass(StripMetaModifier::class)]
 final class StripMetaModifierTest extends ImagickTestCase
 {
+    /**
+     * Decode the given encoded image again to inspect what the encoder
+     * actually wrote instead of what is left on the wand.
+     */
+    private function decodeAgain(EncodedImageInterface $encoded): Imagick
+    {
+        $imagick = new Imagick();
+        $imagick->readImageBlob((string) $encoded);
+
+        return $imagick;
+    }
+
     public function testApply(): void
     {
         $image = $this->readTestImage('exif.jpg');
@@ -21,7 +37,7 @@ final class StripMetaModifierTest extends ImagickTestCase
         $image->modify(new StripMetaModifier());
         $this->assertNull($image->exif('IFD0.Artist'));
         $result = $image->encodeUsingFormat(Format::JPEG);
-        $this->assertEmpty(exif_read_data($result->toStream())['IFD0.Artist'] ?? null);
+        $this->assertArrayNotHasKey('Artist', exif_read_data($result->toStream()));
     }
 
     public function testApplyAnimated(): void
@@ -40,6 +56,10 @@ final class StripMetaModifierTest extends ImagickTestCase
             $this->assertEmpty(
                 $frame->native()->getImageProperty('comment'),
                 'Frame ' . $key . ' kept its meta data',
+            );
+            $this->assertNull(
+                $frame->native()->getImageArtifact('png:exclude-chunk'),
+                'Frame ' . $key . ' kept the artifact left behind by stripImage()',
             );
         }
     }
@@ -69,5 +89,83 @@ final class StripMetaModifierTest extends ImagickTestCase
                 'Frame ' . $key . ' lost its icc profile',
             );
         }
+    }
+
+    public function testApplyKeepsIccProfileInEncodedPng(): void
+    {
+        $image = $this->readTestImage('test.jpg');
+        $profile = $image->core()->native()->getImageProfiles('icc')['icc'];
+        $this->assertNotEmpty($profile);
+
+        $image->modify(new StripMetaModifier());
+
+        $result = $this->decodeAgain($image->encode(new PngEncoder()));
+
+        $this->assertEquals($profile, $result->getImageProfiles('icc')['icc'] ?? null);
+    }
+
+    public function testApplyKeepsEncoderHintProperties(): void
+    {
+        // "png:" and "jpeg:" properties are hints for the encoders, the sweep
+        // of the property cache has to leave them alone
+        $jpeg = $this->readTestImage('exif.jpg');
+        $png = $this->readTestImage('rgb.png');
+        $this->assertNotEmpty($jpeg->core()->native()->getImageProperty('jpeg:sampling-factor'));
+        $this->assertNotEmpty(preg_grep('/^png:/', array_keys($png->core()->native()->getImageProperties())));
+
+        $jpeg->modify(new StripMetaModifier());
+        $png->modify(new StripMetaModifier());
+
+        $this->assertNotEmpty(
+            $jpeg->core()->native()->getImageProperty('jpeg:sampling-factor'),
+            'The sweep removed the jpeg encoder hints',
+        );
+        $this->assertNotEmpty(
+            preg_grep('/^png:/', array_keys($png->core()->native()->getImageProperties())),
+            'The sweep removed the png encoder hints',
+        );
+    }
+
+    public function testApplyRemovesMetaDataFromEncodedPng(): void
+    {
+        $image = $this->readTestImage('exif.jpg');
+
+        $image->modify(new StripMetaModifier());
+
+        $result = $this->decodeAgain($image->encode(new PngEncoder()));
+
+        $this->assertEmpty(
+            preg_grep('/^exif:/', array_keys($result->getImageProperties())),
+            'Encoded png carries exif meta data',
+        );
+    }
+
+    public function testApplyRemovesMetaDataHiddenFromPropertyEnumeration(): void
+    {
+        // Imagick::getImageProperties() does not report properties whose name
+        // starts with "[", but the png encoder writes them out all the same
+        $image = $this->readTestImage('test.jpg');
+        $image->core()->native()->setImageProperty('[hidden', 'meta data');
+
+        $image->modify(new StripMetaModifier());
+
+        $result = $this->decodeAgain($image->encode(new PngEncoder()));
+
+        $this->assertFalse($result->getImageProperty('[hidden'), 'Encoded png carries hidden meta data');
+    }
+
+    public function testApplyDoesNotAffectLaterPngEncoding(): void
+    {
+        // the modifier runs on the image itself, so anything it leaves behind
+        // on the wand is still there when the same image is encoded again
+        $image = $this->readTestImage('test.jpg');
+        $profile = $image->core()->native()->getImageProfiles('icc')['icc'];
+        $this->assertNotEmpty($profile);
+
+        $image->encode(new JpegEncoder(strip: true));
+
+        $result = $this->decodeAgain($image->encode(new PngEncoder()));
+
+        $this->assertEquals($profile, $result->getImageProfiles('icc')['icc'] ?? null);
     }
 }


### PR DESCRIPTION
`StripMetaModifier` reads the icc profile, calls `Imagick::stripImage()`, then puts the profile back. That works for JPEG, WebP and the other formats that reach the modifier. Not for PNG: the profile is on the wand afterwards, but the encoded PNG carries none.

`stripImage()` sets a `png:exclude-chunk` artifact and that artifact stays on the wand, so it also hits any later PNG encode of the same image:

```php
$image = $manager->decodePath('test.jpg');
$image->encode(new JpegEncoder(strip: true));   // icc kept
$image->encode(new PngEncoder());               // icc gone
```

Encoding the PNG first keeps the profile, so the result depends on the order. Same with `strip: true` in the config.

The cause lives in `coders/png.c` the loop that writes profiles is guarded by

```c
if ((mng_info->exclude_tEXt == MagickFalse ||
     mng_info->exclude_zTXt == MagickFalse) &&
   (ping_exclude_iCCP == MagickFalse || ping_exclude_zCCP == MagickFalse))
```

The list `stripImage()` sets excludes both `tEXt` and `zTXt`, so no profile is written at all. Removing only `iCCP` from that list does not help, I checked, and `png:include-chunk=iCCP` does not either. The list also excludes `pHYs`, so a resolution set after the strip is lost in the PNG too.

Fix: delete the artifact and clear the property cache instead. The sweep is needed because the JPEG reader materialises `exif:*` into the property cache and `stripImage()` leaves them there, so once the artifact is gone the PNG writer would serialise them back into text chunks. `png:` and `jpeg:` properties are kept, the writer skips those prefixes anyway.

One caveat on the sweep, and the reason I am flagging it rather than deciding it myself.

`Imagick::getImageProperties()` does not report properties whose name starts with `[`, and a PNG `tEXt` keyword can produce one (`0x5B` is a legal keyword byte). The PNG writer has no such restriction, so a sweep based only on `getImageProperties()` lets those through, which is worse than today where the artifact suppresses every text chunk. I complete the list with the names from `identifyFormat('%[*]')`, which walks the same property iterator as the writer.

That call builds a string of every property with its value. On normal images it is nothing, on a crafted PNG it is not:

| input | strip cost | php peak |
| --- | --- | --- |
| `exif.jpg` | 0.1 ms | 27 KB |
| crafted 125 KB PNG, 2000 `zTXt` chunks x 20 KB | 1.7 ms | 46 KB |
| same file, keywords prefixed with `[` | 620 ms | 81 MB |

The sweep runs `%[*]` last, once everything it can enumerate is already deleted, which is why the middle row is cheap. The last row I could not avoid: to delete those properties I have to read them, and reading them is the cost. Timings grow faster than the payload, my guess is the repeated realloc in `AppendKeyValue2Text`. For reference that same file takes about 100 ms to decode, and 72 ms to decode and re-encode as PNG without stripping.

I tried `identifyImage(true)` (9.5 s on a 4000x3000 image), `identifyImage(false)` (no properties), `%[property:*]` (returns nothing) and a glob restricted to `[` names to keep the output small (could not express one, the `%[...]` parser counts bracket depth). None of them work.

So if the last row is not acceptable, the alternative is to drop the `identifyFormat('%[*]')` part and accept that `[` prefixed text chunks survive a strip in PNG output. Happy to do that, just tell me which you prefer. Both underlying problems look like ImageMagick ones anyway, the profile loop guarded by the text chunk flags and `getImageProperties()` hiding names the writer will write. Not reported upstream yet.

Side effect: a stripped PNG now carries the `cHRM`, `bKGD` and `pHYs` chunks the artifact used to suppress, so it is slightly larger. `test.jpg` stripped and encoded as PNG goes from 2356 to 3034 bytes, 536 of which are the icc profile that was missing.
